### PR TITLE
refactor: simplify collision detection and remove redundancies

### DIFF
--- a/src/core/bullet.py
+++ b/src/core/bullet.py
@@ -45,6 +45,8 @@ class Bullet(GameObject):
         self.color: ColorTuple = WHITE
         self.owner = owner
         self.owner_type: OwnerType = owner.owner_type
+        self.map_width_px: int = owner.map_width_px
+        self.map_height_px: int = owner.map_height_px
         logger.trace(
             f"Created bullet for {self.owner_type} "
             f"at ({x:.1f}, {y:.1f}) moving {direction}"
@@ -67,9 +69,9 @@ class Bullet(GameObject):
         # Check if bullet is out of bounds
         if (
             self.x < 0
-            or self.x > self.owner.map_width_px
+            or self.x > self.map_width_px
             or self.y < 0
-            or self.y > self.owner.map_height_px
+            or self.y > self.map_height_px
         ):
             self.active = False
             return

--- a/src/core/map.py
+++ b/src/core/map.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple
+from typing import Iterable, List, Optional, Tuple
 import pygame
 import pytmx
 from pytmx.util_pygame import load_pygame
@@ -189,7 +189,7 @@ class Map:
         if self._tile_cache_dirty:
             self._rebuild_tile_caches()
 
-    def get_tiles_by_type(self, types: List[TileType]) -> List[Tile]:
+    def get_tiles_by_type(self, types: Iterable[TileType]) -> List[Tile]:
         """Get a list of tiles matching the specified types."""
         self._ensure_cache()
         result = []

--- a/src/managers/collision_manager.py
+++ b/src/managers/collision_manager.py
@@ -48,72 +48,52 @@ class CollisionManager:
             all_tanks.append(player_tank)
         all_tanks.extend(enemy_tanks)
 
-        # Player bullets vs Enemy tanks
-        for bullet in player_bullets:
-            for tank in enemy_tanks:
-                if bullet.rect.colliderect(tank.rect):
-                    self._queue_collision(bullet, tank)
+        # Bullet collisions
+        self._check_group_vs_group(player_bullets, enemy_tanks)
+        self._check_group_vs_group(player_bullets, destructible_tiles)
+        self._check_group_vs_group(player_bullets, enemy_bullets)
+        self._check_group_vs_group(player_bullets, impassable_tiles)
+        self._check_group_vs_group(enemy_bullets, destructible_tiles)
+        self._check_group_vs_group(enemy_bullets, impassable_tiles)
 
-        # Player bullets vs Destructible tiles
-        for bullet in player_bullets:
-            for tile in destructible_tiles:
-                if bullet.rect.colliderect(tile.rect):
-                    self._queue_collision(bullet, tile)
-
-        # Player bullets vs Enemy bullets
-        for p_bullet in player_bullets:
-            for e_bullet in enemy_bullets:
-                if p_bullet.rect.colliderect(e_bullet.rect):
-                    self._queue_collision(p_bullet, e_bullet)
-
-        # Player bullets vs Impassable tiles
-        for bullet in player_bullets:
-            for tile in impassable_tiles:
-                if bullet.rect.colliderect(tile.rect):
-                    self._queue_collision(bullet, tile)
-
-        # Player bullets vs Player base
+        # Bullets vs single targets
         if player_base:
-            for bullet in player_bullets:
-                if bullet.rect.colliderect(player_base.rect):
-                    self._queue_collision(bullet, player_base)
-
-        # Enemy bullets vs Player base
-        if player_base:
-            for bullet in enemy_bullets:
-                if bullet.rect.colliderect(player_base.rect):
-                    self._queue_collision(bullet, player_base)
-
-        # Enemy bullets vs Player tank
+            self._check_group_vs_single(player_bullets, player_base)
+            self._check_group_vs_single(enemy_bullets, player_base)
         if player_tank:
-            for bullet in enemy_bullets:
-                if bullet.rect.colliderect(player_tank.rect):
-                    self._queue_collision(bullet, player_tank)
+            self._check_group_vs_single(enemy_bullets, player_tank)
 
-        # Enemy bullets vs Destructible tiles
-        for bullet in enemy_bullets:
-            for tile in destructible_tiles:
-                if bullet.rect.colliderect(tile.rect):
-                    self._queue_collision(bullet, tile)
+        # Tank collisions
+        self._check_group_vs_group(all_tanks, impassable_tiles)
+        self._check_self_collisions(all_tanks)
 
-        # Enemy bullets vs Impassable tiles
-        for bullet in enemy_bullets:
-            for tile in impassable_tiles:
-                if bullet.rect.colliderect(tile.rect):
-                    self._queue_collision(bullet, tile)
+    def _check_group_vs_group(
+        self,
+        group_a: Sequence[Collidable],
+        group_b: Sequence[Collidable],
+    ) -> None:
+        """Check all pairs between two groups for collisions."""
+        for obj_a in group_a:
+            for obj_b in group_b:
+                if obj_a.rect.colliderect(obj_b.rect):
+                    self._queue_collision(obj_a, obj_b)
 
-        # Tanks vs Impassable tiles
-        for tank in all_tanks:
-            for tile in impassable_tiles:
-                if tank.rect.colliderect(tile.rect):
-                    self._queue_collision(tank, tile)
+    def _check_group_vs_single(
+        self,
+        group: Sequence[Collidable],
+        target: Collidable,
+    ) -> None:
+        """Check all objects in a group against a single target."""
+        for obj in group:
+            if obj.rect.colliderect(target.rect):
+                self._queue_collision(obj, target)
 
-        # Tanks vs Tanks
-        for i, tank_a in enumerate(all_tanks):
-            # Check against tanks listed after tank_a to avoid duplicates/self-collision
-            for tank_b in all_tanks[i + 1 :]:
-                if tank_a.rect.colliderect(tank_b.rect):
-                    self._queue_collision(tank_a, tank_b)
+    def _check_self_collisions(self, group: Sequence[Collidable]) -> None:
+        """Check all unique pairs within a single group."""
+        for i, obj_a in enumerate(group):
+            for obj_b in group[i + 1 :]:
+                if obj_a.rect.colliderect(obj_b.rect):
+                    self._queue_collision(obj_a, obj_b)
 
     def _queue_collision(self, obj_a: Collidable, obj_b: Collidable) -> None:
         """Adds a collision event to the queue, deduplicating pairs."""

--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -4,10 +4,10 @@ from loguru import logger
 from src.core.map import Map
 from src.core.player_tank import PlayerTank
 from src.core.tile import Tile, TileType, IMPASSABLE_TILE_TYPES
-from src.utils.constants import OwnerType
 from src.core.bullet import Bullet
 from src.states.game_state import GameState
 from src.utils.constants import (
+    OwnerType,
     WINDOW_TITLE,
     FPS,
     TILE_SIZE,
@@ -128,7 +128,7 @@ class GameManager:
         # --- Prepare data for Collision Manager ---
         destructible_tiles: List[Tile] = self.map.get_tiles_by_type([TileType.BRICK])
         impassable_tiles: List[Tile] = self.map.get_tiles_by_type(
-            list(IMPASSABLE_TILE_TYPES)
+            IMPASSABLE_TILE_TYPES
         )
         player_base: Optional[Tile] = self.map.get_base()
 
@@ -149,8 +149,7 @@ class GameManager:
             self._try_shoot(self.player_tank)
         self.player_tank.update(dt)
 
-        # Iterate over a copy for safe removal
-        for enemy in self.spawn_manager.enemy_tanks[:]:
+        for enemy in self.spawn_manager.enemy_tanks:
             enemy.update(dt)
             if enemy.consume_shoot():
                 self._try_shoot(enemy)


### PR DESCRIPTION
## Summary
- Extract `_check_group_vs_group`, `_check_group_vs_single`, and `_check_self_collisions` helpers in `CollisionManager`, replacing 9 repetitive nested-loop blocks (~50 lines → ~15)
- Decouple `Bullet` from `Tank` internals by storing `map_width_px`/`map_height_px` directly instead of reaching through `self.owner` each frame
- Widen `Map.get_tiles_by_type()` to accept any `Iterable[TileType]`, removing the per-frame `list(IMPASSABLE_TILE_TYPES)` conversion
- Merge duplicate `constants` imports in `GameManager` and remove unnecessary `enemy_tanks[:]` list copy

## Test plan
- [x] All 178 existing tests pass
- [x] `ruff check src/` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)