### PR TITLE
Add options menu with volume control and pause system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,6 @@ cython_debug/
 
 # Superpowers docs
 docs/superpowers/
+
+# Game settings (user-specific)
+settings.json

--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -261,7 +261,11 @@ class GameManager:
                 self.input_handler.handle_event(event)
 
     def _handle_escape(self) -> None:
-        """Handle ESC key based on current state."""
+        """Handle ESC key based on current state.
+
+        Only acts during RUNNING, PAUSED, and OPTIONS_MENU.
+        Ignored during animations, game over, and title screen.
+        """
         if self.state == GameState.RUNNING:
             logger.info("Game paused.")
             self.sound_manager.stop_loops()

--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -41,13 +41,14 @@ from src.managers.spawn_manager import SpawnManager
 from src.managers.renderer import Renderer
 from src.managers.power_up_manager import PowerUpManager
 from src.managers.sound_manager import SoundManager
+from src.managers.settings_manager import SettingsManager
 from src.utils.paths import resource_path
 
 
 class GameManager:
     """Manages the core game loop and window."""
 
-    _SELECTABLE_MENU_INDICES = (0, 2)  # Skip disabled "2 PLAYERS" at index 1
+    _SELECTABLE_MENU_INDICES = (0, 2, 3, 4)  # Skip disabled "2 PLAYERS" at index 1
 
     def __init__(self) -> None:
         """Initialize the game window and persistent resources."""
@@ -66,10 +67,16 @@ class GameManager:
         self.clock: pygame.time.Clock = pygame.time.Clock()
         self.fps: int = FPS
         self.input_handler: InputHandler = InputHandler()
-        self.sound_manager: SoundManager = SoundManager()
+        self.settings_manager: SettingsManager = SettingsManager()
+        self.sound_manager: SoundManager = SoundManager(
+            master_volume=self.settings_manager.master_volume
+        )
 
         self.state: GameState = GameState.TITLE_SCREEN
-        self._menu_selection: int = 0  # 0 = 1 Player, 1 = 2 Players
+        self._title_selection: int = 0
+        self._pause_selection: int = 0
+        self._options_selection: int = 0
+        self._options_from_pause: bool = False
         self._state_timer: float = 0.0
         self._demo_mode: bool = False
 
@@ -234,49 +241,132 @@ class GameManager:
                 self._quit_game()
             elif event.type == pygame.KEYDOWN:
                 if event.key == pygame.K_ESCAPE:
-                    logger.info("Escape key pressed, quitting game.")
-                    self._quit_game()
+                    self._handle_escape()
                 elif self.state == GameState.TITLE_SCREEN:
                     self._handle_title_input(event.key)
+                elif self.state == GameState.PAUSED:
+                    self._handle_pause_input(event.key)
+                elif self.state == GameState.OPTIONS_MENU:
+                    self._handle_options_input(event.key)
                 elif event.key == pygame.K_r and self.state in (
                     GameState.GAME_OVER,
                     GameState.GAME_COMPLETE,
                 ):
                     logger.info("R key pressed, returning to title screen.")
                     self.state = GameState.TITLE_SCREEN
-                    self._menu_selection = 0
+                    self._title_selection = 0
 
             # Pass events to input handler only if game is running
             if self.state == GameState.RUNNING:
                 self.input_handler.handle_event(event)
 
+    def _handle_escape(self) -> None:
+        """Handle ESC key based on current state."""
+        if self.state == GameState.RUNNING:
+            logger.info("Game paused.")
+            self.sound_manager.stop_loops()
+            self._pause_selection = 0
+            self.state = GameState.PAUSED
+        elif self.state == GameState.PAUSED:
+            logger.info("Game resumed.")
+            self.state = GameState.RUNNING
+        elif self.state == GameState.OPTIONS_MENU:
+            self.settings_manager.save()
+            if self._options_from_pause:
+                self.state = GameState.PAUSED
+            else:
+                self.state = GameState.TITLE_SCREEN
+
     def _handle_title_input(self, key: int) -> None:
         """Handle keyboard input on the title screen."""
         if key in (pygame.K_UP, pygame.K_DOWN):
             indices = self._SELECTABLE_MENU_INDICES
-            if self._menu_selection in indices:
-                pos = indices.index(self._menu_selection)
+            if self._title_selection in indices:
+                pos = indices.index(self._title_selection)
             else:
                 pos = 0
             if key == pygame.K_UP:
                 pos = (pos - 1) % len(indices)
             else:
                 pos = (pos + 1) % len(indices)
-            self._menu_selection = indices[pos]
+            self._title_selection = indices[pos]
             self.sound_manager.play_menu_select()
         elif key == pygame.K_RETURN:
-            if self._menu_selection in (0, 2):
-                self._demo_mode = self._menu_selection == 2
+            if self._title_selection in (0, 3):
+                self._demo_mode = self._title_selection == 3
                 label = "Demo" if self._demo_mode else "1 Player"
                 logger.info(f"{label} selected, starting game.")
                 self._new_game()
                 self.state = GameState.STAGE_CURTAIN_CLOSE
                 self._state_timer = 0.0
                 self.sound_manager.play_stage_start()
+            elif self._title_selection == 2:
+                self._options_from_pause = False
+                self._options_selection = 0
+                self.state = GameState.OPTIONS_MENU
+            elif self._title_selection == 4:
+                self._quit_game()
+
+    def _handle_pause_input(self, key: int) -> None:
+        """Handle keyboard input on the pause menu."""
+        if key in (pygame.K_UP, pygame.K_DOWN):
+            if key == pygame.K_UP:
+                self._pause_selection = (self._pause_selection - 1) % 4
+            else:
+                self._pause_selection = (self._pause_selection + 1) % 4
+            self.sound_manager.play_menu_select()
+        elif key == pygame.K_RETURN:
+            if self._pause_selection == 0:
+                # RESUME
+                self.state = GameState.RUNNING
+            elif self._pause_selection == 1:
+                # OPTIONS
+                self._options_from_pause = True
+                self._options_selection = 0
+                self.state = GameState.OPTIONS_MENU
+            elif self._pause_selection == 2:
+                # TITLE SCREEN
+                self.sound_manager.stop_loops()
+                self._title_selection = 0
+                self.state = GameState.TITLE_SCREEN
+            elif self._pause_selection == 3:
+                # QUIT
+                self._quit_game()
+
+    def _handle_options_input(self, key: int) -> None:
+        """Handle keyboard input on the options menu."""
+        if key in (pygame.K_UP, pygame.K_DOWN):
+            if key == pygame.K_UP:
+                self._options_selection = (self._options_selection - 1) % 2
+            else:
+                self._options_selection = (self._options_selection + 1) % 2
+            self.sound_manager.play_menu_select()
+        elif key == pygame.K_LEFT and self._options_selection == 0:
+            self.settings_manager.master_volume = max(
+                0.0, self.settings_manager.master_volume - 0.1
+            )
+            self.sound_manager.set_master_volume(self.settings_manager.master_volume)
+            self.sound_manager.play_menu_select()
+        elif key == pygame.K_RIGHT and self._options_selection == 0:
+            self.settings_manager.master_volume = min(
+                1.0, self.settings_manager.master_volume + 0.1
+            )
+            self.sound_manager.set_master_volume(self.settings_manager.master_volume)
+            self.sound_manager.play_menu_select()
+        elif key == pygame.K_RETURN:
+            if self._options_selection == 1:
+                self.settings_manager.save()
+                if self._options_from_pause:
+                    self.state = GameState.PAUSED
+                else:
+                    self.state = GameState.TITLE_SCREEN
 
     def update(self) -> None:
         """Update game state."""
         dt: float = 1.0 / self.fps
