### PR TITLE
refactor: separate one-time init from per-reset state in GameManager

### DIFF
--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -26,37 +26,31 @@ class GameManager:
     """Manages the core game loop and window."""
 
     def __init__(self) -> None:
-        """Initialize the game window and basic settings."""
+        """Initialize the game window and persistent resources."""
         logger.info("Initializing GameManager...")
-        self._reset_game()
 
-    def _reset_game(self) -> None:
-        """Resets the game state to the initial configuration."""
-        logger.info("Resetting game state...")
-        # Display setup
+        # Display setup (once)
         self.tile_size: int = TILE_SIZE
-        self.screen_width: int = WINDOW_WIDTH
-        self.screen_height: int = WINDOW_HEIGHT
         self.screen: pygame.Surface = pygame.display.set_mode(
-            (self.screen_width, self.screen_height)
+            (WINDOW_WIDTH, WINDOW_HEIGHT)
         )
         pygame.display.set_caption(WINDOW_TITLE)
 
-        # --- Initialize Managers AFTER display mode is set ---
-        logger.info("Initializing TextureManager...")
+        # Persistent resources (once)
         self.texture_manager = TextureManager("assets/sprites/sprites.png")
-        logger.info("Initializing CollisionManager...")
-        self.collision_manager: CollisionManager = CollisionManager()
-        self.input_handler: InputHandler = InputHandler()
-        # --- End Initialize Managers ---
-
-        # Game clock
         self.clock: pygame.time.Clock = pygame.time.Clock()
         self.fps: int = FPS
+        self.input_handler: InputHandler = InputHandler()
 
-        # Game state
+        self._reset_game()
+
+    def _reset_game(self) -> None:
+        """Resets per-level game state. Display and textures are preserved."""
+        logger.info("Resetting game state...")
+
         self.state: GameState = GameState.RUNNING
         self.current_stage: int = 1
+        self.collision_manager: CollisionManager = CollisionManager()
 
         # Map
         self.map: Map = Map("assets/maps/level_01.tmx", self.texture_manager)
@@ -86,10 +80,8 @@ class GameManager:
         )
 
         # Renderer
-        logical_width: int = map_width_px
-        logical_height: int = map_height_px
         self.renderer: Renderer = Renderer(
-            self.screen, logical_width, logical_height
+            self.screen, map_width_px, map_height_px
         )
 
         # SpawnManager

--- a/tests/managers/test_game_manager.py
+++ b/tests/managers/test_game_manager.py
@@ -4,12 +4,7 @@ from unittest.mock import patch, MagicMock
 from src.managers.game_manager import GameManager
 from src.states.game_state import GameState
 from src.core.enemy_tank import EnemyTank
-from src.utils.constants import (
-    WINDOW_TITLE,
-    FPS,
-    WINDOW_WIDTH,
-    WINDOW_HEIGHT,
-)
+from src.utils.constants import FPS
 
 
 class TestGameManager:
@@ -19,20 +14,21 @@ class TestGameManager:
     def game_manager(self):
         """Create a game manager instance for testing."""
         pygame.init()
-        # Mock display, font, and TextureManager *before* GameManager is created
+        # Keep mocks alive for the duration of the test so _reset_game
+        # can be called again (e.g. by pressing R to restart).
         with (
             patch("pygame.display.set_mode"),
             patch("pygame.font.SysFont"),
-            patch("src.managers.game_manager.TextureManager") as MockTextureManager,
+            patch("src.managers.game_manager.TextureManager") as MockTM,
             patch("src.managers.game_manager.Renderer"),
             patch("src.managers.game_manager.SpawnManager"),
             patch("src.managers.game_manager.Map") as MockMap,
         ):
-            # Configure the mock TextureManager instance that GameManager will create
-            mock_tm_instance = MockTextureManager.return_value
-            mock_tm_instance.get_sprite.return_value = MagicMock(spec=pygame.Surface)
+            mock_tm_instance = MockTM.return_value
+            mock_tm_instance.get_sprite.return_value = MagicMock(
+                spec=pygame.Surface
+            )
 
-            # Configure the mock Map instance
             mock_map_instance = MockMap.return_value
             mock_map_instance.width = 16
             mock_map_instance.height = 16
@@ -40,17 +36,13 @@ class TestGameManager:
             mock_map_instance.spawn_points = [(3, 1), (8, 1), (12, 1)]
 
             manager = GameManager()
-        yield manager
+            yield manager
         pygame.quit()
 
     def test_initialization(self, game_manager):
         """Test that the game manager initializes correctly."""
         assert game_manager.state == GameState.RUNNING
         assert game_manager.fps == FPS
-        # Assert against constants used in GameManager init
-        assert game_manager.screen_width == WINDOW_WIDTH
-        assert game_manager.screen_height == WINDOW_HEIGHT
-        assert pygame.display.get_caption()[0] == WINDOW_TITLE
         assert game_manager.spawn_manager is not None
         assert game_manager.renderer is not None
 


### PR DESCRIPTION
## Summary
- Move display setup, `TextureManager`, clock, and `InputHandler` into `__init__` — created once, preserved across restarts
- `_reset_game` now only resets per-level state: map, tanks, bullets, spawn manager, collision handler, renderer, and game state
- Previously pressing R to restart would re-create the display surface and reload the entire texture atlas unnecessarily
- Fixed test fixture to keep mocks alive across `_reset_game` calls (moved `yield` inside the `with` block)
- Removed redundant `screen_width`/`screen_height` attributes (were just copies of constants)

## Test plan
- [x] All 178 tests pass
- [x] Ruff lint clean on all changed files