### PR TITLE
Fix bullet-vs-bullet collision detection

### DIFF
--- a/src/core/bullet.py
+++ b/src/core/bullet.py
@@ -40,6 +40,8 @@ class Bullet(GameObject):
         self.speed: float = speed
         self.active: bool = True
         self.color: Tuple[int, int, int] = WHITE
+        self.prev_x: float = x
+        self.prev_y: float = y
         self.owner = owner
         self.owner_type: OwnerType = owner.owner_type
         self.map_width_px: int = owner.map_width_px
@@ -59,6 +61,9 @@ class Bullet(GameObject):
         if not self.active:
             return
 
+        self.prev_x = self.x
+        self.prev_y = self.y
+
         dx, dy = self.direction.delta
         self.x += dx * self.speed * dt
         self.y += dy * self.speed * dt
@@ -75,6 +80,19 @@ class Bullet(GameObject):
 
         # Update the bullet's rect
         super().update(dt)
+
+    @property
+    def swept_rect(self) -> pygame.Rect:
+        """Return a rect covering both the previous and current positions.
+
+        Used for continuous collision detection so fast-moving bullets
+        cannot tunnel through each other between frames.
+        """
+        x1 = min(self.prev_x, self.x)
+        y1 = min(self.prev_y, self.y)
+        x2 = max(self.prev_x + self.width, self.x + self.width)
+        y2 = max(self.prev_y + self.height, self.y + self.height)
+        return pygame.Rect(round(x1), round(y1), round(x2 - x1), round(y2 - y1))
 
     def draw(self, surface: pygame.Surface) -> None:
         """

--- a/src/managers/collision_manager.py
+++ b/src/managers/collision_manager.py
@@ -51,7 +51,7 @@ class CollisionManager:
         # Bullet collisions
         self._check_group_vs_group(player_bullets, enemy_tanks)
         self._check_group_vs_group(player_bullets, destructible_tiles)
-        self._check_group_vs_group(player_bullets, enemy_bullets)
+        self._check_bullet_vs_bullet(player_bullets, enemy_bullets)
         self._check_group_vs_group(player_bullets, impassable_tiles)
         self._check_group_vs_group(enemy_bullets, destructible_tiles)
         self._check_group_vs_group(enemy_bullets, impassable_tiles)
@@ -78,6 +78,24 @@ class CollisionManager:
                 if obj_a.rect.colliderect(obj_b.rect):
                     self._queue_collision(obj_a, obj_b)
 
+    def _check_bullet_vs_bullet(
+        self,
+        group_a: Sequence[Collidable],
+        group_b: Sequence[Collidable],
+    ) -> None:
+        """Check bullet-vs-bullet collisions using swept rects to prevent tunneling.
+
+        Swept rects cover both the previous and current positions of each
+        bullet, so fast-moving bullets heading towards each other cannot
+        pass through one another between frames.
+        """
+        for bullet_a in group_a:
+            rect_a = self._get_swept_rect(bullet_a)
+            for bullet_b in group_b:
+                rect_b = self._get_swept_rect(bullet_b)
+                if rect_a.colliderect(rect_b):
+                    self._queue_collision(bullet_a, bullet_b)
+
     def _check_group_vs_single(
         self,
         group: Sequence[Collidable],
@@ -94,6 +112,14 @@ class CollisionManager:
             for obj_b in group[i + 1 :]:
                 if obj_a.rect.colliderect(obj_b.rect):
                     self._queue_collision(obj_a, obj_b)
+
+    @staticmethod
+    def _get_swept_rect(obj: Collidable) -> pygame.Rect:
+        """Return the swept_rect if available, otherwise fall back to rect."""
+        swept = getattr(obj, "swept_rect", None)
+        if isinstance(swept, pygame.Rect):
+            return swept
+        return obj.rect
 
     def _queue_collision(self, obj_a: Collidable, obj_b: Collidable) -> None:
         """Adds a collision event to the queue, deduplicating pairs."""

--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -134,19 +134,6 @@ class GameManager:
 
         dt: float = 1.0 / self.fps
 
-        # --- Prepare data for Collision Manager ---
-        destructible_tiles: List[Tile] = self.map.get_tiles_by_type([TileType.BRICK])
-        impassable_tiles: List[Tile] = self.map.get_tiles_by_type(IMPASSABLE_TILE_TYPES)
-        player_base: Optional[Tile] = self.map.get_base()
-
-        player_bullets = [
-            b for b in self.bullets if b.owner_type == OwnerType.PLAYER and b.active
-        ]
-        enemy_bullets = [
-            b for b in self.bullets if b.owner_type == OwnerType.ENEMY and b.active
-        ]
-        # --- End Prepare data ---
-
         self.map.update(dt)
         # Drive player tank from input
         dx, dy = self.input_handler.get_movement_direction()
@@ -168,6 +155,19 @@ class GameManager:
         self.bullets = [b for b in self.bullets if b.active]
 
         self.spawn_manager.update(dt, self.player_tank, self.map)
+
+        # --- Prepare data for Collision Manager ---
+        # Built AFTER updates so newly fired bullets are included
+        destructible_tiles: List[Tile] = self.map.get_tiles_by_type([TileType.BRICK])
+        impassable_tiles: List[Tile] = self.map.get_tiles_by_type(IMPASSABLE_TILE_TYPES)
+        player_base: Optional[Tile] = self.map.get_base()
+
+        player_bullets = [
+            b for b in self.bullets if b.owner_type == OwnerType.PLAYER and b.active
+        ]
+        enemy_bullets = [
+            b for b in self.bullets if b.owner_type == OwnerType.ENEMY and b.active
+        ]
 
         self.collision_manager.check_collisions(
             player_tank=self.player_tank,


### PR DESCRIPTION
## Summary
- **Fixed stale bullet lists**: collision detection lists were built before tanks fired and bullets moved, so newly fired bullets were invisible to collision checks on their first frame. Moved list creation to after all updates.
- **Fixed bullet tunneling**: 2x2 px bullets at 180 px/s close at 6 px/frame head-on, exceeding the 4px collision window (~33% miss rate). Added swept-rect continuous collision detection that covers each bullet's full path between frames.

## Test plan
- [ ] Verify all existing tests pass (`pytest`)
- [ ] Play the game and shoot directly at oncoming enemy bullets — they should consistently cancel each other out
- [ ] Test shooting while turning the tank in different directions
- [ ] Verify no regressions in bullet-vs-tank and bullet-vs-tile collisions