+
+        if self.state in (GameState.PAUSED, GameState.OPTIONS_MENU):
+            return
 
         if self.state == GameState.VICTORY:
             self._state_timer += dt
@@ -567,7 +657,7 @@ class GameManager:
     def render(self) -> None:
         """Render the game state."""
         if self.state == GameState.TITLE_SCREEN:
-            self.renderer.render_title_screen(self._menu_selection)
+            self.renderer.render_title_screen(self._title_selection)
             return
 
         if self.state in (
@@ -575,6 +665,16 @@ class GameManager:
             GameState.STAGE_CURTAIN_OPEN,
         ):
             self.renderer.render_curtain(self._curtain_progress, self.current_stage)
+            return
+
+        if self.state == GameState.OPTIONS_MENU:
+            self.renderer.render_options_menu(
+                self.settings_manager.master_volume, self._options_selection
+            )
+            return
+
+        if self.state == GameState.PAUSED:
+            self.renderer.render_pause_menu(self._pause_selection)
             return
 
         game_over_rise_progress = None

--- a/src/managers/renderer.py
+++ b/src/managers/renderer.py
@@ -228,7 +228,7 @@ class Renderer:
         """Render the title screen with menu options.
 
         Args:
-            menu_selection: Currently selected menu item (0, 1, or 2).
+            menu_selection: Currently selected menu item (0-4).
         """
         self.game_surface.fill(BLACK)
 
@@ -241,8 +241,8 @@ class Renderer:
         self.game_surface.blit(title, title_rect)
 
         # Menu options
-        options = ["1 PLAYER", "2 PLAYERS", "DEMO"]
-        colors = [WHITE, GRAY, WHITE]  # 2 Players is greyed out (disabled)
+        options = ["1 PLAYER", "2 PLAYERS", "OPTIONS", "DEMO", "QUIT"]
+        colors = [WHITE, GRAY, WHITE, WHITE, WHITE]
         for i, (label, color) in enumerate(zip(options, colors)):
             text = self.small_font.render(label, True, color)
             text_rect = text.get_rect(center=(cx, cy + i * 30))
@@ -252,6 +252,76 @@ class Renderer:
         cursor_y = cy + menu_selection * 30
         cursor_text = self.small_font.render(">", True, WHITE)
         cursor_rect = cursor_text.get_rect(midright=(cx - 60, cursor_y))
+        self.game_surface.blit(cursor_text, cursor_rect)
+
+        self._present_surface()
+
+    def render_pause_menu(self, menu_selection: int) -> None:
+        """Render pause menu overlay on top of frozen game frame.
+
+        Does NOT clear the game surface — draws on top of the
+        last rendered game frame to show the paused game behind.
+        """
+        overlay = pygame.Surface(
+            (self.logical_width, self.logical_height), pygame.SRCALPHA
+        )
+        overlay.fill((0, 0, 0, 160))
+        self.game_surface.blit(overlay, (0, 0))
+
+        cx = self.logical_width // 2
+        cy = self.logical_height // 2
+
+        title = self.font.render("PAUSED", True, WHITE)
+        title_rect = title.get_rect(center=(cx, cy - 60))
+        self.game_surface.blit(title, title_rect)
+
+        options = ["RESUME", "OPTIONS", "TITLE SCREEN", "QUIT"]
+        for i, label in enumerate(options):
+            text = self.small_font.render(label, True, WHITE)
+            text_rect = text.get_rect(center=(cx, cy + i * 30))
+            self.game_surface.blit(text, text_rect)
+
+        cursor_y = cy + menu_selection * 30
+        cursor_text = self.small_font.render(">", True, WHITE)
+        cursor_rect = cursor_text.get_rect(midright=(cx - 80, cursor_y))
+        self.game_surface.blit(cursor_text, cursor_rect)
+
+        self._present_surface()
+
+    def render_options_menu(self, master_volume: float, selection: int) -> None:
+        """Render options menu with volume slider."""
+        self.game_surface.fill(BLACK)
+
+        cx = self.logical_width // 2
+        cy = self.logical_height // 2
+
+        title = self.font.render("OPTIONS", True, WHITE)
+        title_rect = title.get_rect(center=(cx, cy - 60))
+        self.game_surface.blit(title, title_rect)
+
+        filled = round(master_volume * 10)
+        bar = "#" * filled + "-" * (10 - filled)
+        pct = f"{round(master_volume * 100)}%"
+        vol_label = f"VOLUME  [{bar}] {pct}"
+        vol_text = self.small_font.render(vol_label, True, WHITE)
+        vol_rect = vol_text.get_rect(center=(cx, cy))
+        self.game_surface.blit(vol_text, vol_rect)
+
+        # LEFT/RIGHT hints when volume is selected
+        if selection == 0:
+            left_hint = self.small_font.render("<", True, GRAY)
+            self.game_surface.blit(left_hint, (vol_rect.left - 20, cy - 6))
+            right_hint = self.small_font.render(">", True, GRAY)
+            self.game_surface.blit(right_hint, (vol_rect.right + 8, cy - 6))
+
+        back_text = self.small_font.render("BACK", True, WHITE)
+        back_rect = back_text.get_rect(center=(cx, cy + 40))
+        self.game_surface.blit(back_text, back_rect)
+
+        cursor_y = cy if selection == 0 else cy + 40
+        target_rect = vol_rect if selection == 0 else back_rect
+        cursor_text = self.small_font.render(">", True, WHITE)
+        cursor_rect = cursor_text.get_rect(midright=(target_rect.left - 10, cursor_y))
         self.game_surface.blit(cursor_text, cursor_rect)
 
         self._present_surface()

