### PR TITLE
Simplify nested conditionals with guard clauses

### DIFF
--- a/src/core/map.py
+++ b/src/core/map.py
@@ -270,32 +270,36 @@ class Map:
         if tile.type != TileType.BRICK:
             return
 
-        if tile.brick_variant == "full":
-            surviving_variant = self._DIRECTION_TO_VARIANT.get(bullet_direction)
-            if surviving_variant is None:
-                self.set_tile_type(tile, TileType.EMPTY)
-                return
-            sprite = self._brick_variant_sprites.get(surviving_variant)
-            if sprite:
-                tile.brick_variant = surviving_variant
-                tile.tmx_sprite = sprite
-                # Shrink collision rect to match the surviving half
-                fracs = self._VARIANT_RECT.get(surviving_variant)
-                if fracs:
-                    dx, dy, w, h = fracs
-                    base_x = tile.x * tile.size
-                    base_y = tile.y * tile.size
-                    tile.rect = pygame.Rect(
-                        int(base_x + dx * tile.size),
-                        int(base_y + dy * tile.size),
-                        int(w * tile.size),
-                        int(h * tile.size),
-                    )
-                self._tile_cache_dirty = True
-            else:
-                self.set_tile_type(tile, TileType.EMPTY)
-        else:
+        # Non-full bricks are destroyed entirely
+        if tile.brick_variant != "full":
             self.set_tile_type(tile, TileType.EMPTY)
+            return
+
+        surviving_variant = self._DIRECTION_TO_VARIANT.get(bullet_direction)
+        sprite = (
+            self._brick_variant_sprites.get(surviving_variant)
+            if surviving_variant
+            else None
+        )
+        if not sprite:
+            self.set_tile_type(tile, TileType.EMPTY)
+            return
+
+        tile.brick_variant = surviving_variant
+        tile.tmx_sprite = sprite
+        # Shrink collision rect to match the surviving half
+        fracs = self._VARIANT_RECT.get(surviving_variant)
+        if fracs:
+            dx, dy, w, h = fracs
+            base_x = tile.x * tile.size
+            base_y = tile.y * tile.size
+            tile.rect = pygame.Rect(
+                int(base_x + dx * tile.size),
+                int(base_y + dy * tile.size),
+                int(w * tile.size),
+                int(h * tile.size),
+            )
+        self._tile_cache_dirty = True
 
     def set_tile_type(self, tile: Tile, new_type: TileType) -> None:
         """Change a tile's type and invalidate caches."""

--- a/src/core/tile.py
+++ b/src/core/tile.py
@@ -109,14 +109,14 @@ class Tile:
             return
 
         # Animated tiles: use TMX animation sprites if available
-        if self.is_animated:
-            if self.animation_sprites:
-                surface.blit(self.animation_sprites[self.current_frame_index], draw_pos)
-                return
-            if self.animation_frames:
-                sprite_name = self.animation_frames[self.current_frame_index]
-                surface.blit(texture_manager.get_sub_sprite(sprite_name), draw_pos)
-                return
+        if self.is_animated and self.animation_sprites:
+            surface.blit(self.animation_sprites[self.current_frame_index], draw_pos)
+            return
+
+        if self.is_animated and self.animation_frames:
+            sprite_name = self.animation_frames[self.current_frame_index]
+            surface.blit(texture_manager.get_sub_sprite(sprite_name), draw_pos)
+            return
 
         # Fallback: use type-based sprite lookup
         sprite_name = self.SPRITE_NAME_MAP.get(self.type)

--- a/src/managers/collision_response_handler.py
+++ b/src/managers/collision_response_handler.py
@@ -96,18 +96,18 @@ class CollisionResponseHandler:
 
             # Tank collisions
             if isinstance(a, Tank) and isinstance(b, Tank):
-                if a not in reverted_tanks or b not in reverted_tanks:
-                    if handler(a, b, enemies_to_remove):
-                        reverted_tanks.add(a)
-                        reverted_tanks.add(b)
+                if (
+                    (a not in reverted_tanks or b not in reverted_tanks)
+                    and handler(a, b, enemies_to_remove)
+                ):
+                    reverted_tanks.add(a)
+                    reverted_tanks.add(b)
             elif isinstance(a, Tank):
