### PR TITLE
refactor: replace stringly-typed owner_type with OwnerType enum

### DIFF
--- a/src/core/bullet.py
+++ b/src/core/bullet.py
@@ -4,6 +4,7 @@ from loguru import logger
 from .game_object import GameObject
 from src.utils.constants import (
     Direction,
+    OwnerType,
     BULLET_SPEED,
     BULLET_WIDTH,
     BULLET_HEIGHT,
@@ -21,7 +22,7 @@ class Bullet(GameObject):
         self,
         x: float,
         y: float,
-        direction: str,
+        direction: Direction,
         owner,
         sprite: Optional[pygame.Surface] = None,
         speed: float = BULLET_SPEED,
@@ -38,12 +39,12 @@ class Bullet(GameObject):
             speed: Speed of the bullet in pixels per second
         """
         super().__init__(x, y, BULLET_WIDTH, BULLET_HEIGHT, sprite)
-        self.direction: str = direction
+        self.direction: Direction = direction
         self.speed: float = speed
         self.active: bool = True
         self.color: ColorTuple = WHITE
         self.owner = owner
-        self.owner_type: str = owner.owner_type
+        self.owner_type: OwnerType = owner.owner_type
         logger.trace(
             f"Created bullet for {self.owner_type} "
             f"at ({x:.1f}, {y:.1f}) moving {direction}"

--- a/src/core/enemy_tank.py
+++ b/src/core/enemy_tank.py
@@ -2,7 +2,7 @@ import random
 from loguru import logger
 from .tank import Tank
 from typing import Literal, Dict, TypedDict
-from src.utils.constants import Direction, TANK_SPEED, BULLET_SPEED
+from src.utils.constants import Direction, OwnerType, TANK_SPEED, BULLET_SPEED
 from src.managers.texture_manager import TextureManager
 
 TankType = Literal["basic", "fast", "power", "armor"]
@@ -99,7 +99,7 @@ class EnemyTank(Tank):
             map_height_px=map_height_px,
         )
         self.tank_type = tank_type
-        self.owner_type = "enemy"
+        self.owner_type = OwnerType.ENEMY
         self.direction = random.choice(list(Direction))
         self.direction_timer: float = 0
         self.direction_change_interval: float = props["direction_change_interval"]

--- a/src/core/player_tank.py
+++ b/src/core/player_tank.py
@@ -1,7 +1,7 @@
 from loguru import logger
 from .tank import Tank
 from src.managers.texture_manager import TextureManager
-from src.utils.constants import Direction
+from src.utils.constants import Direction, OwnerType
 
 
 class PlayerTank(Tank):
@@ -42,7 +42,7 @@ class PlayerTank(Tank):
             map_width_px=map_width_px,
             map_height_px=map_height_px,
         )
-        self.owner_type = "player"
+        self.owner_type = OwnerType.PLAYER
         self.initial_position = (grid_x, grid_y)
         self.invincibility_duration = 3.0
         self._update_sprite()

--- a/src/core/tank.py
+++ b/src/core/tank.py
@@ -6,6 +6,7 @@ from .bullet import Bullet
 from src.managers.texture_manager import TextureManager
 from src.utils.constants import (
     Direction,
+    OwnerType,
     TILE_SIZE,
     TANK_SPEED,
     TANK_WIDTH,
@@ -64,7 +65,7 @@ class Tank(GameObject):
         self.health: int = health
         self.max_health: int = health
         self.lives: int = lives
-        self.owner_type: str = "base_tank"  # Default or abstract type
+        self.owner_type: OwnerType = OwnerType.PLAYER
         self.distance_since_last_toggle: float = 0
         # Store previous position for collision rollback
         self.prev_x: float = x
@@ -80,12 +81,7 @@ class Tank(GameObject):
     def _update_sprite(self) -> None:
         """Updates the tank's sprite based on direction and animation frame."""
 
-        base_sprite_name = f"{self.owner_type}_tank"
-
-        if self.owner_type.startswith("enemy"):
-            base_sprite_name = "enemy_tank"
-
-        sprite_name = f"{base_sprite_name}_{self.direction}_{self.animation_frame}"
+        sprite_name = f"{self.owner_type}_tank_{self.direction}_{self.animation_frame}"
         try:
             self.sprite = self.texture_manager.get_sprite(sprite_name)
 

--- a/src/managers/collision_response_handler.py
+++ b/src/managers/collision_response_handler.py
@@ -4,6 +4,7 @@ from src.core.bullet import Bullet
 from src.core.player_tank import PlayerTank
 from src.core.enemy_tank import EnemyTank
 from src.core.tile import Tile, TileType, IMPASSABLE_TILE_TYPES
+from src.utils.constants import OwnerType
 from src.core.map import Map
 from src.states.game_state import GameState
 
@@ -107,7 +108,7 @@ class CollisionResponseHandler:
     ) -> bool:
         if not bullet.active:
             return False
-        if bullet.owner_type != "player":
+        if bullet.owner_type != OwnerType.PLAYER:
             return False
         logger.debug(f"Player bullet hit enemy tank (type: {enemy.tank_type})")
         bullet.active = False
@@ -125,7 +126,7 @@ class CollisionResponseHandler:
     ) -> bool:
         if not bullet.active:
             return False
-        if bullet.owner_type != "enemy":
+        if bullet.owner_type != OwnerType.ENEMY:
             return False
         logger.debug("Enemy bullet hit player tank.")
         bullet.active = False

--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -4,6 +4,7 @@ from loguru import logger
 from src.core.map import Map
 from src.core.player_tank import PlayerTank
 from src.core.tile import Tile, TileType, IMPASSABLE_TILE_TYPES
+from src.utils.constants import OwnerType
 from src.core.bullet import Bullet
 from src.states.game_state import GameState
 from src.utils.constants import (
@@ -140,10 +141,10 @@ class GameManager:
         player_base: Optional[Tile] = self.map.get_base()
 
         player_bullets = [
-            b for b in self.bullets if b.owner_type == "player" and b.active
+            b for b in self.bullets if b.owner_type == OwnerType.PLAYER and b.active
         ]
         enemy_bullets = [
-            b for b in self.bullets if b.owner_type == "enemy" and b.active
+            b for b in self.bullets if b.owner_type == OwnerType.ENEMY and b.active
         ]
         # --- End Prepare data ---
 

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -16,6 +16,14 @@ class Direction(str, Enum):
         return self.value
 
 
+class OwnerType(str, Enum):
+    PLAYER = "player"
+    ENEMY = "enemy"
+
+    def __str__(self) -> str:
+        return self.value
+
+
 # Window settings
 WINDOW_WIDTH: int = 1024  # Logical width (16*32) * 2
 WINDOW_HEIGHT: int = 1024  # Logical height (16*32) * 2


### PR DESCRIPTION
## Summary
- Add `OwnerType(str, Enum)` with `PLAYER` and `ENEMY` values to `constants.py`
- Update `Tank`, `PlayerTank`, `EnemyTank`, `Bullet` to use `OwnerType` instead of raw strings
- Update `CollisionResponseHandler` and `GameManager` comparisons to use enum values
- Fix `Bullet.direction` type annotation from `str` to `Direction` (was already receiving enum values)
- Simplify `Tank._update_sprite()` by removing the `startswith("enemy")` workaround

## Test plan
- [x] All 178 tests pass
- [x] Ruff lint clean on all changed files
- [x] `OwnerType` inherits from `str` so existing string comparisons in tests remain compatible