--- a/src/managers/settings_manager.py
+++ b/src/managers/settings_manager.py
@@ -29,7 +29,7 @@ class SettingsManager:
 
     def save(self) -> None:
         """Save current settings to file."""
-        data = {"master_volume": self.master_volume}
+        data = {"master_volume": round(self.master_volume, 1)}
         with open(self._path, "w") as f:
             json.dump(data, f, indent=2)
         logger.debug(f"Settings saved to {self._path}")

--- a/src/managers/settings_manager.py
+++ b/src/managers/settings_manager.py
@@ -1,0 +1,35 @@
+"""Manages persistent game settings."""
+
+import json
+
+from loguru import logger
+
+
+class SettingsManager:
+    """Loads and saves game settings to a JSON file."""
+
+    def __init__(self, path: str = "settings.json") -> None:
+        self.master_volume: float = 1.0
+        self._path = path
+        self._load()
+
+    def _load(self) -> None:
+        """Load settings from file. Use defaults on error."""
+        try:
+            with open(self._path) as f:
+                data = json.load(f)
+            self.master_volume = max(
+                0.0, min(1.0, float(data.get("master_volume", 1.0)))
+            )
+        except (FileNotFoundError, json.JSONDecodeError, ValueError, TypeError):
+            logger.warning(
+                f"Could not load settings from {self._path}; using defaults."
+            )
+            self.master_volume = 1.0
+
+    def save(self) -> None:
+        """Save current settings to file."""
+        data = {"master_volume": self.master_volume}
+        with open(self._path, "w") as f:
+            json.dump(data, f, indent=2)
+        logger.debug(f"Settings saved to {self._path}")

--- a/src/managers/sound_manager.py
+++ b/src/managers/sound_manager.py
@@ -24,10 +24,11 @@ class SoundManager:
         "powerup_spawn": "assets/sounds/powerup_spawn.wav",
     }
 
-    def __init__(self) -> None:
+    def __init__(self, master_volume: float = 1.0) -> None:
         self._enabled: bool = False
         self._sounds: dict[str, pygame.mixer.Sound] = {}
         self._looping_channels: dict[str, pygame.mixer.Channel] = {}
+        self._master_volume: float = 1.0
 
         try:
             pygame.mixer.init()
@@ -47,6 +48,16 @@ class SoundManager:
         n_loaded = len(self._sounds)
         n_total = len(self._SOUND_FILES)
         logger.info(f"SoundManager loaded {n_loaded}/{n_total} sounds.")
+
+        self.set_master_volume(master_volume)
+
+    def set_master_volume(self, volume: float) -> None:
+        """Set master volume for all sounds, clamped to 0.0-1.0."""
+        self._master_volume = max(0.0, min(1.0, volume))
+        for sound in self._sounds.values():
+            sound.set_volume(self._master_volume)
+        for channel in self._looping_channels.values():
+            channel.set_volume(self._master_volume)
 
     def _play(self, name: str) -> None:
         """Play a named sound if enabled and loaded."""
@@ -110,6 +121,7 @@ class SoundManager:
         channel = pygame.mixer.find_channel()
         if channel is not None:
             channel.play(sound, loops=-1)
+            channel.set_volume(self._master_volume)
             self._looping_channels[name] = channel
 
     def _stop_loop(self, name: str) -> None:

--- a/src/states/game_state.py
+++ b/src/states/game_state.py
@@ -13,3 +13,5 @@ class GameState(Enum):
     STAGE_CURTAIN_OPEN = 6
     GAME_OVER_ANIMATION = 7
     GAME_COMPLETE = 8
+    PAUSED = 9
+    OPTIONS_MENU = 10

--- a/tests/unit/managers/test_game_manager.py
+++ b/tests/unit/managers/test_game_manager.py
@@ -21,9 +21,12 @@ class TestGameManager:
             patch("src.managers.game_manager.Renderer"),
             patch("src.managers.game_manager.SpawnManager"),
             patch("src.managers.game_manager.Map") as MockMap,
+            patch("src.managers.game_manager.SettingsManager") as MockSM,
         ):
             mock_tm_instance = MockTM.return_value
             mock_tm_instance.get_sprite.return_value = MagicMock(spec=pygame.Surface)
+            mock_sm_instance = MockSM.return_value
+            mock_sm_instance.master_volume = 1.0
             mock_map_instance = MockMap.return_value
             mock_map_instance.width = 16
             mock_map_instance.height = 16
@@ -51,25 +54,31 @@ class TestGameManager:
     def test_initialization_starts_at_title_screen(self, game_manager_at_title):
         """Test that GameManager starts at the title screen."""
         assert game_manager_at_title.state == GameState.TITLE_SCREEN
-        assert game_manager_at_title._menu_selection == 0
+        assert game_manager_at_title._title_selection == 0
 
     def test_title_screen_cursor_moves(self, game_manager_at_title, key_down_event):
-        """Test up/down keys cycle through selectable items (0 and 2, skipping 1)."""
+        """Test up/down keys cycle through selectable items (0, 2, 3, 4)."""
         gm = game_manager_at_title
-        assert gm._menu_selection == 0
+        assert gm._title_selection == 0
         pygame.event.post(key_down_event(pygame.K_DOWN))
         gm.handle_events()
-        assert gm._menu_selection == 2
+        assert gm._title_selection == 2
+        pygame.event.post(key_down_event(pygame.K_DOWN))
+        gm.handle_events()
+        assert gm._title_selection == 3
+        pygame.event.post(key_down_event(pygame.K_DOWN))
+        gm.handle_events()
+        assert gm._title_selection == 4
         pygame.event.post(key_down_event(pygame.K_UP))
         gm.handle_events()
-        assert gm._menu_selection == 0
+        assert gm._title_selection == 3
 
     def test_title_screen_enter_starts_game(
         self, game_manager_at_title, key_down_event
     ):
         """Test Enter on '1 PLAYER' begins the curtain-close transition."""
         gm = game_manager_at_title
-        gm._menu_selection = 0
+        gm._title_selection = 0
         pygame.event.post(key_down_event(pygame.K_RETURN))
         gm.handle_events()
         assert gm.state == GameState.STAGE_CURTAIN_CLOSE
@@ -79,7 +88,7 @@ class TestGameManager:
     ):
         """Test Enter on '2 PLAYERS' (disabled) does nothing."""
         gm = game_manager_at_title
