### PR TITLE
refactor: deduplicate impassable tile types and unify tank-vs-tile handlers

### DIFF
--- a/src/core/map.py
+++ b/src/core/map.py
@@ -3,7 +3,7 @@ import pygame
 import pytmx
 from pytmx.util_pygame import load_pygame
 from loguru import logger
-from .tile import Tile, TileType
+from .tile import Tile, TileType, IMPASSABLE_TILE_TYPES
 from src.managers.texture_manager import TextureManager
 from src.utils.constants import TILE_SIZE
 
@@ -146,12 +146,7 @@ class Map:
     def _rebuild_tile_caches(self) -> None:
         """Rebuild all cached tile lists from the grid."""
         self._cached_tiles_by_type = {}
-        collidable_types = {
-            TileType.BRICK,
-            TileType.STEEL,
-            TileType.BASE,
-            TileType.WATER,
-        }
+        collidable_types = IMPASSABLE_TILE_TYPES
         collidable_rects = []
         base = None
 

--- a/src/core/tank.py
+++ b/src/core/tank.py
@@ -179,6 +179,10 @@ class Tank(GameObject):
         super().update(dt)
 
 
+    def on_wall_hit(self) -> None:
+        """Called when the tank collides with a wall tile. No-op by default."""
+        pass
+
     def _move(self, dx: int, dy: int, dt: float) -> bool:
         """
         Attempt to move the tank by updating its position.

--- a/src/core/tile.py
+++ b/src/core/tile.py
@@ -19,6 +19,12 @@ class TileType(Enum):
     BASE_DESTROYED = auto()
 
 
+# Tile types that block tank movement
+IMPASSABLE_TILE_TYPES = frozenset(
+    {TileType.BRICK, TileType.STEEL, TileType.WATER, TileType.BASE}
+)
+
+
 class Tile:
     """Represents a single tile in the game map."""
 

--- a/src/managers/collision_response_handler.py
+++ b/src/managers/collision_response_handler.py
@@ -3,7 +3,7 @@ from loguru import logger
 from src.core.bullet import Bullet
 from src.core.player_tank import PlayerTank
 from src.core.enemy_tank import EnemyTank
-from src.core.tile import Tile, TileType
+from src.core.tile import Tile, TileType, IMPASSABLE_TILE_TYPES
 from src.core.map import Map
 from src.states.game_state import GameState
 
@@ -27,8 +27,8 @@ class CollisionResponseHandler:
             (PlayerTank, EnemyTank): self._handle_tank_vs_tank,
             (PlayerTank, PlayerTank): self._handle_tank_vs_tank,
             (EnemyTank, EnemyTank): self._handle_tank_vs_tank,
-            (PlayerTank, Tile): self._handle_player_tank_vs_tile,
-            (EnemyTank, Tile): self._handle_enemy_tank_vs_tile,
+            (PlayerTank, Tile): self._handle_tank_vs_tile,
+            (EnemyTank, Tile): self._handle_tank_vs_tile,
         }
 
     def process_collisions(self, events: List[Tuple[Any, Any]]) -> List[EnemyTank]:
@@ -188,36 +188,13 @@ class CollisionResponseHandler:
         tank_b.revert_move()
         return True
 
-    def _handle_player_tank_vs_tile(
+    def _handle_tank_vs_tile(
         self,
-        tank: PlayerTank,
+        tank: Any,
         tile: Tile,
         enemies_to_remove: List[EnemyTank],
     ) -> bool:
-        impassable = [
-            TileType.STEEL,
-            TileType.WATER,
-            TileType.BASE,
-            TileType.BRICK,
-        ]
-        if tile.type in impassable:
-            tank.revert_move(tile.rect)
-            return True
-        return False
-
-    def _handle_enemy_tank_vs_tile(
-        self,
-        tank: EnemyTank,
-        tile: Tile,
-        enemies_to_remove: List[EnemyTank],
-    ) -> bool:
-        impassable = [
-            TileType.STEEL,
-            TileType.WATER,
-            TileType.BASE,
-            TileType.BRICK,
-        ]
-        if tile.type in impassable:
+        if tile.type in IMPASSABLE_TILE_TYPES:
             tank.revert_move(tile.rect)
             tank.on_wall_hit()
             return True

--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 from loguru import logger
 from src.core.map import Map
 from src.core.player_tank import PlayerTank
-from src.core.tile import Tile, TileType
+from src.core.tile import Tile, TileType, IMPASSABLE_TILE_TYPES
 from src.core.bullet import Bullet
 from src.states.game_state import GameState
 from src.utils.constants import (
@@ -135,7 +135,7 @@ class GameManager:
         # --- Prepare data for Collision Manager ---
         destructible_tiles: List[Tile] = self.map.get_tiles_by_type([TileType.BRICK])
         impassable_tiles: List[Tile] = self.map.get_tiles_by_type(
-            [TileType.STEEL, TileType.WATER, TileType.BASE, TileType.BRICK]
+            list(IMPASSABLE_TILE_TYPES)
         )
         player_base: Optional[Tile] = self.map.get_base()
 


### PR DESCRIPTION
## Summary
- Define `IMPASSABLE_TILE_TYPES` as a shared `frozenset` in `tile.py`, replacing 4 independent copies across `collision_response_handler.py` (x2), `game_manager.py`, and `map.py`
- Add a no-op `on_wall_hit()` to base `Tank` class, enabling polymorphic dispatch
- Merge near-identical `_handle_player_tank_vs_tile` / `_handle_enemy_tank_vs_tile` into a single `_handle_tank_vs_tile` method

## Test plan
- [x] All 178 tests pass
- [x] Ruff lint clean on all changed files