### PR TITLE
feat: 4-quadrant brick segment destruction

### DIFF
--- a/src/core/map.py
+++ b/src/core/map.py
@@ -173,6 +173,10 @@ class Map:
             logger.warning(f"Attempted to get tile outside map bounds at ({x}, {y})")
             return None
 
+    def mark_tile_cache_dirty(self) -> None:
+        """Mark tile caches as needing rebuild."""
+        self._tile_cache_dirty = True
+
     def set_tile_type(self, tile: Tile, new_type: TileType) -> None:
         """Change a tile's type and invalidate caches."""
         old_type = tile.type

--- a/src/core/tile.py
+++ b/src/core/tile.py
@@ -3,7 +3,24 @@ from typing import List, Optional
 import pygame
 from loguru import logger
 from src.managers.texture_manager import TextureManager
-from src.utils.constants import SUB_TILE_SIZE, TILE_ANIMATION_INTERVAL
+from src.utils.constants import (
+    SUB_TILE_SIZE,
+    TILE_ANIMATION_INTERVAL,
+    SEGMENT_TOP_LEFT,
+    SEGMENT_TOP_RIGHT,
+    SEGMENT_BOTTOM_LEFT,
+    SEGMENT_BOTTOM_RIGHT,
+    SEGMENT_FULL,
+    BRICK_SEGMENT_SIZE,
+)
+
+# Quadrant pixel offsets within a sub-tile: (dx, dy)
+_QUADRANT_OFFSETS = {
+    SEGMENT_TOP_LEFT: (0, 0),
+    SEGMENT_TOP_RIGHT: (BRICK_SEGMENT_SIZE, 0),
+    SEGMENT_BOTTOM_LEFT: (0, BRICK_SEGMENT_SIZE),
+    SEGMENT_BOTTOM_RIGHT: (BRICK_SEGMENT_SIZE, BRICK_SEGMENT_SIZE),
+}
 
 
 class TileType(Enum):
@@ -62,6 +79,11 @@ class Tile:
         self.rect = pygame.Rect(x * size, y * size, size, size)
         self.is_group_primary = is_group_primary
 
+        # Brick segment tracking: each sub-tile has 4 quadrants (8x8 each)
+        self.brick_segments: int = SEGMENT_FULL if tile_type == TileType.BRICK else 0
+        # Cached draw data for partial bricks: list of (dest, source_rect)
+        self._segment_draw_cache: List = []
+
         # Animation attributes
         self.is_animated: bool = False
         self.animation_frames: List[str] = []
@@ -91,6 +113,46 @@ class Tile:
             return True
         return False
 
+    def get_segment_rect(self, segment: int) -> pygame.Rect:
+        """Return the pixel rect for a single quadrant segment."""
+        base_x = self.x * self.size
+        base_y = self.y * self.size
+        dx, dy = _QUADRANT_OFFSETS[segment]
+        return pygame.Rect(
+            base_x + dx, base_y + dy, BRICK_SEGMENT_SIZE, BRICK_SEGMENT_SIZE
+        )
+
+    def remove_brick_segment(self, segment: int) -> None:
+        """Remove segment(s) and update the collision rect.
+
+        If all segments are gone the tile should be set to EMPTY by the caller.
+        """
+        self.brick_segments &= ~segment
+        if self.brick_segments == 0 or self.brick_segments == SEGMENT_FULL:
+            self._segment_draw_cache = []
+            return
+        # Recompute bounding rect and draw cache from remaining quadrants
+        base_x = self.x * self.size
+        base_y = self.y * self.size
+        min_x = base_x + self.size
+        min_y = base_y + self.size
+        max_x = base_x
+        max_y = base_y
+        draw_cache = []
+        for quad, (dx, dy) in _QUADRANT_OFFSETS.items():
+            if self.brick_segments & quad:
+                sx, sy = base_x + dx, base_y + dy
+                min_x = min(min_x, sx)
+                min_y = min(min_y, sy)
+                max_x = max(max_x, sx + BRICK_SEGMENT_SIZE)
+                max_y = max(max_y, sy + BRICK_SEGMENT_SIZE)
+                s = BRICK_SEGMENT_SIZE
+                draw_cache.append(
+                    ((sx, sy), pygame.Rect(dx, dy, s, s))
+                )
+        self.rect = pygame.Rect(min_x, min_y, max_x - min_x, max_y - min_y)
+        self._segment_draw_cache = draw_cache
+
     def draw(self, surface: pygame.Surface, texture_manager: TextureManager) -> None:
         """Draw the tile on the given surface using textures."""
         sprite_name: Optional[str] = None