-        gm._menu_selection = 1
+        gm._title_selection = 1
         pygame.event.post(key_down_event(pygame.K_RETURN))
         gm.handle_events()
         assert gm.state == GameState.TITLE_SCREEN
@@ -107,11 +116,16 @@ class TestGameManager:
         # Check if state is set to EXIT
         assert game_manager.state == GameState.EXIT
 
-    def test_handle_events_escape(self, game_manager, key_down_event):
-        """Test handling escape key event sets state to EXIT."""
+    def test_handle_events_escape_during_running_pauses(
+        self, game_manager, key_down_event
+    ):
+        """Test ESC during RUNNING pauses the game."""
+        game_manager.state = GameState.RUNNING
+        game_manager.sound_manager = MagicMock()
         pygame.event.post(key_down_event(pygame.K_ESCAPE))
         game_manager.handle_events()
-        assert game_manager.state == GameState.EXIT
+        assert game_manager.state == GameState.PAUSED
+        game_manager.sound_manager.stop_loops.assert_called_once()
 
     def test_handle_events_restart(self, game_manager, key_down_event):
         """Test pressing R on game over returns to title screen."""
@@ -173,9 +187,12 @@ class TestGameManagerSoundWiring:
             patch("src.managers.game_manager.Renderer"),
             patch("src.managers.game_manager.SpawnManager"),
             patch("src.managers.game_manager.Map") as MockMap,
+            patch("src.managers.game_manager.SettingsManager") as MockSM,
         ):
             mock_tm_instance = MockTM.return_value
             mock_tm_instance.get_sprite.return_value = MagicMock(spec=pygame.Surface)
+            mock_sm_instance = MockSM.return_value
+            mock_sm_instance.master_volume = 1.0
             mock_map_instance = MockMap.return_value
             mock_map_instance.width = 16
             mock_map_instance.height = 16
@@ -247,9 +264,12 @@ class TestStageProgression:
             patch("src.managers.game_manager.Renderer"),
             patch("src.managers.game_manager.SpawnManager"),
             patch("src.managers.game_manager.Map") as MockMap,
+            patch("src.managers.game_manager.SettingsManager") as MockSM,
         ):
             mock_tm_instance = MockTM.return_value
             mock_tm_instance.get_sprite.return_value = MagicMock(spec=pygame.Surface)
+            mock_sm_instance = MockSM.return_value
+            mock_sm_instance.master_volume = 1.0
             mock_map_instance = MockMap.return_value
             mock_map_instance.width = 16
             mock_map_instance.height = 16
@@ -313,3 +333,384 @@ class TestStageProgression:
         with patch("pygame.event.get", return_value=[event]):
             game_manager.handle_events()
         assert game_manager.state == GameState.TITLE_SCREEN