-                if a not in reverted_tanks:
-                    if handler(a, b, enemies_to_remove):
-                        reverted_tanks.add(a)
+                if a not in reverted_tanks and handler(a, b, enemies_to_remove):
+                    reverted_tanks.add(a)
             elif isinstance(b, Tank):
-                if b not in reverted_tanks:
-                    if handler(a, b, enemies_to_remove):
-                        reverted_tanks.add(b)
+                if b not in reverted_tanks and handler(a, b, enemies_to_remove):
+                    reverted_tanks.add(b)
 
         return enemies_to_remove
 
@@ -263,24 +263,17 @@ class CollisionResponseHandler:
         b_caused = self._caused_collision(tank_b, tank_a)
         neither = not a_caused and not b_caused
 
-        if neither:
-            # Pre-existing overlap (e.g. from spawn): prev positions
-            # already collided. Let both tanks move freely so they can
-            # separate instead of getting permanently stuck.
-            if tank_a.prev_rect.colliderect(tank_b.prev_rect):
-                return False
-            # Both moved into each other from non-overlapping positions
+        # Pre-existing overlap (e.g. from spawn): let both tanks move
+        # freely so they can separate instead of getting permanently stuck.
+        if neither and tank_a.prev_rect.colliderect(tank_b.prev_rect):
+            return False
+
+        if neither or a_caused:
             tank_a.revert_move()
             tank_a.on_movement_blocked()
+        if neither or b_caused:
             tank_b.revert_move()
             tank_b.on_movement_blocked()
-        else:
-            if a_caused:
-                tank_a.revert_move()
-                tank_a.on_movement_blocked()
-            if b_caused:
-                tank_b.revert_move()
-                tank_b.on_movement_blocked()
         return True
 
     def _handle_tank_vs_tile(

--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -85,8 +85,7 @@ class GameManager:
         self.current_stage = 1
         self.score = 0
         self._state_timer = 0.0
-        if hasattr(self, "player_tank"):
-            del self.player_tank
+        self.player_tank = None
         self._load_stage()
 
     @property
@@ -103,9 +102,9 @@ class GameManager:
         logger.info(f"Loading stage {self.current_stage}...")
 
         # Preserve player progress across stages
-        player_lives = self.player_tank.lives if hasattr(self, "player_tank") else 3
+        player_lives = self.player_tank.lives if self.player_tank is not None else 3
         player_star_level = (
-            self.player_tank.star_level if hasattr(self, "player_tank") else 0
+            self.player_tank.star_level if self.player_tank is not None else 0
         )
 
         self.collision_manager = CollisionManager()

--- a/src/managers/spawn_manager.py
+++ b/src/managers/spawn_manager.py
@@ -209,12 +209,12 @@ class SpawnManager:
         # Materialize tanks whose spawn animation is done
         still_pending = []
         for pending in self._pending_spawns:
-            if not pending.effect.active:
-                self._materialize_enemy(
-                    pending.x, pending.y, pending.tank_type, pending.is_carrier
-                )
-            else:
+            if pending.effect.active:
                 still_pending.append(pending)
+                continue
+            self._materialize_enemy(
+                pending.x, pending.y, pending.tank_type, pending.is_carrier
+            )
         self._pending_spawns = still_pending
 
         self.spawn_timer += dt


### PR DESCRIPTION
## Summary
- Flatten nested `if`/`else` blocks in collision handling, brick damage, tile drawing, spawn processing, and game manager using guard clauses, short-circuit `and`, and `continue` statements
- Replace fragile `hasattr` checks with explicit `None` initialization and `is not None` comparisons
- Reduce nesting depth by 1-2 levels across 5 files with no behavioral changes

## Test plan
- [x] All 435 tests pass
- [x] Ruff linter passes on all modified files
- [ ] Manual smoke test: play through a level to verify collision, brick destruction, spawning, and power-ups work correctly