### PR TITLE
Fix gameplay bugs: input reset, bush overlay, HUD timer, respawn

### DIFF
--- a/src/core/map.py
+++ b/src/core/map.py
@@ -359,6 +359,20 @@ class Map:
             )
         self._tile_cache_dirty = True
 
+    def _remove_from_render_lists(self, tile: Tile) -> None:
+        """Remove a tile from drawable and overlay lists."""
+        if tile in self._drawable_tiles:
+            self._drawable_tiles.remove(tile)
+        if tile in self._overlay_tiles:
+            self._overlay_tiles.remove(tile)
+
+    def _add_to_render_list(self, tile: Tile) -> None:
+        """Add a tile to the appropriate render list based on its type."""
+        if tile.type == TileType.BUSH:
+            self._overlay_tiles.append(tile)
+        elif tile.type != TileType.EMPTY:
+            self._drawable_tiles.append(tile)
+
     def set_tile_type(self, tile: Tile, new_type: TileType) -> None:
         """Change a tile's type, update collision flags, and invalidate caches."""
         old_type = tile.type
@@ -368,11 +382,9 @@ class Map:
         tile.blocks_tanks = bt
         tile.blocks_bullets = bb
         self._tile_cache_dirty = True
-        if old_type == TileType.EMPTY and new_type != TileType.EMPTY:
-            self._drawable_tiles.append(tile)
-        elif old_type != TileType.EMPTY and new_type == TileType.EMPTY:
-            if tile in self._drawable_tiles:
-                self._drawable_tiles.remove(tile)
+        if old_type != new_type:
+            self._remove_from_render_lists(tile)
+            self._add_to_render_list(tile)
 
     def destroy_base(self) -> None:
         """Destroy all BASE tiles on the map."""
@@ -382,14 +394,10 @@ class Map:
     def place_tile(self, x: int, y: int, tile: Tile) -> None:
         """Place a tile at grid coordinates and invalidate caches."""
         old_tile = self.tiles[y][x]
-        if old_tile and old_tile.type != TileType.EMPTY:
-            try:
-                self._drawable_tiles.remove(old_tile)
-            except ValueError:
-                pass
+        if old_tile:
+            self._remove_from_render_lists(old_tile)
         self.tiles[y][x] = tile
-        if tile.type != TileType.EMPTY:
-            self._drawable_tiles.append(tile)
+        self._add_to_render_list(tile)
         self._tile_cache_dirty = True
 
     def _rebuild_tile_caches(self) -> None:

--- a/src/core/map.py
+++ b/src/core/map.py
@@ -238,14 +238,17 @@ class Map:
         return composition
 
     def _build_derived_tile_lists(self) -> None:
-        """Build the lists of animated and drawable (non-empty) tiles."""
+        """Build the lists of animated, drawable, and overlay tiles."""
         self._animated_tiles = []
         self._drawable_tiles = []
+        self._overlay_tiles = []
         for row in self.tiles:
             for tile in row:
                 if not tile:
                     continue
-                if tile.type != TileType.EMPTY:
+                if tile.type == TileType.BUSH:
+                    self._overlay_tiles.append(tile)
+                elif tile.type != TileType.EMPTY:
                     self._drawable_tiles.append(tile)
                 if tile.is_animated:
                     self._animated_tiles.append(tile)
@@ -270,8 +273,13 @@ class Map:
             tile.update(dt)
 
     def draw(self, surface: pygame.Surface) -> None:
-        """Draw non-empty tiles on the given surface."""
+        """Draw non-empty, non-overlay tiles on the given surface."""
         for tile in self._drawable_tiles:
+            tile.draw(surface, self.texture_manager)
+
+    def draw_overlay(self, surface: pygame.Surface) -> None:
+        """Draw overlay tiles (bushes) on top of tanks and bullets."""
+        for tile in self._overlay_tiles:
             tile.draw(surface, self.texture_manager)
 
     def get_tile_at(self, x: int, y: int) -> Optional[Tile]:

--- a/src/core/player_tank.py
+++ b/src/core/player_tank.py
@@ -39,6 +39,8 @@ class PlayerTank(Tank):
             map_width_px: Map width in pixels (for boundary clamping)
             map_height_px: Map height in pixels (for boundary clamping)
         """
+        # Store spawn position before Tank.__init__ snaps to grid
+        self.initial_position = (float(x), float(y))
         super().__init__(
             x,
             y,
@@ -51,7 +53,6 @@ class PlayerTank(Tank):
             map_width_px=map_width_px,
             map_height_px=map_height_px,
         )
-        self.initial_position = (self.x, self.y)
         self.star_level: int = 0
         self._update_sprite()
         self._shield_frames: list[pygame.Surface] = [

--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -108,6 +108,8 @@ class GameManager:
         """Load/reload a stage. Preserves score, current_stage, and player progress."""
         logger.info(f"Loading stage {self.current_stage}...")
 
+        self.input_handler.reset()
+
         # Preserve player progress across stages
         player_lives = self.player_tank.lives if self.player_tank is not None else 3
         player_star_level = (

--- a/src/managers/input_handler.py
+++ b/src/managers/input_handler.py
@@ -62,6 +62,12 @@ class InputHandler:
                 dy += ddy
         return (dx, dy)
 
+    def reset(self) -> None:
+        """Reset all input state. Called between stages."""
+        for direction in self.directions:
+            self.directions[direction] = False
+        self.shoot_pressed = False
+
     def consume_shoot(self) -> bool:
         """
         Check if shoot was pressed and reset the flag.