+        assert game_manager._title_selection == 0
+
+
+class TestPauseAndOptionsStateMachine:
+    """Tests for PAUSED and OPTIONS_MENU state transitions."""
+
+    @pytest.fixture
+    def _mock_game_deps(self):
+        with (
+            patch("pygame.display.set_mode"),
+            patch("pygame.font.SysFont"),
+            patch("src.managers.game_manager.TextureManager") as MockTM,
+            patch("src.managers.game_manager.EffectManager"),
+            patch("src.managers.game_manager.Renderer"),
+            patch("src.managers.game_manager.SpawnManager"),
+            patch("src.managers.game_manager.Map") as MockMap,
+            patch("src.managers.game_manager.SettingsManager") as MockSM,
+        ):
+            mock_tm_instance = MockTM.return_value
+            mock_tm_instance.get_sprite.return_value = MagicMock(spec=pygame.Surface)
+            mock_sm_instance = MockSM.return_value
+            mock_sm_instance.master_volume = 1.0
+            mock_map_instance = MockMap.return_value
+            mock_map_instance.width = 16
+            mock_map_instance.height = 16
+            mock_map_instance.player_spawn = (4, 12)
+            mock_map_instance.spawn_points = [(3, 1), (8, 1), (12, 1)]
+            yield
+
+    @pytest.fixture
+    def game_manager(self, _mock_game_deps):
+        pygame.init()
+        manager = GameManager()
+        manager._reset_game()
+        yield manager
+        pygame.quit()
+
+    @pytest.fixture
+    def game_manager_at_title(self, _mock_game_deps):
+        pygame.init()
+        manager = GameManager()
+        yield manager
+        pygame.quit()
+
+    # --- ESC state transitions ---
+
+    def test_esc_during_running_pauses(self, game_manager, key_down_event):
+        """ESC during RUNNING transitions to PAUSED."""
+        game_manager.state = GameState.RUNNING
+        game_manager.sound_manager = MagicMock()
+        pygame.event.post(key_down_event(pygame.K_ESCAPE))
+        game_manager.handle_events()
+        assert game_manager.state == GameState.PAUSED
+        assert game_manager._pause_selection == 0
+
+    def test_esc_during_paused_resumes(self, game_manager, key_down_event):
+        """ESC during PAUSED transitions back to RUNNING."""
+        game_manager.state = GameState.PAUSED
+        pygame.event.post(key_down_event(pygame.K_ESCAPE))
+        game_manager.handle_events()
+        assert game_manager.state == GameState.RUNNING
+
+    def test_esc_during_title_screen_does_nothing(
+        self, game_manager_at_title, key_down_event
+    ):
+        """ESC during TITLE_SCREEN does nothing."""
+        pygame.event.post(key_down_event(pygame.K_ESCAPE))
+        game_manager_at_title.handle_events()
+        assert game_manager_at_title.state == GameState.TITLE_SCREEN
+
+    def test_esc_during_options_from_title_returns_to_title(
+        self, game_manager_at_title, key_down_event
+    ):
+        """ESC during OPTIONS_MENU (from title) saves and returns to TITLE_SCREEN."""
+        gm = game_manager_at_title
+        gm.state = GameState.OPTIONS_MENU
+        gm._options_from_pause = False
+        gm.settings_manager = MagicMock()
+        pygame.event.post(key_down_event(pygame.K_ESCAPE))
+        gm.handle_events()
+        assert gm.state == GameState.TITLE_SCREEN
+        gm.settings_manager.save.assert_called_once()
+
+    def test_esc_during_options_from_pause_returns_to_paused(
+        self, game_manager, key_down_event
+    ):
+        """ESC during OPTIONS_MENU (from pause) saves and returns to PAUSED."""
+        gm = game_manager
+        gm.state = GameState.OPTIONS_MENU
+        gm._options_from_pause = True
+        gm.settings_manager = MagicMock()
+        pygame.event.post(key_down_event(pygame.K_ESCAPE))
+        gm.handle_events()
+        assert gm.state == GameState.PAUSED
+        gm.settings_manager.save.assert_called_once()
+
+    def test_esc_during_game_over_does_nothing(self, game_manager, key_down_event):
+        """ESC during GAME_OVER does nothing."""
+        game_manager.state = GameState.GAME_OVER
+        pygame.event.post(key_down_event(pygame.K_ESCAPE))
+        game_manager.handle_events()
+        assert game_manager.state == GameState.GAME_OVER
+
+    def test_esc_during_game_over_animation_does_nothing(
+        self, game_manager, key_down_event
+    ):
+        """ESC during GAME_OVER_ANIMATION does nothing."""
+        game_manager.state = GameState.GAME_OVER_ANIMATION
+        pygame.event.post(key_down_event(pygame.K_ESCAPE))
+        game_manager.handle_events()
+        assert game_manager.state == GameState.GAME_OVER_ANIMATION
+
+    def test_esc_during_game_complete_does_nothing(
+        self, game_manager, key_down_event
+    ):
+        """ESC during GAME_COMPLETE does nothing."""
+        game_manager.state = GameState.GAME_COMPLETE
+        pygame.event.post(key_down_event(pygame.K_ESCAPE))
+        game_manager.handle_events()
+        assert game_manager.state == GameState.GAME_COMPLETE
+
+    # --- Title screen options and quit ---
+
+    def test_title_options_transitions_to_options_menu(
+        self, game_manager_at_title, key_down_event
+    ):
+        """Enter on OPTIONS (index 2) on title screen goes to OPTIONS_MENU."""
+        gm = game_manager_at_title
+        gm._title_selection = 2
+        pygame.event.post(key_down_event(pygame.K_RETURN))
+        gm.handle_events()
+        assert gm.state == GameState.OPTIONS_MENU
+        assert gm._options_from_pause is False
+        assert gm._options_selection == 0
+
+    def test_title_demo_starts_game(self, game_manager_at_title, key_down_event):
+        """Enter on DEMO (index 3) on title screen starts demo mode."""
+        gm = game_manager_at_title
+        gm._title_selection = 3
+        pygame.event.post(key_down_event(pygame.K_RETURN))
+        gm.handle_events()
+        assert gm.state == GameState.STAGE_CURTAIN_CLOSE
+        assert gm._demo_mode is True
+
+    def test_title_quit_exits(self, game_manager_at_title, key_down_event):
+        """Enter on QUIT (index 4) on title screen exits the game."""
+        gm = game_manager_at_title
+        gm._title_selection = 4
+        gm.sound_manager = MagicMock()
+        pygame.event.post(key_down_event(pygame.K_RETURN))
+        gm.handle_events()
+        assert gm.state == GameState.EXIT
+
+    # --- Pause menu navigation ---
+
+    def test_pause_resume(self, game_manager, key_down_event):
+        """Enter on RESUME (0) in pause menu returns to RUNNING."""
+        gm = game_manager
+        gm.state = GameState.PAUSED
+        gm._pause_selection = 0
+        pygame.event.post(key_down_event(pygame.K_RETURN))
+        gm.handle_events()
+        assert gm.state == GameState.RUNNING
+
+    def test_pause_options(self, game_manager, key_down_event):
+        """Enter on OPTIONS (1) in pause menu goes to OPTIONS_MENU."""
+        gm = game_manager
+        gm.state = GameState.PAUSED
+        gm._pause_selection = 1
+        gm.sound_manager = MagicMock()
+        pygame.event.post(key_down_event(pygame.K_RETURN))
+        gm.handle_events()
+        assert gm.state == GameState.OPTIONS_MENU
+        assert gm._options_from_pause is True
+        assert gm._options_selection == 0
+
+    def test_pause_title_screen(self, game_manager, key_down_event):
+        """Enter on TITLE SCREEN (2) in pause menu returns to title."""
+        gm = game_manager
+        gm.state = GameState.PAUSED
+        gm._pause_selection = 2
+        gm.sound_manager = MagicMock()
+        pygame.event.post(key_down_event(pygame.K_RETURN))
+        gm.handle_events()
+        assert gm.state == GameState.TITLE_SCREEN
+        assert gm._title_selection == 0
+        gm.sound_manager.stop_loops.assert_called_once()
+
+    def test_pause_quit(self, game_manager, key_down_event):
+        """Enter on QUIT (3) in pause menu exits the game."""
+        gm = game_manager
+        gm.state = GameState.PAUSED
+        gm._pause_selection = 3
+        gm.sound_manager = MagicMock()
+        pygame.event.post(key_down_event(pygame.K_RETURN))
+        gm.handle_events()
+        assert gm.state == GameState.EXIT
+
+    def test_pause_navigation_up_down(self, game_manager, key_down_event):
+        """UP/DOWN navigation wraps through 4 pause items."""
+        gm = game_manager
+        gm.state = GameState.PAUSED
+        gm._pause_selection = 0
+        gm.sound_manager = MagicMock()
+        # Down from 0 -> 1
+        pygame.event.post(key_down_event(pygame.K_DOWN))
+        gm.handle_events()
+        assert gm._pause_selection == 1
+        # Down from 1 -> 2
+        pygame.event.post(key_down_event(pygame.K_DOWN))
+        gm.handle_events()
+        assert gm._pause_selection == 2
+        # Down from 2 -> 3
+        pygame.event.post(key_down_event(pygame.K_DOWN))
+        gm.handle_events()
+        assert gm._pause_selection == 3
+        # Down from 3 -> 0 (wrap)
+        pygame.event.post(key_down_event(pygame.K_DOWN))
+        gm.handle_events()
+        assert gm._pause_selection == 0
+        # Up from 0 -> 3 (wrap)
+        pygame.event.post(key_down_event(pygame.K_UP))
+        gm.handle_events()
+        assert gm._pause_selection == 3
+
+    def test_pause_plays_menu_select_on_navigation(
+        self, game_manager, key_down_event
+    ):
+        """Navigating pause menu plays menu_select sound."""
+        gm = game_manager
+        gm.state = GameState.PAUSED
+        gm._pause_selection = 0
+        gm.sound_manager = MagicMock()
+        pygame.event.post(key_down_event(pygame.K_DOWN))
+        gm.handle_events()
+        gm.sound_manager.play_menu_select.assert_called()
+
+    # --- Options menu ---
+
+    def test_options_volume_left_decreases(self, game_manager, key_down_event):
+        """LEFT on VOLUME (0) in options decreases master volume."""
+        gm = game_manager
+        gm.state = GameState.OPTIONS_MENU
+        gm._options_selection = 0
+        gm.settings_manager = MagicMock()
+        gm.settings_manager.master_volume = 0.5
+        gm.sound_manager = MagicMock()
+        pygame.event.post(key_down_event(pygame.K_LEFT))
+        gm.handle_events()
+        assert gm.settings_manager.master_volume == pytest.approx(0.4, abs=0.01)
+        gm.sound_manager.set_master_volume.assert_called_once_with(
+            pytest.approx(0.4, abs=0.01)
+        )
+
+    def test_options_volume_right_increases(self, game_manager, key_down_event):
+        """RIGHT on VOLUME (0) in options increases master volume."""
+        gm = game_manager
+        gm.state = GameState.OPTIONS_MENU
+        gm._options_selection = 0
+        gm.settings_manager = MagicMock()
+        gm.settings_manager.master_volume = 0.5
+        gm.sound_manager = MagicMock()
+        pygame.event.post(key_down_event(pygame.K_RIGHT))
+        gm.handle_events()
+        assert gm.settings_manager.master_volume == pytest.approx(0.6, abs=0.01)
+        gm.sound_manager.set_master_volume.assert_called_once_with(
+            pytest.approx(0.6, abs=0.01)
+        )
+
+    def test_options_volume_clamps_at_zero(self, game_manager, key_down_event):
+        """Volume does not go below 0.0."""
+        gm = game_manager
+        gm.state = GameState.OPTIONS_MENU
+        gm._options_selection = 0
+        gm.settings_manager = MagicMock()
+        gm.settings_manager.master_volume = 0.0
+        gm.sound_manager = MagicMock()
+        pygame.event.post(key_down_event(pygame.K_LEFT))
+        gm.handle_events()
+        assert gm.settings_manager.master_volume == 0.0
+
+    def test_options_volume_clamps_at_one(self, game_manager, key_down_event):
+        """Volume does not go above 1.0."""
+        gm = game_manager
+        gm.state = GameState.OPTIONS_MENU
+        gm._options_selection = 0
+        gm.settings_manager = MagicMock()
+        gm.settings_manager.master_volume = 1.0
+        gm.sound_manager = MagicMock()
+        pygame.event.post(key_down_event(pygame.K_RIGHT))
+        gm.handle_events()
+        assert gm.settings_manager.master_volume == 1.0
+
+    def test_options_back_saves_and_returns_to_title(
+        self, game_manager, key_down_event
+    ):
+        """Enter on BACK (1) in options saves and returns to origin."""
+        gm = game_manager
+        gm.state = GameState.OPTIONS_MENU
+        gm._options_selection = 1
+        gm._options_from_pause = False
+        gm.settings_manager = MagicMock()
+        pygame.event.post(key_down_event(pygame.K_RETURN))
+        gm.handle_events()
+        assert gm.state == GameState.TITLE_SCREEN
+        gm.settings_manager.save.assert_called_once()
+
+    def test_options_back_saves_and_returns_to_pause(
+        self, game_manager, key_down_event
+    ):
+        """Enter on BACK (1) in options from pause saves and returns to PAUSED."""
+        gm = game_manager
+        gm.state = GameState.OPTIONS_MENU
+        gm._options_selection = 1
+        gm._options_from_pause = True
+        gm.settings_manager = MagicMock()
+        pygame.event.post(key_down_event(pygame.K_RETURN))
+        gm.handle_events()
+        assert gm.state == GameState.PAUSED
+        gm.settings_manager.save.assert_called_once()
+
+    def test_options_navigation_up_down(self, game_manager, key_down_event):
+        """UP/DOWN navigation wraps between 2 options items."""
+        gm = game_manager
+        gm.state = GameState.OPTIONS_MENU
+        gm._options_selection = 0
+        gm.sound_manager = MagicMock()
+        pygame.event.post(key_down_event(pygame.K_DOWN))
+        gm.handle_events()
+        assert gm._options_selection == 1
+        pygame.event.post(key_down_event(pygame.K_DOWN))
+        gm.handle_events()
+        assert gm._options_selection == 0
+
+    # --- Update early return for PAUSED/OPTIONS_MENU ---
+
+    def test_update_does_nothing_when_paused(self, game_manager):
+        """Update does not process game logic when PAUSED."""
+        gm = game_manager
+        gm.state = GameState.PAUSED
+        gm.player_tank.update = MagicMock()
+        gm.update()
+        gm.player_tank.update.assert_not_called()
+
+    def test_update_does_nothing_when_in_options(self, game_manager):
+        """Update does not process game logic when in OPTIONS_MENU."""
+        gm = game_manager
+        gm.state = GameState.OPTIONS_MENU
+        gm.player_tank.update = MagicMock()
+        gm.update()
+        gm.player_tank.update.assert_not_called()
+
+    # --- Render routing ---
+
+    def test_render_paused_calls_render_pause_menu(self, game_manager):
+        """PAUSED state renders pause menu overlay."""
+        gm = game_manager
+        gm.state = GameState.PAUSED
+        gm.renderer = MagicMock()
+        gm.render()
+        gm.renderer.render_pause_menu.assert_called_once_with(gm._pause_selection)
+
+    def test_render_options_calls_render_options_menu(self, game_manager):
+        """OPTIONS_MENU state renders options menu."""
+        gm = game_manager
+        gm.state = GameState.OPTIONS_MENU
+        gm.renderer = MagicMock()
+        gm.settings_manager = MagicMock()
+        gm.settings_manager.master_volume = 0.7
+        gm.render()
+        gm.renderer.render_options_menu.assert_called_once_with(
+            0.7, gm._options_selection
+        )
+
+    def test_render_title_uses_title_selection(self, game_manager_at_title):
+        """TITLE_SCREEN renders with _title_selection."""
+        gm = game_manager_at_title
+        gm.renderer = MagicMock()
+        gm._title_selection = 2
+        gm.render()
+        gm.renderer.render_title_screen.assert_called_once_with(2)

