### PR TITLE
refactor: move grid alignment into base Tank constructor

### DIFF
--- a/src/core/enemy_tank.py
+++ b/src/core/enemy_tank.py
@@ -76,18 +76,9 @@ class EnemyTank(Tank):
         """
         props = self.TANK_PROPERTIES[tank_type]
 
-        # Ensure x and y are aligned to the grid
-        grid_x = round(x / tile_size) * tile_size
-        grid_y = round(y / tile_size) * tile_size
-
-        logger.debug(
-            f"Creating EnemyTank (type: {tank_type}) at grid ({grid_x}, {grid_y})"
-        )
-
-        # Initialize with grid-aligned position and type-specific properties
         super().__init__(
-            grid_x,
-            grid_y,
+            x,
+            y,
             texture_manager,
             tile_size,
             None,

--- a/src/core/player_tank.py
+++ b/src/core/player_tank.py
@@ -28,12 +28,9 @@ class PlayerTank(Tank):
             map_width_px: Map width in pixels (for boundary clamping)
             map_height_px: Map height in pixels (for boundary clamping)
         """
-        grid_x = round(x / tile_size) * tile_size
-        grid_y = round(y / tile_size) * tile_size
-        logger.debug(f"Creating PlayerTank at initial grid ({grid_x}, {grid_y})")
         super().__init__(
-            grid_x,
-            grid_y,
+            x,
+            y,
             texture_manager,
             tile_size,
             None,
@@ -43,7 +40,7 @@ class PlayerTank(Tank):
             map_height_px=map_height_px,
         )
         self.owner_type = OwnerType.PLAYER
-        self.initial_position = (grid_x, grid_y)
+        self.initial_position = (self.x, self.y)
         self.invincibility_duration = 3.0
         self._update_sprite()
 

--- a/src/core/tank.py
+++ b/src/core/tank.py
@@ -52,6 +52,9 @@ class Tank(GameObject):
             map_width_px: Map width in pixels (for boundary clamping)
             map_height_px: Map height in pixels (for boundary clamping)
         """
+        # Snap to grid
+        x = round(x / tile_size) * tile_size
+        y = round(y / tile_size) * tile_size
         logger.debug(f"Creating Tank at ({x}, {y})")
         super().__init__(x, y, TANK_WIDTH, TANK_HEIGHT, sprite)
         self.texture_manager = texture_manager


### PR DESCRIPTION
## Summary
- Move duplicated grid-snap logic (`round(x / tile_size) * tile_size`) from `PlayerTank.__init__` and `EnemyTank.__init__` into base `Tank.__init__`
- Subclasses now pass raw coordinates; the base class handles alignment
- Dropped the `MapConfig` dataclass idea from the original plan — the current parameters are clear and well-named, a dataclass would be a speculative abstraction

## Test plan
- [x] All 178 tests pass
- [x] Ruff lint clean on all changed files