--- a/src/managers/renderer.py
+++ b/src/managers/renderer.py
@@ -1,7 +1,7 @@
 import pygame
 from typing import List, Optional, Sequence, Tuple
 from src.states.game_state import GameState
-from src.utils.constants import WHITE, YELLOW, BLACK, RED, GREEN, GRAY
+from src.utils.constants import WHITE, BLACK, RED, GREEN, GRAY
 from src.utils.paths import resource_path
 
 
@@ -84,24 +84,21 @@ class Renderer:
         # Clear the map area with black background
         self.map_surface.fill(self.background_color)
 
-        # Draw the map onto the map surface
+        # Draw ground tiles (everything except bushes)
         game_map.draw(self.map_surface)
 
-        # Draw the player tank onto the map surface
+        # Draw game objects (tanks pass under bushes)
         player_tank.draw(self.map_surface)
-
-        # Draw enemy tanks onto the map surface
         for enemy in enemy_tanks:
             enemy.draw(self.map_surface)
-
-        # Draw power-ups
         for power_up in power_ups:
             power_up.draw(self.map_surface)
-
-        # Draw all bullets
         for bullet in bullets:
             if bullet.active:
                 bullet.draw(self.map_surface)
+
+        # Draw bush overlay on top of tanks/bullets
+        game_map.draw_overlay(self.map_surface)
 
         effect_manager.draw(self.map_surface)
 
@@ -137,28 +134,15 @@ class Renderer:
         """Draw the heads-up display.
 
         Args:
-            player_tank: The player's tank (used for lives and invincibility).
+            player_tank: The player's tank (used for lives).
             score: Current player score.
         """
-        # Draw lives in the top border area
         lives_text = self.small_font.render(f"Lives: {player_tank.lives}", True, WHITE)
         self.game_surface.blit(lives_text, (10, 10))
 
-        # Draw score
         score_text = self.small_font.render(f"Score: {score:>6}", True, WHITE)
         score_rect = score_text.get_rect(topright=(self.logical_width - 10, 10))
         self.game_surface.blit(score_text, score_rect)
-
-        # Draw invincibility timer if active
-        if player_tank.is_invincible:
-            remaining_time = max(
-                0,
-                player_tank.invincibility_duration - player_tank.invincibility_timer,
-            )
-            invincible_text = self.small_font.render(
-                f"Invincible: {remaining_time:.1f}s", True, YELLOW
-            )
-            self.game_surface.blit(invincible_text, (10, 30))
 
     def _draw_game_over_rising(self, progress: float) -> None:
         """Draw 'GAME OVER' text rising from bottom to center.

--- a/tests/unit/core/test_player_tank.py
+++ b/tests/unit/core/test_player_tank.py
@@ -34,7 +34,7 @@ class TestPlayerTank:
         """Test PlayerTank initialization aligns to grid and sets correct defaults."""
         assert player_tank.x == 0
         assert player_tank.y == 0
-        assert player_tank.initial_position == (0, 0)
+        assert player_tank.initial_position == (5.0, 12.0)
         assert player_tank.lives == 3
         assert player_tank.health == 1
         assert not player_tank.is_invincible

--- a/tests/unit/managers/test_renderer.py
+++ b/tests/unit/managers/test_renderer.py
@@ -175,8 +175,8 @@ class TestRendererRender:
 class TestRendererHUD:
     """Tests for HUD and overlay rendering."""
 
-    def test_hud_shows_invincibility_timer(self, renderer):
-        """Test that HUD renders invincibility text when player is invincible."""
+    def test_hud_does_not_show_invincibility_timer(self, renderer):
+        """Test that HUD does not render invincibility text."""
         mock_map = MagicMock()
         mock_player = MagicMock()
         mock_player.lives = 3
@@ -192,8 +192,8 @@ class TestRendererHUD:
             mock_em = MagicMock()
             renderer.render(mock_map, mock_player, [], [], mock_em, GameState.RUNNING)
 
-        # small_font.render: lives + score + invincibility
-        assert renderer.small_font.render.call_count == 3
+        # small_font.render: lives + score only (no invincibility)
+        assert renderer.small_font.render.call_count == 2
 
     def test_overlay_screen_renders_title_and_subtitle(self, renderer):
         """Test that _draw_overlay_screen blits overlay, title, and subtitle."""


### PR DESCRIPTION
## Summary

- Reset input handler between stages so player tank doesn't move on its own at stage start
- Draw bush tiles as overlay on top of tanks/bullets (matching original NES behavior)
- Remove debug invincibility timer from HUD
- Store raw spawn coordinates for reliable respawn position
- Handle overlay tiles correctly in `set_tile_type()` and `place_tile()`

Fixes #114, fixes #115, fixes #116, fixes #117

## Test plan

- [ ] 555 tests pass (`uv run pytest`)
- [ ] Zero lint errors (`uv run ruff check src/ tests/`)
- [ ] Game runs, player tank is static at stage start
- [ ] Tanks pass under bush tiles
- [ ] No invincibility timer text in HUD
- [ ] Player respawns at correct spawn point after being hit