--- a/tests/unit/managers/test_game_manager.py
+++ b/tests/unit/managers/test_game_manager.py
@@ -454,6 +454,15 @@ class TestPauseAndOptionsStateMachine:
         game_manager.handle_events()
         assert game_manager.state == GameState.GAME_COMPLETE
 
+    def test_esc_during_victory_does_nothing(
+        self, game_manager, key_down_event
+    ):
+        """ESC during VICTORY does nothing."""
+        game_manager.state = GameState.VICTORY
+        pygame.event.post(key_down_event(pygame.K_ESCAPE))
+        game_manager.handle_events()
+        assert game_manager.state == GameState.VICTORY
+
     # --- Title screen options and quit ---
 
     def test_title_options_transitions_to_options_menu(

--- a/tests/unit/managers/test_game_manager_curtain.py
+++ b/tests/unit/managers/test_game_manager_curtain.py
@@ -109,16 +109,16 @@ class TestCurtainTransitions:
         game.handle_events()
         assert game.state == GameState.VICTORY
 
-    def test_escape_works_during_curtain(self, game):
+    def test_escape_does_nothing_during_curtain(self, game):
         game.state = GameState.STAGE_CURTAIN_CLOSE
         event = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_ESCAPE)
         pygame.event.post(event)
         game.handle_events()
