### PR TITLE
refactor: convert TankType to enum

### DIFF
--- a/src/core/enemy_tank.py
+++ b/src/core/enemy_tank.py
@@ -1,11 +1,9 @@
 import random
 from loguru import logger
 from .tank import Tank
-from typing import Literal, Dict, TypedDict
-from src.utils.constants import Direction, OwnerType, TANK_SPEED, BULLET_SPEED
+from typing import Dict, TypedDict
+from src.utils.constants import Direction, OwnerType, TankType, TANK_SPEED, BULLET_SPEED
 from src.managers.texture_manager import TextureManager
-
-TankType = Literal["basic", "fast", "power", "armor"]
 
 
 # Define the structure for the properties dictionary
@@ -21,28 +19,28 @@ class EnemyTank(Tank):
     """Enemy tank entity with basic AI and type variations."""
 
     TANK_PROPERTIES: Dict[TankType, TankPropertyDict] = {
-        "basic": {
+        TankType.BASIC: {
             "speed": TANK_SPEED * 0.75,
             "bullet_speed": BULLET_SPEED,
             "health": 1,
             "shoot_interval": 2.0,
             "direction_change_interval": 2.5,
         },
-        "fast": {
+        TankType.FAST: {
             "speed": TANK_SPEED * 1.5,
             "bullet_speed": BULLET_SPEED,
             "health": 1,
             "shoot_interval": 1.8,
             "direction_change_interval": 1.5,
         },
-        "power": {
+        TankType.POWER: {
             "speed": TANK_SPEED,
             "bullet_speed": BULLET_SPEED * 1.5,
             "health": 1,
             "shoot_interval": 1.0,
             "direction_change_interval": 2.0,
         },
-        "armor": {
+        TankType.ARMOR: {
             "speed": TANK_SPEED,
             "bullet_speed": BULLET_SPEED,
             "health": 4,

--- a/src/managers/spawn_manager.py
+++ b/src/managers/spawn_manager.py
@@ -8,6 +8,7 @@ from src.core.enemy_tank import EnemyTank
 from src.core.map import Map
 from src.core.player_tank import PlayerTank
 from src.managers.texture_manager import TextureManager
+from src.utils.constants import TankType
 from src.utils.level_data import STAGE_ENEMIES
 
 
@@ -42,7 +43,7 @@ class SpawnManager:
         self.tile_size = tile_size
         self.texture_manager = texture_manager
         self.spawn_points = spawn_points
-        self._spawn_queue: List[str] = self._build_spawn_queue(stage)
+        self._spawn_queue: List[TankType] = self._build_spawn_queue(stage)
         self.max_enemy_spawns: int = len(self._spawn_queue)
         self.spawn_interval = spawn_interval
         self.map_width_px = map_width_px
@@ -53,22 +54,22 @@ class SpawnManager:
         # Initial spawn
         self.spawn_enemy(player_tank, game_map)
 
-    def _build_spawn_queue(self, stage: int) -> List[str]:
+    def _build_spawn_queue(self, stage: int) -> List[TankType]:
         """Build a shuffled list of enemy types for the given stage.
 
         Args:
             stage: Stage number (1-based). Clamped to valid range.
 
         Returns:
-            Shuffled list of enemy type strings.
+            Shuffled list of TankType enum members.
         """
         index = min(stage - 1, len(STAGE_ENEMIES) - 1)
         basic, fast, power, armor = STAGE_ENEMIES[index]
-        queue = (
-            ["basic"] * basic
-            + ["fast"] * fast
-            + ["power"] * power
-            + ["armor"] * armor
+        queue: List[TankType] = (
+            [TankType.BASIC] * basic
+            + [TankType.FAST] * fast
+            + [TankType.POWER] * power
+            + [TankType.ARMOR] * armor
         )
         random.shuffle(queue)
         return queue

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -50,6 +50,16 @@ class OwnerType(str, Enum):
         return self.value
 
 
+class TankType(str, Enum):
+    BASIC = "basic"
+    FAST = "fast"
+    POWER = "power"
+    ARMOR = "armor"
+
+    def __str__(self) -> str:
+        return self.value
+
+
 # Window settings
 WINDOW_WIDTH: int = 1024  # Logical width (16*32) * 2
 WINDOW_HEIGHT: int = 1024  # Logical height (16*32) * 2

--- a/tests/core/test_enemy_tank.py
+++ b/tests/core/test_enemy_tank.py
@@ -1,6 +1,6 @@
 import pytest
-from src.core.enemy_tank import EnemyTank, TankType
-from src.utils.constants import TILE_SIZE, TANK_SPEED, BULLET_SPEED
+from src.core.enemy_tank import EnemyTank
+from src.utils.constants import TILE_SIZE, TANK_SPEED, BULLET_SPEED, TankType
 
 # Define expected properties based on EnemyTank.TANK_PROPERTIES for easier assertion
 EXPECTED_PROPERTIES = {


### PR DESCRIPTION
## Summary
- Converted `TankType` from a `Literal["basic", "fast", "power", "armor"]` type alias to a proper `(str, Enum)` class, matching the pattern used by `Direction` and `OwnerType`
- Moved `TankType` from `src/core/enemy_tank.py` to `src/utils/constants.py` for consistency with other enums
- Updated `TANK_PROPERTIES` dict keys, `SpawnManager._build_spawn_queue`, and test imports to use enum members

## Test plan
- [x] All 115 unit tests pass (`uv run pytest tests/core/ tests/managers/`)
- [x] Lint clean on changed files (`uv run ruff check src/ tests/`)
- [x] `TankType` uses `(str, Enum)` with `__str__` returning `self.value`, so string comparisons (e.g. `== "basic"`) and f-string formatting continue to work without breaking existing code