### PR TITLE
refactor: make Tank.owner_type required and fix set_position annotation

### DIFF
--- a/src/core/enemy_tank.py
+++ b/src/core/enemy_tank.py
@@ -86,11 +86,11 @@ class EnemyTank(Tank):
             lives=1,
             speed=props["speed"],
             bullet_speed=props["bullet_speed"],
+            owner_type=OwnerType.ENEMY,
             map_width_px=map_width_px,
             map_height_px=map_height_px,
         )
         self.tank_type = tank_type
-        self.owner_type = OwnerType.ENEMY
         self.direction = random.choice(list(Direction))
         self.direction_timer: float = 0
         self.direction_change_interval: float = props["direction_change_interval"]

--- a/src/core/game_object.py
+++ b/src/core/game_object.py
@@ -62,7 +62,7 @@ class GameObject:
         """Get the current position of the object."""
         return (self.x, self.y)
 
-    def set_position(self, x: int, y: int) -> None:
+    def set_position(self, x: float, y: float) -> None:
         """
         Set the position of the object.
 

--- a/src/core/player_tank.py
+++ b/src/core/player_tank.py
@@ -36,10 +36,10 @@ class PlayerTank(Tank):
             None,
             health=1,
             lives=3,
+            owner_type=OwnerType.PLAYER,
             map_width_px=map_width_px,
             map_height_px=map_height_px,
         )
-        self.owner_type = OwnerType.PLAYER
         self.initial_position = (self.x, self.y)
         self.invincibility_duration = 3.0
         self._update_sprite()

--- a/src/core/tank.py
+++ b/src/core/tank.py
@@ -33,6 +33,7 @@ class Tank(GameObject):
         speed: float = TANK_SPEED,
         bullet_speed: float = BULLET_SPEED,
         *,
+        owner_type: OwnerType,
         map_width_px: int,
         map_height_px: int,
     ) -> None:
@@ -49,6 +50,7 @@ class Tank(GameObject):
             lives: Number of lives
             speed: Movement speed in pixels per second
             bullet_speed: Speed of bullets fired by this tank
+            owner_type: Whether this tank belongs to a player or enemy
             map_width_px: Map width in pixels (for boundary clamping)
             map_height_px: Map height in pixels (for boundary clamping)
         """
@@ -68,7 +70,7 @@ class Tank(GameObject):
         self.health: int = health
         self.max_health: int = health
         self.lives: int = lives
-        self.owner_type: OwnerType = OwnerType.PLAYER
+        self.owner_type: OwnerType = owner_type
         self.distance_since_last_toggle: float = 0
         # Store previous position for collision rollback
         self.prev_x: float = x

--- a/tests/core/test_tank.py
+++ b/tests/core/test_tank.py
@@ -4,6 +4,7 @@ from src.core.tank import Tank
 from src.core.bullet import Bullet
 from src.utils.constants import (
     Direction,
+    OwnerType,
     TILE_SIZE,
     TANK_SPEED,
     BULLET_WIDTH,
@@ -23,6 +24,7 @@ class TestTank:
         """Create a tank instance for testing."""
         return Tank(
             0, 0, mock_texture_manager, tile_size=TILE_SIZE,
+            owner_type=OwnerType.PLAYER,
             map_width_px=MAP_WIDTH_PX, map_height_px=MAP_HEIGHT_PX,
         )
 
@@ -31,6 +33,7 @@ class TestTank:
         """Create a tank instance with two lives for testing."""
         return Tank(
             0, 0, mock_texture_manager, tile_size=TILE_SIZE, lives=2,
+            owner_type=OwnerType.PLAYER,
             map_width_px=MAP_WIDTH_PX, map_height_px=MAP_HEIGHT_PX,
         )
 
@@ -39,6 +42,7 @@ class TestTank:
         """Create a tank instance with two health for testing."""
         return Tank(
             0, 0, mock_texture_manager, tile_size=TILE_SIZE, health=2,
+            owner_type=OwnerType.PLAYER,
             map_width_px=MAP_WIDTH_PX, map_height_px=MAP_HEIGHT_PX,
         )
 


### PR DESCRIPTION
## Summary
- Make `owner_type` a required keyword-only parameter in `Tank.__init__()` instead of silently defaulting to `OwnerType.PLAYER`. Both `PlayerTank` and `EnemyTank` now pass it via `super().__init__()` and no longer override it post-init.
- Fix `GameObject.set_position()` type annotation from `int` to `float` to match the actual types of `self.x` / `self.y`.

## Test plan
- [x] All 115 unit tests pass (`uv run pytest tests/core/ tests/managers/`)
- [x] No new lint issues introduced (`uv run ruff check src/ tests/`)