-        assert game.state == GameState.EXIT
+        assert game.state == GameState.STAGE_CURTAIN_CLOSE
 
     def test_title_start_triggers_curtain(self, game):
         game.state = GameState.TITLE_SCREEN
-        game._menu_selection = 0
+        game._title_selection = 0
         event = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_RETURN)
         pygame.event.post(event)
         game.handle_events()

--- a/tests/unit/managers/test_renderer.py
+++ b/tests/unit/managers/test_renderer.py
@@ -247,3 +247,144 @@ class TestRenderCurtain:
         # font.render should be called at progress=1.0 but not at 0.0
         assert calls_at_closed > calls_at_open
         assert any("STAGE 3" in c for c in font_render_calls)
+
+
+class TestRenderPauseMenu:
+    """Tests for render_pause_menu."""
+
+    def test_overlay_surface_is_created_and_blitted(self, renderer):
+        """Pause menu creates a semi-transparent overlay and blits it."""
+        mock_overlay = MagicMock(spec=pygame.Surface)
+        with (
+            patch("pygame.Surface") as mock_surface_cls,
+            patch("pygame.transform.scale"),
+            patch("pygame.display.flip"),
+        ):
+            mock_surface_cls.return_value = mock_overlay
+            renderer.render_pause_menu(0)
+
+        # The overlay should be created with SRCALPHA and blitted
+        mock_surface_cls.assert_called_once_with(
+            (renderer.logical_width, renderer.logical_height), pygame.SRCALPHA
+        )
+        mock_overlay.fill.assert_called_once_with((0, 0, 0, 160))
+
+    def test_paused_title_is_rendered(self, renderer):
+        """Pause menu renders 'PAUSED' title."""
+        with (
+            patch("pygame.Surface"),
+            patch("pygame.transform.scale"),
+            patch("pygame.display.flip"),
+        ):
+            renderer.render_pause_menu(0)
+
+        render_calls = [call.args[0] for call in renderer.font.render.call_args_list]
+        assert "PAUSED" in render_calls
+
+    def test_four_menu_items_rendered(self, renderer):
+        """Pause menu renders RESUME, OPTIONS, TITLE SCREEN, QUIT."""
+        with (
+            patch("pygame.Surface"),
+            patch("pygame.transform.scale"),
+            patch("pygame.display.flip"),
+        ):
+            renderer.render_pause_menu(0)
+
+        render_calls = [
+            call.args[0] for call in renderer.small_font.render.call_args_list
+        ]
+        assert "RESUME" in render_calls
+        assert "OPTIONS" in render_calls
+        assert "TITLE SCREEN" in render_calls
+        assert "QUIT" in render_calls
+
+    def test_cursor_is_rendered(self, renderer):
+        """Pause menu renders '>' cursor."""
+        with (
+            patch("pygame.Surface"),
+            patch("pygame.transform.scale"),
+            patch("pygame.display.flip"),
+        ):
+            renderer.render_pause_menu(0)
+
+        render_calls = [
+            call.args[0] for call in renderer.small_font.render.call_args_list
+        ]
+        assert ">" in render_calls
+
+
+class TestRenderOptionsMenu:
+    """Tests for render_options_menu."""
+
+    def test_options_title_rendered(self, renderer):
+        """Options menu renders 'OPTIONS' title."""
+        with (
+            patch("pygame.transform.scale"),
+            patch("pygame.display.flip"),
+        ):
+            renderer.render_options_menu(0.8, 0)
+
+        render_calls = [call.args[0] for call in renderer.font.render.call_args_list]
+        assert "OPTIONS" in render_calls
+
+    def test_volume_bar_contains_volume_info(self, renderer):
+        """Options menu renders volume bar with percentage."""
+        with (
+            patch("pygame.transform.scale"),
+            patch("pygame.display.flip"),
+        ):
+            renderer.render_options_menu(0.8, 0)
+
+        render_calls = [
+            call.args[0] for call in renderer.small_font.render.call_args_list
+        ]
+        volume_calls = [c for c in render_calls if "VOLUME" in c]
+        assert len(volume_calls) == 1
+        assert "80%" in volume_calls[0]
+
+    def test_back_is_rendered(self, renderer):
+        """Options menu renders 'BACK' option."""
+        with (
+            patch("pygame.transform.scale"),
+            patch("pygame.display.flip"),
+        ):
+            renderer.render_options_menu(0.8, 0)
+
+        render_calls = [
+            call.args[0] for call in renderer.small_font.render.call_args_list
+        ]
+        assert "BACK" in render_calls
+
+    def test_cursor_rendered(self, renderer):
+        """Options menu renders '>' cursor."""
+        with (
+            patch("pygame.transform.scale"),
+            patch("pygame.display.flip"),
+        ):
+            renderer.render_options_menu(0.8, 0)
+
+        render_calls = [
+            call.args[0] for call in renderer.small_font.render.call_args_list
+        ]
+        assert ">" in render_calls
+
+
+class TestRenderTitleScreenUpdated:
+    """Tests for updated title screen with OPTIONS and QUIT."""
+
+    def test_five_menu_items_rendered(self, renderer):
+        """Title screen renders 1 PLAYER, 2 PLAYERS, OPTIONS, DEMO, QUIT."""
+        with (
+            patch("pygame.transform.scale"),
+            patch("pygame.display.flip"),
+        ):
+            renderer.render_title_screen(0)
+
+        render_calls = [
+            call.args[0] for call in renderer.small_font.render.call_args_list
+        ]
+        assert "1 PLAYER" in render_calls
+        assert "2 PLAYERS" in render_calls
+        assert "OPTIONS" in render_calls
+        assert "DEMO" in render_calls
+        assert "QUIT" in render_calls

--- a/tests/unit/managers/test_settings_manager.py
+++ b/tests/unit/managers/test_settings_manager.py
@@ -1,5 +1,4 @@
 import json
