### PR TITLE
fix: add steering assist for tank grid alignment

### DIFF
--- a/src/core/tank.py
+++ b/src/core/tank.py
@@ -12,6 +12,7 @@ from src.utils.constants import (
     TANK_WIDTH,
     TANK_HEIGHT,
     TANK_ANIMATION_DISTANCE,
+    TANK_ALIGN_THRESHOLD,
     BULLET_WIDTH,
     BULLET_HEIGHT,
     BULLET_SPEED,
@@ -180,6 +181,22 @@ class Tank(GameObject):
         """Called when the tank collides with a wall tile. No-op by default."""
         pass
 
+    def _align_to_grid(self, value: float, dt: float) -> float:
+        """Nudge a coordinate toward the nearest TILE_SIZE grid line.
+
+        If the offset is within TANK_ALIGN_THRESHOLD, move toward the grid
+        line at the tank's speed so the correction feels natural.
+        """
+        nearest = round(value / TILE_SIZE) * TILE_SIZE
+        offset = nearest - value
+        if abs(offset) > TANK_ALIGN_THRESHOLD:
+            return value
+        # Move toward the grid line, but don't overshoot
+        max_step = self.speed * dt
+        if abs(offset) <= max_step:
+            return float(nearest)
+        return value + max_step * (1.0 if offset > 0 else -1.0)
+
     def _move(self, dx: int, dy: int, dt: float) -> bool:
         """
         Attempt to move the tank by updating its position.
@@ -198,6 +215,12 @@ class Tank(GameObject):
 
         if dx == 0 and dy == 0:
             return False  # No movement requested
+
+        # Steering assist: nudge perpendicular axis toward grid alignment
+        if dx != 0:
+            self.y = self._align_to_grid(self.y, dt)
+        else:
+            self.x = self._align_to_grid(self.x, dt)
 
         # Calculate target position
         target_x = self.x + dx * self.speed * dt

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -91,6 +91,7 @@ TANK_SPEED: float = 80  # pixels per second (was 12 px/step)
 TANK_WIDTH: int = TILE_SIZE
 TANK_HEIGHT: int = TILE_SIZE
 TANK_ANIMATION_DISTANCE: float = 4  # pixels traveled between animation frame toggles
+TANK_ALIGN_THRESHOLD: float = 8.0  # max px offset for steering assist (half a sub-tile)
 
 # Brick segment bitmask constants (each sub-tile has 4 quadrants, 8x8 each)
 SEGMENT_TOP_LEFT: int = 0b0001

--- a/tests/unit/core/test_tank.py
+++ b/tests/unit/core/test_tank.py
@@ -5,6 +5,7 @@ from src.utils.constants import (
     Direction,
     TILE_SIZE,
     TANK_SPEED,
+    TANK_ALIGN_THRESHOLD,
     BULLET_WIDTH,
     BULLET_HEIGHT,
     FPS,
@@ -120,10 +121,11 @@ class TestTank:
         assert tank.y == 0
 
         # Move again without any timer reset needed
+        # Steering assist nudges x toward nearest grid line (0) when moving vertically
         tank.prev_x = tank.x
         tank.prev_y = tank.y
         assert tank._move(0, 1, dt)
-        assert tank.x == pytest.approx(TANK_SPEED * dt)
+        assert tank.x == pytest.approx(0.0)
         assert tank.y == pytest.approx(TANK_SPEED * dt)
 
     def test_move_edge_cases(self, tank):
@@ -146,6 +148,49 @@ class TestTank:
         # Position should not change after failed diagonal attempt
         assert tank.x == 0
         assert tank.y == 0
+
+    @staticmethod
+    def _offset_tank(tank, x=None, y=None):
+        """Set tank position after init (bypasses constructor grid snap)."""
+        if x is not None:
+            tank.x = float(x)
+        if y is not None:
+            tank.y = float(y)
+        tank.rect.topleft = (round(tank.x), round(tank.y))
+
+    def test_steering_assist_nudges_within_threshold(self, create_tank):
+        """Moving horizontally nudges Y toward nearest grid line."""
+        tank = create_tank(x=0, y=0)
+        self._offset_tank(tank, y=TILE_SIZE + 5)
+        dt = 1.0 / FPS
+        tank._move(1, 0, dt)
+        assert tank.y < TILE_SIZE + 5
+
+    def test_steering_assist_snaps_when_close(self, create_tank):
+        """Small offset snaps exactly to grid in one frame."""
+        tank = create_tank(x=0, y=0)
+        self._offset_tank(tank, y=TILE_SIZE + 1)
+        dt = 1.0 / FPS
+        tank._move(1, 0, dt)
+        assert tank.y == pytest.approx(float(TILE_SIZE))
+
+    def test_steering_assist_ignores_beyond_threshold(self, create_tank):
+        """Offset beyond threshold is not corrected."""
+        tank = create_tank(x=0, y=0)
+        offset = TANK_ALIGN_THRESHOLD + 1
+        self._offset_tank(tank, y=TILE_SIZE + offset)
+        dt = 1.0 / FPS
+        tank._move(1, 0, dt)
+        assert tank.y == pytest.approx(TILE_SIZE + offset)
+
+    def test_steering_assist_vertical_nudges_x(self, create_tank):
+        """Moving vertically nudges X toward nearest grid line."""
+        tank = create_tank(x=0, y=0)
+        self._offset_tank(tank, x=TILE_SIZE + 3)
+        dt = 1.0 / FPS
+        tank._move(0, 1, dt)
+        # X should move toward TILE_SIZE but may not arrive in one frame
+        assert tank.x < TILE_SIZE + 3
 
     @pytest.mark.parametrize(
         "start_x,start_y,dx,dy",


### PR DESCRIPTION
## Summary
- Add steering assist that nudges tanks toward the nearest TILE_SIZE grid line on the perpendicular axis when moving, matching the original NES Battle City behavior
- Tanks within 8px (half a sub-tile) of a grid line get smoothly nudged at movement speed — no teleporting
- Applies to both player and enemy tanks, making gap navigation feel natural
- New `TANK_ALIGN_THRESHOLD` constant controls the max correction distance

## Test plan
- [x] All 235 tests pass (231 existing + 4 new)
- [x] New tests cover: nudge within threshold, snap when close, ignore beyond threshold, vertical axis nudge
- [x] Existing movement tests updated for steering assist behavior
- [x] Manual verification: tanks slide into gaps smoothly without getting stuck on edges