### PR TITLE
refactor: add delta and opposite properties to Direction enum

### DIFF
--- a/src/core/bullet.py
+++ b/src/core/bullet.py
@@ -60,15 +60,9 @@ class Bullet(GameObject):
         if not self.active:
             return
 
-        # Calculate movement based on direction
-        if self.direction == Direction.LEFT:
-            self.x -= self.speed * dt
-        elif self.direction == Direction.RIGHT:
-            self.x += self.speed * dt
-        elif self.direction == Direction.UP:
-            self.y -= self.speed * dt
-        elif self.direction == Direction.DOWN:
-            self.y += self.speed * dt
+        dx, dy = self.direction.delta
+        self.x += dx * self.speed * dt
+        self.y += dy * self.speed * dt
 
         # Check if bullet is out of bounds
         if (

--- a/src/core/enemy_tank.py
+++ b/src/core/enemy_tank.py
@@ -114,34 +114,27 @@ class EnemyTank(Tank):
             f"shoot_interval={self.shoot_interval:.2f}"
         )
 
+    _ALL_DIRECTIONS = list(Direction)
+
     def _change_direction(self) -> None:
         """Randomly change the tank's direction and update its sprite."""
         old_direction = self.direction
-        new_direction = old_direction  # Start with the current direction
-        directions = list(Direction)
+        new_direction = old_direction
 
         # Try to avoid reversing first
-        opposite_direction = {
-            Direction.UP: Direction.DOWN,
-            Direction.DOWN: Direction.UP,
-            Direction.LEFT: Direction.RIGHT,
-            Direction.RIGHT: Direction.LEFT,
-        }
-        if len(directions) > 1 and old_direction in opposite_direction:
+        possible_directions = [
+            d for d in self._ALL_DIRECTIONS if d != old_direction.opposite
+        ]
+        if possible_directions:
+            new_direction = random.choice(possible_directions)
+
+        # If direction didn't change, pick any different direction (fallback)
+        if new_direction == old_direction:
             possible_directions = [
-                d for d in directions if d != opposite_direction[old_direction]
+                d for d in self._ALL_DIRECTIONS if d != old_direction
             ]
             if possible_directions:
                 new_direction = random.choice(possible_directions)
-            # else: If only reversing is possible, let the fallback handle it
-
-        # If direction didn't change above, or if reversing was the only option,
-        # pick a different direction randomly (fallback).
-        if new_direction == old_direction:
-            possible_directions = [d for d in directions if d != old_direction]
-            if possible_directions:
-                new_direction = random.choice(possible_directions)
-            # else: If tank is somehow stuck in a 1-way path, direction won't change.
 
         # Only update sprite if the direction actually changed
         if new_direction != old_direction:
@@ -196,15 +189,5 @@ class EnemyTank(Tank):
             self._wants_to_shoot = True
             self.shoot_timer = random.uniform(0, 0.3)  # Add small random offset
 
-        # Calculate movement based on current direction
-        dx, dy = 0, 0
-        if self.direction == Direction.LEFT:
-            dx = -1
-        elif self.direction == Direction.RIGHT:
-            dx = 1
-        elif self.direction == Direction.UP:
-            dy = -1
-        elif self.direction == Direction.DOWN:
-            dy = 1
-
+        dx, dy = self.direction.delta
         self._move(dx, dy, dt)

--- a/src/managers/input_handler.py
+++ b/src/managers/input_handler.py
@@ -55,16 +55,11 @@ class InputHandler:
         """
         dx = 0
         dy = 0
-
-        if self.directions[Direction.UP]:
-            dy -= 1
-        if self.directions[Direction.DOWN]:
-            dy += 1
-        if self.directions[Direction.LEFT]:
-            dx -= 1
-        if self.directions[Direction.RIGHT]:
-            dx += 1
-
+        for direction, pressed in self.directions.items():
+            if pressed:
+                ddx, ddy = direction.delta
+                dx += ddx
+                dy += ddy
         return (dx, dy)
 
     def consume_shoot(self) -> bool:

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -15,6 +15,32 @@ class Direction(str, Enum):
     def __str__(self) -> str:
         return self.value
 
+    @property
+    def opposite(self) -> "Direction":
+        """Return the opposite direction."""
+        return _OPPOSITE_DIRECTIONS[self]
+
+    @property
+    def delta(self) -> Tuple[int, int]:
+        """Return the (dx, dy) unit vector for this direction."""
+        return _DIRECTION_DELTAS[self]
+
+
+# Lookup tables defined after the enum class
+_OPPOSITE_DIRECTIONS: dict["Direction", "Direction"] = {
+    Direction.UP: Direction.DOWN,
+    Direction.DOWN: Direction.UP,
+    Direction.LEFT: Direction.RIGHT,
+    Direction.RIGHT: Direction.LEFT,
+}
+
+_DIRECTION_DELTAS: dict["Direction", Tuple[int, int]] = {
+    Direction.UP: (0, -1),
+    Direction.DOWN: (0, 1),
+    Direction.LEFT: (-1, 0),
+    Direction.RIGHT: (1, 0),
+}
+
 
 class OwnerType(str, Enum):
     PLAYER = "player"


### PR DESCRIPTION
## Summary
- Add `Direction.delta` property returning `(dx, dy)` unit vectors (e.g., `Direction.UP.delta` → `(0, -1)`)
- Add `Direction.opposite` property (e.g., `Direction.UP.opposite` → `Direction.DOWN`)
- Replace if/elif direction-to-delta chains in `Bullet.update`, `EnemyTank.update`, and `InputHandler.get_movement_direction`
- Replace local `opposite_direction` dict in `EnemyTank._change_direction` with `Direction.opposite`
- Cache `list(Direction)` as `EnemyTank._ALL_DIRECTIONS` class attribute

## Test plan
- [x] All 178 tests pass
- [x] Ruff lint clean on all changed files