-import pytest
 from src.managers.settings_manager import SettingsManager
 
 

--- a/tests/unit/managers/test_settings_manager.py
+++ b/tests/unit/managers/test_settings_manager.py
@@ -1,0 +1,54 @@
+import json
+import pytest
+from src.managers.settings_manager import SettingsManager
+
+
+class TestSettingsManager:
+    def test_default_volume(self, tmp_path):
+        path = str(tmp_path / "settings.json")
+        sm = SettingsManager(path=path)
+        assert sm.master_volume == 1.0
+
+    def test_load_existing_settings(self, tmp_path):
+        path = str(tmp_path / "settings.json")
+        with open(path, "w") as f:
+            json.dump({"master_volume": 0.5}, f)
+        sm = SettingsManager(path=path)
+        assert sm.master_volume == 0.5
+
+    def test_save_creates_file(self, tmp_path):
+        path = str(tmp_path / "settings.json")
+        sm = SettingsManager(path=path)
+        sm.master_volume = 0.7
+        sm.save()
+        with open(path) as f:
+            data = json.load(f)
+        assert data["master_volume"] == 0.7
+
+    def test_corrupted_file_uses_defaults(self, tmp_path):
+        path = str(tmp_path / "settings.json")
+        with open(path, "w") as f:
+            f.write("not json!")
+        sm = SettingsManager(path=path)
+        assert sm.master_volume == 1.0
+
+    def test_volume_clamped_high(self, tmp_path):
+        path = str(tmp_path / "settings.json")
+        with open(path, "w") as f:
+            json.dump({"master_volume": 5.0}, f)
+        sm = SettingsManager(path=path)
+        assert sm.master_volume == 1.0
+
+    def test_volume_clamped_low(self, tmp_path):
+        path = str(tmp_path / "settings.json")
+        with open(path, "w") as f:
+            json.dump({"master_volume": -0.5}, f)
+        sm = SettingsManager(path=path)
+        assert sm.master_volume == 0.0
+
+    def test_missing_key_uses_default(self, tmp_path):
+        path = str(tmp_path / "settings.json")
+        with open(path, "w") as f:
+            json.dump({}, f)
+        sm = SettingsManager(path=path)
+        assert sm.master_volume == 1.0

--- a/tests/unit/managers/test_sound_manager.py
+++ b/tests/unit/managers/test_sound_manager.py
@@ -199,3 +199,63 @@ class TestUpdatePowerupBlink:
             sm.update_powerup_blink(True)
             sm.update_powerup_blink(False)
             assert "powerup_spawn" not in sm._looping_channels
+
+
+class TestMasterVolume:
+    def test_set_master_volume_stores_value(self):
+        with patch("src.managers.sound_manager.pygame") as mock_pg:
+            mock_pg.mixer.Sound.return_value = MagicMock()
+            sm = SoundManager()
+            sm.set_master_volume(0.5)
+            assert sm._master_volume == 0.5
+
+    def test_set_master_volume_applies_to_sounds(self):
+        with patch("src.managers.sound_manager.pygame") as mock_pg:
+            mock_sound = MagicMock()
+            mock_pg.mixer.Sound.return_value = mock_sound
+            sm = SoundManager()
+            sm.set_master_volume(0.3)
+            mock_sound.set_volume.assert_called_with(0.3)
+
+    def test_set_master_volume_applies_to_looping_channels(self):
+        with patch("src.managers.sound_manager.pygame") as mock_pg:
+            mock_sound = MagicMock()
+            mock_pg.mixer.Sound.return_value = mock_sound
+            mock_channel = MagicMock()
+            mock_pg.mixer.find_channel.return_value = mock_channel
+            sm = SoundManager()
+            sm._start_loop("engine")
+            sm.set_master_volume(0.4)
+            mock_channel.set_volume.assert_called_with(0.4)
+
+    def test_init_with_master_volume(self):
+        with patch("src.managers.sound_manager.pygame") as mock_pg:
+            mock_sound = MagicMock()
+            mock_pg.mixer.Sound.return_value = mock_sound
+            sm = SoundManager(master_volume=0.6)
+            assert sm._master_volume == 0.6
+            mock_sound.set_volume.assert_called_with(0.6)
+
+    def test_start_loop_applies_master_volume_to_channel(self):
+        with patch("src.managers.sound_manager.pygame") as mock_pg:
+            mock_sound = MagicMock()
+            mock_pg.mixer.Sound.return_value = mock_sound
+            mock_channel = MagicMock()
+            mock_pg.mixer.find_channel.return_value = mock_channel
+            sm = SoundManager(master_volume=0.7)
+            sm._start_loop("engine")
+            mock_channel.set_volume.assert_called_with(0.7)
+
+    def test_set_master_volume_clamps_high(self):
+        with patch("src.managers.sound_manager.pygame") as mock_pg:
+            mock_pg.mixer.Sound.return_value = MagicMock()
+            sm = SoundManager()
+            sm.set_master_volume(1.5)
+            assert sm._master_volume == 1.0
+
+    def test_set_master_volume_clamps_low(self):
+        with patch("src.managers.sound_manager.pygame") as mock_pg:
+            mock_pg.mixer.Sound.return_value = MagicMock()
+            sm = SoundManager()
+            sm.set_master_volume(-0.3)
+            assert sm._master_volume == 0.0


### PR DESCRIPTION
## Summary

- Add `SettingsManager` for persistent volume settings (`settings.json`)
- Add `SoundManager.set_master_volume()` with clamping and channel support
- Add pause menu (ESC during gameplay) with RESUME, OPTIONS, TITLE SCREEN, QUIT
- Add options menu with 10-step volume slider and visual bar
- Add OPTIONS and QUIT items to title screen
- ESC never quits — always "go back". Quitting is explicit via QUIT menu items
- ESC ignored during animations (curtain, game over, victory)
- Volume persists between sessions, saved only when leaving options menu
- Float values rounded on save to avoid drift

## Test plan

- [ ] 608 tests pass (`uv run pytest`)
- [ ] Zero lint errors (`uv run ruff check src/ tests/`)
- [ ] Title screen shows 5 items: 1 PLAYER, 2 PLAYERS, OPTIONS, DEMO, QUIT
- [ ] OPTIONS opens volume slider, LEFT/RIGHT adjusts, BACK returns
- [ ] QUIT exits from title screen and pause menu
- [ ] ESC during gameplay opens pause menu, ESC resumes
- [ ] ESC during animations does nothing
- [ ] Volume slider plays audio feedback at adjusted level
- [ ] Volume persists after relaunch (`settings.json` created)