### PR TITLE
refactor: remove dead state, empty override, and fix KeyError bug

### DIFF
--- a/src/core/player_tank.py
+++ b/src/core/player_tank.py
@@ -78,15 +78,6 @@ class PlayerTank(Tank):
 
         self._move(dx, dy, dt)
 
-    def update(self, dt: float) -> None:
-        """
-        Update the tank's state.
-
-        Args:
-            dt: Time elapsed since last update in seconds
-        """
-        super().update(dt)
-
     def respawn(self) -> None:
         """Respawn the tank at its initial position."""
         if self.lives > 0:
@@ -95,7 +86,6 @@ class PlayerTank(Tank):
                 f"Lives: {self.lives}"
             )
             self.x, self.y = self.initial_position
-            self.target_position = self.initial_position
             self.is_invincible = True
             self.invincibility_timer = 0
             self.blink_timer = 0

--- a/src/core/tank.py
+++ b/src/core/tank.py
@@ -1,5 +1,5 @@
 import pygame
-from typing import Optional, Tuple
+from typing import Optional
 from loguru import logger
 from .game_object import GameObject
 from .bullet import Bullet
@@ -70,7 +70,6 @@ class Tank(GameObject):
         # Store previous position for collision rollback
         self.prev_x: float = x
         self.prev_y: float = y
-        self.target_position: Tuple[float, float] = (x, y)
         self.is_invincible: bool = False
         self.invincibility_timer: float = 0
         self.invincibility_duration: float = 0
@@ -205,7 +204,6 @@ class Tank(GameObject):
         # Apply movement (position will be validated/reverted by GameManager)
         self.x = target_x
         self.y = target_y
-        self.target_position = (self.x, self.y)
 
         # Distance-based animation toggle
         distance = abs(dx * self.speed * dt) + abs(dy * self.speed * dt)
@@ -254,7 +252,6 @@ class Tank(GameObject):
             self.y = self.prev_y
 
         self.rect.topleft = (round(self.x), round(self.y))
-        self.target_position = (self.x, self.y)
 
     def draw(self, surface: pygame.Surface) -> None:
         """

--- a/src/managers/texture_manager.py
+++ b/src/managers/texture_manager.py
@@ -115,4 +115,4 @@ class TextureManager:
         except KeyError:
             logger.error(f"Error: Sprite '{name}' not found.")
             # Optionally return a default 'missing' sprite or raise the error
-            raise KeyError(f"Sprite '{name}' not found.") from KeyError
+            raise KeyError(f"Sprite '{name}' not found.") from None

--- a/tests/core/test_player_tank.py
+++ b/tests/core/test_player_tank.py
@@ -76,7 +76,6 @@ def test_player_tank_respawn(player_tank):
     assert player_tank.lives == initial_lives - 1
     assert player_tank.health == initial_health
     assert (player_tank.x, player_tank.y) == initial_pos
-    assert player_tank.target_position == initial_pos
     assert player_tank.is_invincible
     assert player_tank.invincibility_timer == 0
     assert player_tank.blink_timer == 0

--- a/tests/integration/test_collision_integration.py
+++ b/tests/integration/test_collision_integration.py
@@ -49,7 +49,6 @@ def test_player_bullet_vs_tile(
     player_start_x = target_x_grid * TILE_SIZE
     player_start_y = (target_y_grid + 1) * TILE_SIZE
     player_tank.set_position(player_start_x, player_start_y)
-    player_tank.target_position = (player_start_x, player_start_y)
     player_tank.prev_x, player_tank.prev_y = player_start_x, player_start_y
 
     # Aim up and shoot
@@ -143,7 +142,6 @@ def test_player_bullet_destroys_enemy_tank(game_manager_fixture, mocker):
     player_start_x = enemy_x_grid * TILE_SIZE
     player_start_y = (enemy_y_grid + 1) * TILE_SIZE
     player_tank.set_position(player_start_x, player_start_y)
-    player_tank.target_position = (player_start_x, player_start_y)
     player_tank.prev_x, player_tank.prev_y = player_start_x, player_start_y
 
     # Aim up and shoot

--- a/tests/integration/test_enemy_integration.py
+++ b/tests/integration/test_enemy_integration.py
@@ -142,9 +142,6 @@ def test_enemy_spawn_blocked(game_manager_fixture):
     player_tank.set_position(
         blocked_spawn_point_pixels[0], blocked_spawn_point_pixels[1]
     )
-    player_tank.target_position = (
-        blocked_spawn_point_pixels  # Ensure target is also updated
-    )
     player_tank.prev_x, player_tank.prev_y = blocked_spawn_point_pixels
     logger.info(
         f"Blocking spawn point {blocked_spawn_point_grid} with player at "

--- a/tests/integration/test_gamestate_integration.py
+++ b/tests/integration/test_gamestate_integration.py
@@ -143,7 +143,6 @@ def test_player_bullet_hits_base(game_manager_fixture):
         )
 
     player_tank.set_position(player_start_x, player_start_y)
-    player_tank.target_position = (player_start_x, player_start_y)
     player_tank.prev_x, player_tank.prev_y = player_start_x, player_start_y
 
     # Aim DOWN and shoot

--- a/tests/integration/test_player_integration.py
+++ b/tests/integration/test_player_integration.py
@@ -41,7 +41,6 @@ def test_player_movement(key, axis, direction_sign, expected_direction):
                     )
 
     player_tank.set_position(new_x, new_y)
-    player_tank.target_position = (new_x, new_y)  # Ensure target is also updated
     player_tank.prev_x, player_tank.prev_y = new_x, new_y  # Sync previous position
 
     initial_pos = player_tank.get_position()
@@ -145,7 +144,6 @@ def test_player_movement_blocked_by_tile(
 
     # Place player
     player_tank.set_position(start_x, start_y)
-    player_tank.target_position = (start_x, start_y)
     player_tank.prev_x, player_tank.prev_y = start_x, start_y
     # Capture the initial rect based on rounded initial float positions
     initial_player_rect = pygame.Rect(round(start_x), round(start_y), player_tank.width, player_tank.height)


### PR DESCRIPTION
## Summary
- Remove `target_position` from `Tank` — set in `_move()` and `revert_move()` but never read for any decision (dead state). Removed from 5 test files that were setting it unnecessarily.
- Remove `PlayerTank.update()` empty override that only called `super().update(dt)`
- Fix `TextureManager.get_sprite` raising `KeyError(...) from KeyError` (the class) — changed to `from None`

## Test plan
- [x] All 178 tests pass
- [x] Ruff lint clean on all changed files (29 pre-existing errors in untouched files)