@@ -110,6 +172,11 @@ class Tile:
                 return
             sprite = texture_manager.get_sprite(sprite_name)
             surface.blit(sprite, self.rect.topleft)
+        elif self.type == TileType.BRICK and self._segment_draw_cache:
+            # Partial brick: blit pre-computed quadrants
+            sprite = texture_manager.get_sub_sprite(sprite_name)
+            for dest, source_rect in self._segment_draw_cache:
+                surface.blit(sprite, dest, source_rect)
         else:
             # All other tiles render at sub-tile size
             sprite = texture_manager.get_sub_sprite(sprite_name)

--- a/src/managers/collision_response_handler.py
+++ b/src/managers/collision_response_handler.py
@@ -5,7 +5,14 @@ from src.core.tank import Tank
 from src.core.player_tank import PlayerTank
 from src.core.enemy_tank import EnemyTank
 from src.core.tile import Tile, TileType, IMPASSABLE_TILE_TYPES
-from src.utils.constants import Direction, OwnerType
+from src.utils.constants import (
+    Direction,
+    OwnerType,
+    SEGMENT_LEFT,
+    SEGMENT_RIGHT,
+    SEGMENT_TOP,
+    SEGMENT_BOTTOM,
+)
 from src.core.map import Map
 from src.states.game_state import GameState
 
@@ -149,7 +156,7 @@ class CollisionResponseHandler:
         if tile.type == TileType.BRICK:
             logger.debug(f"Bullet hit brick tile at ({tile.x}, {tile.y})")
             bullet.active = False
-            self._destroy_brick_pair(tile, bullet.direction)
+            self._destroy_brick_segments(tile, bullet)
             return True
         elif tile.type == TileType.STEEL:
             logger.debug(f"Bullet hit steel tile at ({tile.x}, {tile.y})")
@@ -178,28 +185,57 @@ class CollisionResponseHandler:
         bullet_b.active = False
         return True
 
-    def _destroy_brick_pair(self, tile: Tile, direction: Direction) -> None:
-        """Destroy a brick sub-tile and its directional sibling.
+    def _destroy_brick_segments(self, tile: Tile, bullet: Bullet) -> None:
+        """Destroy brick quadrants hit by a bullet (4x4 segment model).
 
-        Matches NES behavior: a bullet destroys the two sub-tiles on the
-        entry side of a 2x2 brick group. UP/DOWN bullets destroy a
-        horizontal pair (same row). LEFT/RIGHT bullets destroy a vertical
-        pair (same column).
+        Each 32x32 brick = 4 sub-tiles (2x2, 16x16 each).
+        Each sub-tile has 4 quadrants (2x2, 8x8 each) = 16 segments total.
+
+        A bullet destroys the full entry-side row/column of each sub-tile
+        it overlaps. For a RIGHT bullet that means both left-column quadrants
+        (TL+BL); for a DOWN bullet both top-row quadrants (TL+TR), etc.
+
+        If the entry side is already gone the bullet passes through and
+        destroys the remaining side instead.
         """
-        self._map.set_tile_type(tile, TileType.EMPTY)
+        direction = bullet.direction
+        bullet_rect = bullet.rect
 
-        # Find the sibling sub-tile perpendicular to bullet direction
-        if direction in (Direction.UP, Direction.DOWN):
-            # Horizontal pair: sibling is at x±1, same y
-            sibling_x = tile.x ^ 1  # toggle least significant bit
-            sibling = self._map.get_tile_at(sibling_x, tile.y)
+        if direction in (Direction.LEFT, Direction.RIGHT):
+            entry_mask = SEGMENT_LEFT if direction == Direction.RIGHT else SEGMENT_RIGHT
+            sibling = self._map.get_tile_at(tile.x, tile.y ^ 1)
         else:
-            # Vertical pair: sibling is at same x, y±1
-            sibling_y = tile.y ^ 1  # toggle least significant bit
-            sibling = self._map.get_tile_at(tile.x, sibling_y)
+            entry_mask = SEGMENT_TOP if direction == Direction.DOWN else SEGMENT_BOTTOM
+            sibling = self._map.get_tile_at(tile.x ^ 1, tile.y)
 
+        # Always destroy the full entry side of the primary tile
+        self._destroy_entry_side(tile, entry_mask)
+
+        # Sibling only if the bullet physically reaches it
         if sibling and sibling.type == TileType.BRICK:
-            self._map.set_tile_type(sibling, TileType.EMPTY)
+            if bullet_rect.colliderect(sibling.rect):
+                self._destroy_entry_side(sibling, entry_mask)
+
+    def _destroy_entry_side(self, tile: Tile, entry_mask: int) -> None:
+        """Destroy the full entry-side of a sub-tile.
+
+        If entry side has remaining quadrants, destroy them all.
+        If entry side is already gone, destroy the opposite side (pass-through).
+        """
+        target = tile.brick_segments & entry_mask
+        if not target:
+            # Entry side gone — pass-through to remaining quadrants
+            target = tile.brick_segments
+        if target:
+            self._remove_segment(tile, target)
+
+    def _remove_segment(self, tile: Tile, segment: int) -> None:
+        """Remove one segment from a brick sub-tile; set EMPTY if none remain."""
+        tile.remove_brick_segment(segment)
+        if tile.brick_segments == 0:
+            self._map.set_tile_type(tile, TileType.EMPTY)
+        else:
+            self._map.mark_tile_cache_dirty()
 
     def _handle_tank_vs_tank(
         self,

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -92,6 +92,21 @@ TANK_WIDTH: int = TILE_SIZE
 TANK_HEIGHT: int = TILE_SIZE
 TANK_ANIMATION_DISTANCE: float = 4  # pixels traveled between animation frame toggles
 
+# Brick segment bitmask constants (each sub-tile has 4 quadrants, 8x8 each)
+SEGMENT_TOP_LEFT: int = 0b0001
+SEGMENT_TOP_RIGHT: int = 0b0010
+SEGMENT_BOTTOM_LEFT: int = 0b0100
+SEGMENT_BOTTOM_RIGHT: int = 0b1000
+SEGMENT_FULL: int = 0b1111
+
+# Composite masks for entry-side destruction
+SEGMENT_LEFT: int = SEGMENT_TOP_LEFT | SEGMENT_BOTTOM_LEFT
+SEGMENT_RIGHT: int = SEGMENT_TOP_RIGHT | SEGMENT_BOTTOM_RIGHT
+SEGMENT_TOP: int = SEGMENT_TOP_LEFT | SEGMENT_TOP_RIGHT
+SEGMENT_BOTTOM: int = SEGMENT_BOTTOM_LEFT | SEGMENT_BOTTOM_RIGHT
+
+BRICK_SEGMENT_SIZE: int = SUB_TILE_SIZE // 2  # 8px — half a sub-tile (square)
+
 # Bullet settings
 BULLET_SPEED: float = 180  # pixels per second (was 3, multiplied by FPS internally)
 BULLET_WIDTH: int = 2

--- a/tests/integration/test_collision_integration.py
+++ b/tests/integration/test_collision_integration.py
@@ -1,6 +1,6 @@
 import pytest
 from loguru import logger
-from src.utils.constants import Direction, FPS, TILE_SIZE, SUB_TILE_SIZE
+from src.utils.constants import Direction, FPS, TILE_SIZE, SUB_TILE_SIZE, SEGMENT_FULL
 from src.states.game_state import GameState
 from src.core.tile import Tile, TileType
 from src.core.enemy_tank import EnemyTank
@@ -11,7 +11,7 @@ from src.core.enemy_tank import EnemyTank
 @pytest.mark.parametrize(
     "tile_to_place, expected_bullet_active, expected_tile_type",
     [
-        (TileType.BRICK, False, TileType.EMPTY),  # Bullet hits brick, brick destroyed
+        (TileType.BRICK, False, TileType.BRICK),  # Bullet partially destroys brick
         (TileType.STEEL, False, TileType.STEEL),  # Bullet hits steel, steel unchanged
         (TileType.WATER, True, TileType.WATER),  # Bullet passes through water
         (TileType.BUSH, True, TileType.BUSH),  # Bullet passes through bush
@@ -93,13 +93,18 @@ def test_player_bullet_vs_tile(
     )
 
     # 2. Verify the tile's final type
-    # Re-fetch the tile in case it was replaced (though unlikely with current impl)
     final_tile = game_map.get_tile_at(target_x_grid, target_y_grid)
     assert final_tile is not None, "Target tile somehow disappeared."
     assert final_tile.type == expected_tile_type, (
         f"Tile type mismatch for {tile_to_place.name}. "
         f"Expected: {expected_tile_type.name}, Got: {final_tile.type.name}"
     )
+
+    # 3. For brick: verify partial destruction (quadrants removed)
+    if tile_to_place == TileType.BRICK:
+        assert final_tile.brick_segments != SEGMENT_FULL, (
+            "Brick should have lost at least one quadrant after being hit."
+        )
 
 
 def _clear_tiles(game_map, positions):

--- a/tests/unit/core/test_tile.py
+++ b/tests/unit/core/test_tile.py
@@ -3,7 +3,19 @@ import pygame
 from unittest.mock import MagicMock
 from src.core.tile import Tile, TileType
 from src.managers.texture_manager import TextureManager
-from src.utils.constants import TILE_ANIMATION_INTERVAL
+from src.utils.constants import (
+    TILE_ANIMATION_INTERVAL,
+    SEGMENT_TOP_LEFT,
+    SEGMENT_TOP_RIGHT,
+    SEGMENT_BOTTOM_RIGHT,
+    SEGMENT_LEFT,
+    SEGMENT_RIGHT,
+    SEGMENT_TOP,
+    SEGMENT_BOTTOM,
+    SEGMENT_FULL,
+    BRICK_SEGMENT_SIZE,
+    SUB_TILE_SIZE,
+)
 
 
 class TestTileAnimation:
@@ -109,3 +121,90 @@ class TestTileDraw:
         mock_tm.get_sprite.assert_not_called()
         mock_tm.get_sub_sprite.assert_not_called()
         mock_surface.blit.assert_not_called()
+
+    def test_draw_partial_brick_one_quadrant(self, mock_surface, mock_tm):
+        """Brick with one quadrant removed draws remaining three quadrants."""
+        tile = Tile(TileType.BRICK, 2, 3)
+        tile.remove_brick_segment(SEGMENT_TOP_RIGHT)
+        tile.draw(mock_surface, mock_tm)
+        mock_tm.get_sub_sprite.assert_called_once_with("brick")
+        # Should blit 3 remaining quadrants
+        assert mock_surface.blit.call_count == 3
+
+    def test_draw_partial_brick_quadrant_source_rects(self, mock_surface, mock_tm):
+        """Each remaining quadrant blits the correct 8x8 source region."""
+        tile = Tile(TileType.BRICK, 0, 0)
+        # Remove top row, keep only bottom row
+        tile.remove_brick_segment(SEGMENT_TOP)
+        tile.draw(mock_surface, mock_tm)
+        calls = mock_surface.blit.call_args_list
+        source_rects = [tuple(c[0][2]) for c in calls]
+        h = BRICK_SEGMENT_SIZE
+        w = BRICK_SEGMENT_SIZE
+        bl = tuple(pygame.Rect(0, h, w, h))
+        br = tuple(pygame.Rect(w, h, w, h))
+        assert bl in source_rects
+        assert br in source_rects
+
+
+class TestBrickSegments:
+    """Tests for brick quadrant tracking and rect updates."""
+
+    def test_new_brick_has_full_segments(self):
+        tile = Tile(TileType.BRICK, 0, 0)
+        assert tile.brick_segments == SEGMENT_FULL
+
+    def test_non_brick_has_no_segments(self):
+        tile = Tile(TileType.STEEL, 0, 0)
+        assert tile.brick_segments == 0
+
+    def test_remove_left_column_updates_rect(self):
+        tile = Tile(TileType.BRICK, 4, 4)  # px: (64, 64, 16, 16)
+        tile.remove_brick_segment(SEGMENT_LEFT)
+        assert tile.brick_segments == SEGMENT_RIGHT
+        assert tile.rect == pygame.Rect(
+            4 * SUB_TILE_SIZE + BRICK_SEGMENT_SIZE,
+            4 * SUB_TILE_SIZE,
+            BRICK_SEGMENT_SIZE,
+            SUB_TILE_SIZE,
+        )
+
+    def test_remove_top_row_updates_rect(self):
+        tile = Tile(TileType.BRICK, 4, 4)
+        tile.remove_brick_segment(SEGMENT_TOP)
+        assert tile.brick_segments == SEGMENT_BOTTOM
+        assert tile.rect == pygame.Rect(
+            4 * SUB_TILE_SIZE,
+            4 * SUB_TILE_SIZE + BRICK_SEGMENT_SIZE,
+            SUB_TILE_SIZE,
+            BRICK_SEGMENT_SIZE,
+        )
+
+    def test_remove_single_quadrant_updates_rect(self):
+        tile = Tile(TileType.BRICK, 4, 4)
+        tile.remove_brick_segment(SEGMENT_BOTTOM_RIGHT)
+        assert tile.brick_segments == (SEGMENT_FULL & ~SEGMENT_BOTTOM_RIGHT)
+        # Bounding box still covers full sub-tile (3 of 4 corners occupied)
+        assert tile.rect == pygame.Rect(
+            4 * SUB_TILE_SIZE, 4 * SUB_TILE_SIZE, SUB_TILE_SIZE, SUB_TILE_SIZE
+        )
+
+    def test_remove_all_segments_zeroes_bitmask(self):
+        tile = Tile(TileType.BRICK, 0, 0)
+        tile.remove_brick_segment(SEGMENT_FULL)
+        assert tile.brick_segments == 0
+
+    def test_get_segment_rect_top_left(self):
+        tile = Tile(TileType.BRICK, 4, 4)
+        rect = tile.get_segment_rect(SEGMENT_TOP_LEFT)
+        assert rect == pygame.Rect(64, 64, BRICK_SEGMENT_SIZE, BRICK_SEGMENT_SIZE)
+
+    def test_get_segment_rect_bottom_right(self):
+        tile = Tile(TileType.BRICK, 4, 4)
+        rect = tile.get_segment_rect(SEGMENT_BOTTOM_RIGHT)
+        assert rect == pygame.Rect(
+            64 + BRICK_SEGMENT_SIZE,
+            64 + BRICK_SEGMENT_SIZE,
+            BRICK_SEGMENT_SIZE,
+            BRICK_SEGMENT_SIZE,
+        )

--- a/tests/unit/managers/test_collision_response_handler.py
+++ b/tests/unit/managers/test_collision_response_handler.py
@@ -8,7 +8,14 @@ from src.core.enemy_tank import EnemyTank
 from src.core.tile import Tile, TileType
 from src.core.map import Map
 from src.states.game_state import GameState
-from src.utils.constants import Direction, TILE_SIZE
+from src.utils.constants import (
+    Direction,
+    TILE_SIZE,
+    SEGMENT_LEFT,
+    SEGMENT_RIGHT,
+    SEGMENT_TOP,
+    SEGMENT_BOTTOM,
+)
 
 
 @pytest.fixture
@@ -156,64 +163,148 @@ class TestBulletVsPlayer:
 
 
 class TestBulletVsTile:
-    def test_bullet_destroys_brick_and_horizontal_sibling(self, handler, mock_map):
-        """Bullet moving UP destroys hit tile and horizontal sibling."""
-        bullet = MagicMock(spec=Bullet)
-        bullet.active = True
-        bullet.owner = MagicMock()
-        bullet.direction = Direction.UP
-        tile = MagicMock(spec=Tile)
-        tile.type = TileType.BRICK
-        tile.x, tile.y = 4, 5
-        sibling = MagicMock(spec=Tile)
-        sibling.type = TileType.BRICK
-        mock_map.get_tile_at.return_value = sibling
+    """Brick quadrant destruction tests (4x4 segment model).
+
+    Each 32x32 brick = 4 sub-tiles (16x16, 2x2 grid).
+    Each sub-tile has 4 quadrants (8x8, 2x2 grid) = 16 segments total.
+
+    Sub-tile at grid (4,4) has pixel rect (64,64,16,16).
+    Quadrants: TL=(64,64,8,8) TR=(72,64,8,8) BL=(64,72,8,8) BR=(72,72,8,8).
+    """
+
+    @staticmethod
+    def _bullet(direction, px_x, px_y):
+        """Create a mock bullet with a real rect at given pixel coords."""
+        b = MagicMock(spec=Bullet)
+        b.active = True
+        b.owner = MagicMock()
+        b.direction = direction
+        b.rect = pygame.Rect(px_x, px_y, 2, 2)
+        return b
+
+    # -- Horizontal bullets (LEFT / RIGHT) --
+
+    def test_right_bullet_destroys_entry_column(self, handler, mock_map):
+        """RIGHT bullet destroys full left column (TL+BL) of sub-tile."""
+        tile = Tile(TileType.BRICK, 4, 4)
+        mock_map.get_tile_at.return_value = Tile(TileType.EMPTY, 4, 5)
+        bullet = self._bullet(Direction.RIGHT, 64, 66)
 
         handler.process_collisions([(bullet, tile)])
 
         assert not bullet.active
-        # Should destroy both the hit tile and its horizontal sibling
-        mock_map.set_tile_type.assert_any_call(tile, TileType.EMPTY)
-        mock_map.get_tile_at.assert_called_with(5, 5)  # x^1 = 5
-        mock_map.set_tile_type.assert_any_call(sibling, TileType.EMPTY)
+        assert tile.brick_segments == SEGMENT_RIGHT
 
-    def test_bullet_destroys_brick_and_vertical_sibling(self, handler, mock_map):
-        """Bullet moving LEFT destroys hit tile and vertical sibling."""
-        bullet = MagicMock(spec=Bullet)
-        bullet.active = True
-        bullet.owner = MagicMock()
-        bullet.direction = Direction.LEFT
-        tile = MagicMock(spec=Tile)
-        tile.type = TileType.BRICK
-        tile.x, tile.y = 4, 4
-        sibling = MagicMock(spec=Tile)
-        sibling.type = TileType.BRICK
-        mock_map.get_tile_at.return_value = sibling
+    def test_left_bullet_destroys_entry_column(self, handler, mock_map):
+        """LEFT bullet destroys full right column (TR+BR) of sub-tile."""
+        tile = Tile(TileType.BRICK, 4, 4)
+        mock_map.get_tile_at.return_value = Tile(TileType.EMPTY, 4, 5)
+        bullet = self._bullet(Direction.LEFT, 72, 66)
 
         handler.process_collisions([(bullet, tile)])
 
         assert not bullet.active
-        mock_map.set_tile_type.assert_any_call(tile, TileType.EMPTY)
-        mock_map.get_tile_at.assert_called_with(4, 5)  # y^1 = 5
-        mock_map.set_tile_type.assert_any_call(sibling, TileType.EMPTY)
+        assert tile.brick_segments == SEGMENT_LEFT
 
-    def test_bullet_destroys_brick_sibling_already_gone(self, handler, mock_map):
-        """If sibling is already EMPTY, only the hit tile is destroyed."""
-        bullet = MagicMock(spec=Bullet)
-        bullet.active = True
-        bullet.owner = MagicMock()
-        bullet.direction = Direction.UP
-        tile = MagicMock(spec=Tile)
-        tile.type = TileType.BRICK
-        tile.x, tile.y = 4, 5
-        sibling = MagicMock(spec=Tile)
-        sibling.type = TileType.EMPTY
+    def test_right_bullet_center_destroys_both_subtiles(self, handler, mock_map):
+        """RIGHT bullet at row boundary → left column of both sub-tiles."""
+        tile = Tile(TileType.BRICK, 4, 4)
+        sibling = Tile(TileType.BRICK, 4, 5)
         mock_map.get_tile_at.return_value = sibling
+        # Bullet straddles y=80 boundary
+        bullet = self._bullet(Direction.RIGHT, 64, 79)
 
         handler.process_collisions([(bullet, tile)])
 
         assert not bullet.active
+        assert tile.brick_segments == SEGMENT_RIGHT
+        assert sibling.brick_segments == SEGMENT_RIGHT
+
+    def test_horizontal_bullet_sibling_already_gone(self, handler, mock_map):
+        """If vertical sibling is EMPTY, only hit sub-tile loses entry column."""
+        tile = Tile(TileType.BRICK, 4, 4)
+        mock_map.get_tile_at.return_value = Tile(TileType.EMPTY, 4, 5)
+        bullet = self._bullet(Direction.RIGHT, 64, 79)
+
+        handler.process_collisions([(bullet, tile)])
+
+        assert tile.brick_segments == SEGMENT_RIGHT
+
+    def test_horizontal_bullet_entry_gone_passes_through(self, handler, mock_map):
+        """If entry column is gone, bullet destroys remaining column."""
+        tile = Tile(TileType.BRICK, 4, 4)
+        tile.remove_brick_segment(SEGMENT_LEFT)  # left column destroyed
+        mock_map.get_tile_at.return_value = Tile(TileType.EMPTY, 4, 5)
+        bullet = self._bullet(Direction.RIGHT, 72, 66)
+
+        handler.process_collisions([(bullet, tile)])
+
+        assert not bullet.active
+        assert tile.brick_segments == 0
         mock_map.set_tile_type.assert_called_once_with(tile, TileType.EMPTY)
+
+    # -- Vertical bullets (UP / DOWN) --
+
+    def test_down_bullet_destroys_entry_row(self, handler, mock_map):
+        """DOWN bullet destroys full top row (TL+TR) of sub-tile."""
+        tile = Tile(TileType.BRICK, 4, 4)
+        mock_map.get_tile_at.return_value = Tile(TileType.EMPTY, 5, 4)
+        bullet = self._bullet(Direction.DOWN, 66, 64)
+
+        handler.process_collisions([(bullet, tile)])
+
+        assert not bullet.active
+        assert tile.brick_segments == SEGMENT_BOTTOM
+
+    def test_up_bullet_destroys_entry_row(self, handler, mock_map):
+        """UP bullet destroys full bottom row (BL+BR) of sub-tile."""
+        tile = Tile(TileType.BRICK, 4, 4)
+        mock_map.get_tile_at.return_value = Tile(TileType.EMPTY, 5, 4)
+        bullet = self._bullet(Direction.UP, 66, 74)
+
+        handler.process_collisions([(bullet, tile)])
+
+        assert not bullet.active
+        assert tile.brick_segments == SEGMENT_TOP
+
+    def test_down_bullet_center_destroys_both_subtiles(self, handler, mock_map):
+        """DOWN bullet at column boundary → top row of both sub-tiles."""
+        tile = Tile(TileType.BRICK, 4, 4)
+        sibling = Tile(TileType.BRICK, 5, 4)
+        mock_map.get_tile_at.return_value = sibling
+        # Bullet straddles x=80 boundary
+        bullet = self._bullet(Direction.DOWN, 79, 64)
+
+        handler.process_collisions([(bullet, tile)])
+
+        assert not bullet.active
+        assert tile.brick_segments == SEGMENT_BOTTOM
+        assert sibling.brick_segments == SEGMENT_BOTTOM
+
+    def test_vertical_bullet_sibling_already_gone(self, handler, mock_map):
+        """If horizontal sibling is EMPTY, only hit sub-tile loses entry row."""
+        tile = Tile(TileType.BRICK, 4, 4)
+        mock_map.get_tile_at.return_value = Tile(TileType.EMPTY, 5, 4)
+        bullet = self._bullet(Direction.DOWN, 66, 64)
+
+        handler.process_collisions([(bullet, tile)])
+
+        assert tile.brick_segments == SEGMENT_BOTTOM
+
+    def test_vertical_bullet_entry_gone_passes_through(self, handler, mock_map):
+        """If entry row is gone, bullet destroys remaining row."""
+        tile = Tile(TileType.BRICK, 4, 4)
+        tile.remove_brick_segment(SEGMENT_TOP)  # top row destroyed
+        mock_map.get_tile_at.return_value = Tile(TileType.EMPTY, 5, 4)
+        bullet = self._bullet(Direction.DOWN, 66, 72)
+
+        handler.process_collisions([(bullet, tile)])
+
+        assert not bullet.active
+        assert tile.brick_segments == 0
+        mock_map.set_tile_type.assert_called_once_with(tile, TileType.EMPTY)
+
+    # -- Non-brick tiles --
 
     def test_bullet_stops_at_steel(self, handler, mock_map):
         bullet = MagicMock(spec=Bullet)


### PR DESCRIPTION
## Summary
- Replace the old destroy-both-sub-tiles approach with a 4x4 segment model (16 segments per 32x32 brick block, each 8x8)
- Bullets now destroy the full entry-side row/column of each sub-tile they overlap, giving symmetric behavior for horizontal and vertical hits
- Add partial brick rendering with cached draw data to avoid per-frame allocations

## Changes
- **constants.py** — Add quadrant bitmask constants (`SEGMENT_TOP_LEFT`, etc.), composite masks (`SEGMENT_LEFT`, `SEGMENT_TOP`, etc.), and `BRICK_SEGMENT_SIZE`
- **tile.py** — Add `brick_segments` tracking, `get_segment_rect()`, `remove_brick_segment()` with bounding-rect + draw-cache updates, and partial-brick drawing
- **map.py** — Add `mark_tile_cache_dirty()` public API (replaces direct `_tile_cache_dirty` access)
- **collision_response_handler.py** — Replace `_destroy_brick_pair` with `_destroy_brick_segments` / `_destroy_entry_side` / `_remove_segment`

## Test plan
- [x] All 229 existing tests pass
- [x] New unit tests for quadrant segment tracking and rect updates
- [x] New unit tests for horizontal and vertical bullet destruction (entry side, center spanning, pass-through, sibling gone)
- [x] Integration test updated for partial brick destruction
- [x] Ruff lint passes
- [x] Manual playtest: shoot bricks from all 4 directions, verify symmetric destruction