### PR TITLE
Add controller/gamepad support

### DIFF
--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -51,6 +51,14 @@ from src.managers.sound_manager import SoundManager
 from src.managers.settings_manager import SettingsManager
 from src.utils.paths import resource_path
 
+# Mapping from controller D-pad buttons to key constants for menu reuse.
+_CTRL_DPAD_TO_KEY: dict[int, int] = {
+    pygame.CONTROLLER_BUTTON_DPAD_UP: pygame.K_UP,
+    pygame.CONTROLLER_BUTTON_DPAD_DOWN: pygame.K_DOWN,
+    pygame.CONTROLLER_BUTTON_DPAD_LEFT: pygame.K_LEFT,
+    pygame.CONTROLLER_BUTTON_DPAD_RIGHT: pygame.K_RIGHT,
+}
+
 
 class GameManager:
     """Manages the core game loop and window."""
@@ -301,6 +309,17 @@ class GameManager:
             ):
                 self.input_handler.handle_event(event)
 
+    @staticmethod
+    def _translate_axis_to_key(
+        value: float, negative_key: int, positive_key: int
+    ) -> Optional[int]:
+        """Translate an axis value to a key constant using deadzone."""
+        if value < -AXIS_DEADZONE:
+            return negative_key
+        elif value > AXIS_DEADZONE:
+            return positive_key
+        return None
+
     def _translate_joy_event(self, event: pygame.event.Event) -> Optional[int]:
         """Translate a joystick/controller event to a key constant for menus.
 
@@ -311,12 +330,6 @@ class GameManager:
             A pygame key constant, or None if the event has no menu mapping.
         """
         # --- SDL GameController API ---
-        _CTRL_DPAD_TO_KEY = {
-            pygame.CONTROLLER_BUTTON_DPAD_UP: pygame.K_UP,
-            pygame.CONTROLLER_BUTTON_DPAD_DOWN: pygame.K_DOWN,
-            pygame.CONTROLLER_BUTTON_DPAD_LEFT: pygame.K_LEFT,
-            pygame.CONTROLLER_BUTTON_DPAD_RIGHT: pygame.K_RIGHT,
-        }
         if event.type == pygame.CONTROLLERBUTTONDOWN:
             if event.button in _CTRL_DPAD_TO_KEY:
                 return _CTRL_DPAD_TO_KEY[event.button]
@@ -327,15 +340,13 @@ class GameManager:
             return None
         elif event.type == pygame.CONTROLLERAXISMOTION:
             if event.axis == pygame.CONTROLLER_AXIS_LEFTX:
-                if event.value < -AXIS_DEADZONE:
-                    return pygame.K_LEFT
-                elif event.value > AXIS_DEADZONE:
-                    return pygame.K_RIGHT
+                return self._translate_axis_to_key(
+                    event.value, pygame.K_LEFT, pygame.K_RIGHT
+                )
             elif event.axis == pygame.CONTROLLER_AXIS_LEFTY:
-                if event.value < -AXIS_DEADZONE:
-                    return pygame.K_UP
-                elif event.value > AXIS_DEADZONE:
-                    return pygame.K_DOWN
+                return self._translate_axis_to_key(
+                    event.value, pygame.K_UP, pygame.K_DOWN
+                )
             return None
 
         # --- Raw joystick API ---
@@ -352,15 +363,13 @@ class GameManager:
             return None
         elif event.type == pygame.JOYAXISMOTION:
             if event.axis == 0:
-                if event.value < -AXIS_DEADZONE:
-                    return pygame.K_LEFT
-                elif event.value > AXIS_DEADZONE:
-                    return pygame.K_RIGHT
+                return self._translate_axis_to_key(
+                    event.value, pygame.K_LEFT, pygame.K_RIGHT
+                )
             elif event.axis == 1:
-                if event.value < -AXIS_DEADZONE:
-                    return pygame.K_UP
-                elif event.value > AXIS_DEADZONE:
-                    return pygame.K_DOWN
+                return self._translate_axis_to_key(
+                    event.value, pygame.K_UP, pygame.K_DOWN
+                )
             return None
         elif event.type == pygame.JOYBUTTONDOWN:
             if event.button in JOY_SHOOT_BUTTONS:

--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -39,8 +39,12 @@ from src.managers.texture_manager import TextureManager
 from src.managers.input_handler import (
     InputHandler,
     AXIS_DEADZONE,
+    CTRL_DPAD_BUTTONS,
+    DIRECTION_TO_KEY,
     JOY_SHOOT_BUTTONS,
     JOY_START_BUTTON,
+    JOY_AXIS_X,
+    JOY_AXIS_Y,
     CTRL_SHOOT_BUTTONS,
     CTRL_START_BUTTON,
 )
@@ -50,14 +54,6 @@ from src.managers.power_up_manager import PowerUpManager
 from src.managers.sound_manager import SoundManager
 from src.managers.settings_manager import SettingsManager
 from src.utils.paths import resource_path
-
-# Mapping from controller D-pad buttons to key constants for menu reuse.
-_CTRL_DPAD_TO_KEY: dict[int, int] = {
-    pygame.CONTROLLER_BUTTON_DPAD_UP: pygame.K_UP,
-    pygame.CONTROLLER_BUTTON_DPAD_DOWN: pygame.K_DOWN,
-    pygame.CONTROLLER_BUTTON_DPAD_LEFT: pygame.K_LEFT,
-    pygame.CONTROLLER_BUTTON_DPAD_RIGHT: pygame.K_RIGHT,
-}
 
 
 class GameManager:
@@ -278,29 +274,29 @@ class GameManager:
                 pygame.CONTROLLERBUTTONDOWN,
                 pygame.CONTROLLERAXISMOTION,
             ):
-                translated_key = self._translate_joy_event(event)
-                if translated_key is not None:
-                    if translated_key == pygame.K_ESCAPE:
-                        self._handle_escape()
-                    elif self.state == GameState.TITLE_SCREEN:
-                        self._handle_title_input(translated_key)
-                    elif self.state == GameState.PAUSED:
-                        self._handle_pause_input(translated_key)
-                    elif self.state == GameState.OPTIONS_MENU:
-                        self._handle_options_input(translated_key)
-                    elif translated_key == pygame.K_RETURN and self.state in (
-                        GameState.GAME_OVER,
-                        GameState.GAME_COMPLETE,
-                    ):
-                        logger.info(
-                            "Controller button pressed, returning to title screen."
-                        )
-                        self.state = GameState.TITLE_SCREEN
-                        self._title_selection = 0
+                if self.state != GameState.RUNNING:
+                    translated_key = self._translate_joy_event(event)
+                    if translated_key is not None:
+                        if translated_key == pygame.K_ESCAPE:
+                            self._handle_escape()
+                        elif self.state == GameState.TITLE_SCREEN:
+                            self._handle_title_input(translated_key)
+                        elif self.state == GameState.PAUSED:
+                            self._handle_pause_input(translated_key)
+                        elif self.state == GameState.OPTIONS_MENU:
+                            self._handle_options_input(translated_key)
+                        elif translated_key == pygame.K_RETURN and self.state in (
+                            GameState.GAME_OVER,
+                            GameState.GAME_COMPLETE,
+                        ):
+                            logger.info(
+                                "Controller button pressed, returning to title screen."
+                            )
+                            self.state = GameState.TITLE_SCREEN
+                            self._title_selection = 0
 
-            # Pass all events to input handler during gameplay.
-            # Hot-plug events are forwarded in any state so controllers
-            # can be connected/disconnected from menus.
+            # Forward all events to InputHandler during gameplay.
+            # Hot-plug events are forwarded in any state.
             if self.state == GameState.RUNNING:
                 self.input_handler.handle_event(event)
             elif event.type in (
@@ -310,14 +306,12 @@ class GameManager:
                 self.input_handler.handle_event(event)
 
     @staticmethod
-    def _translate_axis_to_key(
-        value: float, negative_key: int, positive_key: int
-    ) -> Optional[int]:
+    def _axis_to_key(value: float, neg_key: int, pos_key: int) -> Optional[int]:
         """Translate an axis value to a key constant using deadzone."""
         if value < -AXIS_DEADZONE:
-            return negative_key
+            return neg_key
         elif value > AXIS_DEADZONE:
-            return positive_key
+            return pos_key
         return None
 
     def _translate_joy_event(self, event: pygame.event.Event) -> Optional[int]:
@@ -329,27 +323,25 @@ class GameManager:
         Returns:
             A pygame key constant, or None if the event has no menu mapping.
         """
-        # --- SDL GameController API ---
         if event.type == pygame.CONTROLLERBUTTONDOWN:
-            if event.button in _CTRL_DPAD_TO_KEY:
-                return _CTRL_DPAD_TO_KEY[event.button]
+            if event.button in CTRL_DPAD_BUTTONS:
+                return DIRECTION_TO_KEY[CTRL_DPAD_BUTTONS[event.button]]
             elif event.button in CTRL_SHOOT_BUTTONS:
                 return pygame.K_RETURN
             elif event.button == CTRL_START_BUTTON:
                 return pygame.K_ESCAPE
             return None
-        elif event.type == pygame.CONTROLLERAXISMOTION:
-            if event.axis == pygame.CONTROLLER_AXIS_LEFTX:
-                return self._translate_axis_to_key(
-                    event.value, pygame.K_LEFT, pygame.K_RIGHT
-                )
-            elif event.axis == pygame.CONTROLLER_AXIS_LEFTY:
-                return self._translate_axis_to_key(
-                    event.value, pygame.K_UP, pygame.K_DOWN
-                )
+
+        elif event.type in (
+            pygame.CONTROLLERAXISMOTION,
+            pygame.JOYAXISMOTION,
+        ):
+            if event.axis in (pygame.CONTROLLER_AXIS_LEFTX, JOY_AXIS_X):
+                return self._axis_to_key(event.value, pygame.K_LEFT, pygame.K_RIGHT)
+            elif event.axis in (pygame.CONTROLLER_AXIS_LEFTY, JOY_AXIS_Y):
+                return self._axis_to_key(event.value, pygame.K_UP, pygame.K_DOWN)
             return None
 
-        # --- Raw joystick API ---
         elif event.type == pygame.JOYHATMOTION:
             hat_x, hat_y = event.value
             if hat_y > 0:
@@ -361,22 +353,14 @@ class GameManager:
             elif hat_x > 0:
                 return pygame.K_RIGHT
             return None
-        elif event.type == pygame.JOYAXISMOTION:
-            if event.axis == 0:
-                return self._translate_axis_to_key(
-                    event.value, pygame.K_LEFT, pygame.K_RIGHT
-                )
-            elif event.axis == 1:
-                return self._translate_axis_to_key(
-                    event.value, pygame.K_UP, pygame.K_DOWN
-                )
-            return None
+
         elif event.type == pygame.JOYBUTTONDOWN:
             if event.button in JOY_SHOOT_BUTTONS:
                 return pygame.K_RETURN
             elif event.button == JOY_START_BUTTON:
                 return pygame.K_ESCAPE
             return None
+
         return None
 
     def _handle_escape(self) -> None:

--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -36,7 +36,7 @@ from src.managers.collision_manager import CollisionManager
 from src.managers.collision_response_handler import CollisionResponseHandler
 from src.managers.effect_manager import EffectManager
 from src.managers.texture_manager import TextureManager
-from src.managers.input_handler import InputHandler
+from src.managers.input_handler import InputHandler, AXIS_DEADZONE, SHOOT_BUTTONS, START_BUTTON
 from src.managers.spawn_manager import SpawnManager
 from src.managers.renderer import Renderer
 from src.managers.power_up_manager import PowerUpManager
@@ -256,9 +256,71 @@ class GameManager:
                     self.state = GameState.TITLE_SCREEN
                     self._title_selection = 0
 
+            elif event.type in (
+                pygame.JOYHATMOTION,
+                pygame.JOYAXISMOTION,
+                pygame.JOYBUTTONDOWN,
+            ):
+                translated_key = self._translate_joy_event(event)
+                if translated_key is not None:
+                    if translated_key == pygame.K_ESCAPE:
+                        self._handle_escape()
+                    elif self.state == GameState.TITLE_SCREEN:
+                        self._handle_title_input(translated_key)
+                    elif self.state == GameState.PAUSED:
+                        self._handle_pause_input(translated_key)
+                    elif self.state == GameState.OPTIONS_MENU:
+                        self._handle_options_input(translated_key)
+                    elif translated_key == pygame.K_RETURN and self.state in (
+                        GameState.GAME_OVER,
+                        GameState.GAME_COMPLETE,
+                    ):
+                        logger.info(
+                            "Controller button pressed, returning to title screen."
+                        )
+                        self.state = GameState.TITLE_SCREEN
+                        self._title_selection = 0
+
             # Pass events to input handler only if game is running
             if self.state == GameState.RUNNING:
                 self.input_handler.handle_event(event)
+
+    def _translate_joy_event(self, event: pygame.event.Event) -> Optional[int]:
+        """Translate a joystick event to an equivalent key constant for menu use.
+
+        Returns:
+            A pygame key constant, or None if the event has no menu mapping.
+        """
+        if event.type == pygame.JOYHATMOTION:
+            hat_x, hat_y = event.value
+            if hat_y > 0:
+                return pygame.K_UP
+            elif hat_y < 0:
+                return pygame.K_DOWN
+            elif hat_x < 0:
+                return pygame.K_LEFT
+            elif hat_x > 0:
+                return pygame.K_RIGHT
+            return None
+        elif event.type == pygame.JOYAXISMOTION:
+            if event.axis == 0:
+                if event.value < -AXIS_DEADZONE:
+                    return pygame.K_LEFT
+                elif event.value > AXIS_DEADZONE:
+                    return pygame.K_RIGHT
+            elif event.axis == 1:
+                if event.value < -AXIS_DEADZONE:
+                    return pygame.K_UP
+                elif event.value > AXIS_DEADZONE:
+                    return pygame.K_DOWN
+            return None
+        elif event.type == pygame.JOYBUTTONDOWN:
+            if event.button in SHOOT_BUTTONS:
+                return pygame.K_RETURN
+            elif event.button == START_BUTTON:
+                return pygame.K_ESCAPE
+            return None
+        return None
 
     def _handle_escape(self) -> None:
         """Handle ESC key based on current state.

--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -36,7 +36,12 @@ from src.managers.collision_manager import CollisionManager
 from src.managers.collision_response_handler import CollisionResponseHandler
 from src.managers.effect_manager import EffectManager
 from src.managers.texture_manager import TextureManager
-from src.managers.input_handler import InputHandler, AXIS_DEADZONE, SHOOT_BUTTONS, START_BUTTON
+from src.managers.input_handler import (
+    InputHandler,
+    AXIS_DEADZONE,
+    SHOOT_BUTTONS,
+    START_BUTTON,
+)
 from src.managers.spawn_manager import SpawnManager
 from src.managers.renderer import Renderer
 from src.managers.power_up_manager import PowerUpManager

--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -39,8 +39,10 @@ from src.managers.texture_manager import TextureManager
 from src.managers.input_handler import (
     InputHandler,
     AXIS_DEADZONE,
-    SHOOT_BUTTONS,
-    START_BUTTON,
+    JOY_SHOOT_BUTTONS,
+    JOY_START_BUTTON,
+    CTRL_SHOOT_BUTTONS,
+    CTRL_START_BUTTON,
 )
 from src.managers.spawn_manager import SpawnManager
 from src.managers.renderer import Renderer
@@ -265,6 +267,8 @@ class GameManager:
                 pygame.JOYHATMOTION,
                 pygame.JOYAXISMOTION,
                 pygame.JOYBUTTONDOWN,
+                pygame.CONTROLLERBUTTONDOWN,
+                pygame.CONTROLLERAXISMOTION,
             ):
                 translated_key = self._translate_joy_event(event)
                 if translated_key is not None:
@@ -286,17 +290,56 @@ class GameManager:
                         self.state = GameState.TITLE_SCREEN
                         self._title_selection = 0
 
-            # Pass events to input handler only if game is running
+            # Pass all events to input handler during gameplay.
+            # Hot-plug events are forwarded in any state so controllers
+            # can be connected/disconnected from menus.
             if self.state == GameState.RUNNING:
+                self.input_handler.handle_event(event)
+            elif event.type in (
+                pygame.JOYDEVICEADDED,
+                pygame.JOYDEVICEREMOVED,
+            ):
                 self.input_handler.handle_event(event)
 
     def _translate_joy_event(self, event: pygame.event.Event) -> Optional[int]:
-        """Translate a joystick event to an equivalent key constant for menu use.
+        """Translate a joystick/controller event to a key constant for menus.
+
+        Handles both SDL GameController events (recognized controllers)
+        and raw joystick events (unrecognized controllers).
 
         Returns:
             A pygame key constant, or None if the event has no menu mapping.
         """
-        if event.type == pygame.JOYHATMOTION:
+        # --- SDL GameController API ---
+        _CTRL_DPAD_TO_KEY = {
+            pygame.CONTROLLER_BUTTON_DPAD_UP: pygame.K_UP,
+            pygame.CONTROLLER_BUTTON_DPAD_DOWN: pygame.K_DOWN,
+            pygame.CONTROLLER_BUTTON_DPAD_LEFT: pygame.K_LEFT,
+            pygame.CONTROLLER_BUTTON_DPAD_RIGHT: pygame.K_RIGHT,
+        }
+        if event.type == pygame.CONTROLLERBUTTONDOWN:
+            if event.button in _CTRL_DPAD_TO_KEY:
+                return _CTRL_DPAD_TO_KEY[event.button]
+            elif event.button in CTRL_SHOOT_BUTTONS:
+                return pygame.K_RETURN
+            elif event.button == CTRL_START_BUTTON:
+                return pygame.K_ESCAPE
+            return None
+        elif event.type == pygame.CONTROLLERAXISMOTION:
+            if event.axis == pygame.CONTROLLER_AXIS_LEFTX:
+                if event.value < -AXIS_DEADZONE:
+                    return pygame.K_LEFT
+                elif event.value > AXIS_DEADZONE:
+                    return pygame.K_RIGHT
+            elif event.axis == pygame.CONTROLLER_AXIS_LEFTY:
+                if event.value < -AXIS_DEADZONE:
+                    return pygame.K_UP
+                elif event.value > AXIS_DEADZONE:
+                    return pygame.K_DOWN
+            return None
+
+        # --- Raw joystick API ---
+        elif event.type == pygame.JOYHATMOTION:
             hat_x, hat_y = event.value
             if hat_y > 0:
                 return pygame.K_UP
@@ -320,9 +363,9 @@ class GameManager:
                     return pygame.K_DOWN
             return None
         elif event.type == pygame.JOYBUTTONDOWN:
-            if event.button in SHOOT_BUTTONS:
+            if event.button in JOY_SHOOT_BUTTONS:
                 return pygame.K_RETURN
-            elif event.button == START_BUTTON:
+            elif event.button == JOY_START_BUTTON:
                 return pygame.K_ESCAPE
             return None
         return None

--- a/src/managers/input_handler.py
+++ b/src/managers/input_handler.py
@@ -4,6 +4,8 @@ from loguru import logger
 from src.utils.constants import Direction
 
 AXIS_DEADZONE: float = 0.5
+SHOOT_BUTTONS: tuple[int, ...] = (0, 1)  # A/Cross, B/Circle
+START_BUTTON: int = 7
 
 
 class InputHandler:
@@ -91,6 +93,9 @@ class InputHandler:
                 self.joy_directions[Direction.RIGHT] = True
             elif hat_x < 0:
                 self.joy_directions[Direction.LEFT] = True
+        elif event.type == pygame.JOYBUTTONDOWN:
+            if event.button in SHOOT_BUTTONS:
+                self.shoot_pressed = True
         elif event.type == pygame.JOYAXISMOTION:
             if event.axis == 0:  # Horizontal
                 if event.value < -AXIS_DEADZONE:

--- a/src/managers/input_handler.py
+++ b/src/managers/input_handler.py
@@ -4,12 +4,28 @@ from loguru import logger
 from src.utils.constants import Direction
 
 AXIS_DEADZONE: float = 0.5
-SHOOT_BUTTONS: tuple[int, ...] = (0, 1)  # A/Cross, B/Circle
-START_BUTTON: int = 7
+
+# Raw joystick API (fallback for controllers not in SDL's GameController DB)
+JOY_SHOOT_BUTTONS: tuple[int, ...] = (0, 1)
+JOY_START_BUTTON: int = 7
+
+# SDL GameController API (normalized IDs for recognized controllers like Xbox)
+# D-pad is reported as buttons, not hat, on recognized controllers.
+CTRL_DPAD_BUTTONS: dict[int, Direction] = {
+    pygame.CONTROLLER_BUTTON_DPAD_UP: Direction.UP,
+    pygame.CONTROLLER_BUTTON_DPAD_DOWN: Direction.DOWN,
+    pygame.CONTROLLER_BUTTON_DPAD_LEFT: Direction.LEFT,
+    pygame.CONTROLLER_BUTTON_DPAD_RIGHT: Direction.RIGHT,
+}
+CTRL_SHOOT_BUTTONS: tuple[int, ...] = (
+    pygame.CONTROLLER_BUTTON_A,
+    pygame.CONTROLLER_BUTTON_B,
+)
+CTRL_START_BUTTON: int = pygame.CONTROLLER_BUTTON_START
 
 
 class InputHandler:
-    """Handles keyboard input for the player tank."""
+    """Handles keyboard and controller input for the player tank."""
 
     def __init__(self, shoot_key: int = pygame.K_SPACE) -> None:
         """Initialize the input handler."""
@@ -27,7 +43,7 @@ class InputHandler:
         }
         self.shoot_key: int = shoot_key
         self.shoot_pressed: bool = False
-        # Joystick state (tracked separately from keyboard)
+        # Joystick/controller state (tracked separately from keyboard)
         self.joy_directions: Dict[Direction, bool] = {
             Direction.UP: False,
             Direction.DOWN: False,
@@ -39,14 +55,21 @@ class InputHandler:
 
     def _init_joystick(self) -> None:
         """Detect and initialize the first connected joystick."""
-        if pygame.joystick.get_count() > 0:
-            self.joystick = pygame.joystick.Joystick(0)
-            self.joystick.init()
-            logger.info(f"Joystick connected: {self.joystick.get_name()}")
+        try:
+            if pygame.joystick.get_count() > 0:
+                self.joystick = pygame.joystick.Joystick(0)
+                self.joystick.init()
+                logger.info(f"Joystick connected: {self.joystick.get_name()}")
+        except pygame.error:
+            logger.debug("Joystick subsystem not initialized, skipping.")
 
     def handle_event(self, event: pygame.event.Event) -> None:
         """
         Handle a pygame event to update input state.
+
+        Handles keyboard, raw joystick (JOY*), and SDL GameController
+        (CONTROLLER*) events. Recognized controllers (Xbox, PlayStation)
+        emit CONTROLLER* events; unrecognized ones emit JOY* events.
 
         Args:
             event: The pygame event to handle
@@ -65,6 +88,8 @@ class InputHandler:
                 if self.directions[direction]:
                     logger.trace(f"Key up: {direction}")
                     self.directions[direction] = False
+
+        # --- Hot-plug (shared by both APIs) ---
         elif event.type == pygame.JOYDEVICEADDED:
             if self.joystick is None:
                 self.joystick = pygame.joystick.Joystick(event.device_index)
@@ -79,12 +104,48 @@ class InputHandler:
                 self.joystick = None
                 for direction in self.joy_directions:
                     self.joy_directions[direction] = False
+
+        # --- SDL GameController API (recognized controllers) ---
+        elif event.type == pygame.CONTROLLERBUTTONDOWN:
+            if event.button in CTRL_DPAD_BUTTONS:
+                direction = CTRL_DPAD_BUTTONS[event.button]
+                # Reset all then set the pressed one
+                for d in self.joy_directions:
+                    self.joy_directions[d] = False
+                self.joy_directions[direction] = True
+            elif event.button in CTRL_SHOOT_BUTTONS:
+                self.shoot_pressed = True
+        elif event.type == pygame.CONTROLLERBUTTONUP:
+            if event.button in CTRL_DPAD_BUTTONS:
+                direction = CTRL_DPAD_BUTTONS[event.button]
+                self.joy_directions[direction] = False
+        elif event.type == pygame.CONTROLLERAXISMOTION:
+            if event.axis == pygame.CONTROLLER_AXIS_LEFTX:
+                if event.value < -AXIS_DEADZONE:
+                    self.joy_directions[Direction.LEFT] = True
+                    self.joy_directions[Direction.RIGHT] = False
+                elif event.value > AXIS_DEADZONE:
+                    self.joy_directions[Direction.RIGHT] = True
+                    self.joy_directions[Direction.LEFT] = False
+                else:
+                    self.joy_directions[Direction.LEFT] = False
+                    self.joy_directions[Direction.RIGHT] = False
+            elif event.axis == pygame.CONTROLLER_AXIS_LEFTY:
+                if event.value < -AXIS_DEADZONE:
+                    self.joy_directions[Direction.UP] = True
+                    self.joy_directions[Direction.DOWN] = False
+                elif event.value > AXIS_DEADZONE:
+                    self.joy_directions[Direction.DOWN] = True
+                    self.joy_directions[Direction.UP] = False
+                else:
+                    self.joy_directions[Direction.UP] = False
+                    self.joy_directions[Direction.DOWN] = False
+
+        # --- Raw joystick API (unrecognized controllers) ---
         elif event.type == pygame.JOYHATMOTION:
             hat_x, hat_y = event.value
-            # Reset all joystick directions first
             for direction in self.joy_directions:
                 self.joy_directions[direction] = False
-            # Vertical takes priority (NES behavior) for diagonals
             if hat_y > 0:
                 self.joy_directions[Direction.UP] = True
             elif hat_y < 0:
@@ -94,7 +155,7 @@ class InputHandler:
             elif hat_x < 0:
                 self.joy_directions[Direction.LEFT] = True
         elif event.type == pygame.JOYBUTTONDOWN:
-            if event.button in SHOOT_BUTTONS:
+            if event.button in JOY_SHOOT_BUTTONS:
                 self.shoot_pressed = True
         elif event.type == pygame.JOYAXISMOTION:
             if event.axis == 0:  # Horizontal

--- a/src/managers/input_handler.py
+++ b/src/managers/input_handler.py
@@ -55,13 +55,34 @@ class InputHandler:
 
     def _init_joystick(self) -> None:
         """Detect and initialize the first connected joystick."""
-        try:
-            if pygame.joystick.get_count() > 0:
-                self.joystick = pygame.joystick.Joystick(0)
-                self.joystick.init()
-                logger.info(f"Joystick connected: {self.joystick.get_name()}")
-        except pygame.error:
-            logger.debug("Joystick subsystem not initialized, skipping.")
+        if pygame.joystick.get_count() > 0:
+            self.joystick = pygame.joystick.Joystick(0)
+            self.joystick.init()
+            logger.info(f"Joystick connected: {self.joystick.get_name()}")
+
+    def _handle_horizontal_axis(self, value: float) -> None:
+        """Update joy_directions for a horizontal axis value."""
+        if value < -AXIS_DEADZONE:
+            self.joy_directions[Direction.LEFT] = True
+            self.joy_directions[Direction.RIGHT] = False
+        elif value > AXIS_DEADZONE:
+            self.joy_directions[Direction.RIGHT] = True
+            self.joy_directions[Direction.LEFT] = False
+        else:
+            self.joy_directions[Direction.LEFT] = False
+            self.joy_directions[Direction.RIGHT] = False
+
+    def _handle_vertical_axis(self, value: float) -> None:
+        """Update joy_directions for a vertical axis value."""
+        if value < -AXIS_DEADZONE:
+            self.joy_directions[Direction.UP] = True
+            self.joy_directions[Direction.DOWN] = False
+        elif value > AXIS_DEADZONE:
+            self.joy_directions[Direction.DOWN] = True
+            self.joy_directions[Direction.UP] = False
+        else:
+            self.joy_directions[Direction.UP] = False
+            self.joy_directions[Direction.DOWN] = False
 
     def handle_event(self, event: pygame.event.Event) -> None:
         """
@@ -121,25 +142,9 @@ class InputHandler:
                 self.joy_directions[direction] = False
         elif event.type == pygame.CONTROLLERAXISMOTION:
             if event.axis == pygame.CONTROLLER_AXIS_LEFTX:
-                if event.value < -AXIS_DEADZONE:
-                    self.joy_directions[Direction.LEFT] = True
-                    self.joy_directions[Direction.RIGHT] = False
-                elif event.value > AXIS_DEADZONE:
-                    self.joy_directions[Direction.RIGHT] = True
-                    self.joy_directions[Direction.LEFT] = False
-                else:
-                    self.joy_directions[Direction.LEFT] = False
-                    self.joy_directions[Direction.RIGHT] = False
+                self._handle_horizontal_axis(event.value)
             elif event.axis == pygame.CONTROLLER_AXIS_LEFTY:
-                if event.value < -AXIS_DEADZONE:
-                    self.joy_directions[Direction.UP] = True
-                    self.joy_directions[Direction.DOWN] = False
-                elif event.value > AXIS_DEADZONE:
-                    self.joy_directions[Direction.DOWN] = True
-                    self.joy_directions[Direction.UP] = False
-                else:
-                    self.joy_directions[Direction.UP] = False
-                    self.joy_directions[Direction.DOWN] = False
+                self._handle_vertical_axis(event.value)
 
         # --- Raw joystick API (unrecognized controllers) ---
         elif event.type == pygame.JOYHATMOTION:
@@ -158,26 +163,10 @@ class InputHandler:
             if event.button in JOY_SHOOT_BUTTONS:
                 self.shoot_pressed = True
         elif event.type == pygame.JOYAXISMOTION:
-            if event.axis == 0:  # Horizontal
-                if event.value < -AXIS_DEADZONE:
-                    self.joy_directions[Direction.LEFT] = True
-                    self.joy_directions[Direction.RIGHT] = False
-                elif event.value > AXIS_DEADZONE:
-                    self.joy_directions[Direction.RIGHT] = True
-                    self.joy_directions[Direction.LEFT] = False
-                else:
-                    self.joy_directions[Direction.LEFT] = False
-                    self.joy_directions[Direction.RIGHT] = False
-            elif event.axis == 1:  # Vertical
-                if event.value < -AXIS_DEADZONE:
-                    self.joy_directions[Direction.UP] = True
-                    self.joy_directions[Direction.DOWN] = False
-                elif event.value > AXIS_DEADZONE:
-                    self.joy_directions[Direction.DOWN] = True
-                    self.joy_directions[Direction.UP] = False
-                else:
-                    self.joy_directions[Direction.UP] = False
-                    self.joy_directions[Direction.DOWN] = False
+            if event.axis == 0:
+                self._handle_horizontal_axis(event.value)
+            elif event.axis == 1:
+                self._handle_vertical_axis(event.value)
 
     def get_movement_direction(self) -> Tuple[int, int]:
         """

--- a/src/managers/input_handler.py
+++ b/src/managers/input_handler.py
@@ -3,6 +3,8 @@ from typing import Tuple, Dict, Optional
 from loguru import logger
 from src.utils.constants import Direction
 
+AXIS_DEADZONE: float = 0.5
+
 
 class InputHandler:
     """Handles keyboard input for the player tank."""
@@ -89,6 +91,27 @@ class InputHandler:
                 self.joy_directions[Direction.RIGHT] = True
             elif hat_x < 0:
                 self.joy_directions[Direction.LEFT] = True
+        elif event.type == pygame.JOYAXISMOTION:
+            if event.axis == 0:  # Horizontal
+                if event.value < -AXIS_DEADZONE:
+                    self.joy_directions[Direction.LEFT] = True
+                    self.joy_directions[Direction.RIGHT] = False
+                elif event.value > AXIS_DEADZONE:
+                    self.joy_directions[Direction.RIGHT] = True
+                    self.joy_directions[Direction.LEFT] = False
+                else:
+                    self.joy_directions[Direction.LEFT] = False
+                    self.joy_directions[Direction.RIGHT] = False
+            elif event.axis == 1:  # Vertical
+                if event.value < -AXIS_DEADZONE:
+                    self.joy_directions[Direction.UP] = True
+                    self.joy_directions[Direction.DOWN] = False
+                elif event.value > AXIS_DEADZONE:
+                    self.joy_directions[Direction.DOWN] = True
+                    self.joy_directions[Direction.UP] = False
+                else:
+                    self.joy_directions[Direction.UP] = False
+                    self.joy_directions[Direction.DOWN] = False
 
     def get_movement_direction(self) -> Tuple[int, int]:
         """

--- a/src/managers/input_handler.py
+++ b/src/managers/input_handler.py
@@ -75,10 +75,26 @@ class InputHandler:
                 self.joystick = None
                 for direction in self.joy_directions:
                     self.joy_directions[direction] = False
+        elif event.type == pygame.JOYHATMOTION:
+            hat_x, hat_y = event.value
+            # Reset all joystick directions first
+            for direction in self.joy_directions:
+                self.joy_directions[direction] = False
+            # Vertical takes priority (NES behavior) for diagonals
+            if hat_y > 0:
+                self.joy_directions[Direction.UP] = True
+            elif hat_y < 0:
+                self.joy_directions[Direction.DOWN] = True
+            elif hat_x > 0:
+                self.joy_directions[Direction.RIGHT] = True
+            elif hat_x < 0:
+                self.joy_directions[Direction.LEFT] = True
 
     def get_movement_direction(self) -> Tuple[int, int]:
         """
         Get the current movement direction as a vector.
+
+        Merges keyboard and joystick input (OR logic).
 
         Returns:
             A tuple (dx, dy) representing the movement direction
@@ -86,6 +102,11 @@ class InputHandler:
         dx = 0
         dy = 0
         for direction, pressed in self.directions.items():
+            if pressed:
+                ddx, ddy = direction.delta
+                dx += ddx
+                dy += ddy
+        for direction, pressed in self.joy_directions.items():
             if pressed:
                 ddx, ddy = direction.delta
                 dx += ddx

--- a/src/managers/input_handler.py
+++ b/src/managers/input_handler.py
@@ -1,5 +1,5 @@
 import pygame
-from typing import Tuple, Dict
+from typing import Tuple, Dict, Optional
 from loguru import logger
 from src.utils.constants import Direction
 
@@ -23,6 +23,22 @@ class InputHandler:
         }
         self.shoot_key: int = shoot_key
         self.shoot_pressed: bool = False
+        # Joystick state (tracked separately from keyboard)
+        self.joy_directions: Dict[Direction, bool] = {
+            Direction.UP: False,
+            Direction.DOWN: False,
+            Direction.LEFT: False,
+            Direction.RIGHT: False,
+        }
+        self.joystick: Optional["pygame.joystick.JoystickType"] = None
+        self._init_joystick()
+
+    def _init_joystick(self) -> None:
+        """Detect and initialize the first connected joystick."""
+        if pygame.joystick.get_count() > 0:
+            self.joystick = pygame.joystick.Joystick(0)
+            self.joystick.init()
+            logger.info(f"Joystick connected: {self.joystick.get_name()}")
 
     def handle_event(self, event: pygame.event.Event) -> None:
         """
@@ -45,6 +61,20 @@ class InputHandler:
                 if self.directions[direction]:
                     logger.trace(f"Key up: {direction}")
                     self.directions[direction] = False
+        elif event.type == pygame.JOYDEVICEADDED:
+            if self.joystick is None:
+                self.joystick = pygame.joystick.Joystick(event.device_index)
+                self.joystick.init()
+                logger.info(f"Joystick connected: {self.joystick.get_name()}")
+        elif event.type == pygame.JOYDEVICEREMOVED:
+            if (
+                self.joystick is not None
+                and event.instance_id == self.joystick.get_instance_id()
+            ):
+                logger.info(f"Joystick disconnected: {self.joystick.get_name()}")
+                self.joystick = None
+                for direction in self.joy_directions:
+                    self.joy_directions[direction] = False
 
     def get_movement_direction(self) -> Tuple[int, int]:
         """
@@ -66,6 +96,8 @@ class InputHandler:
         """Reset all input state. Called between stages."""
         for direction in self.directions:
             self.directions[direction] = False
+        for direction in self.joy_directions:
+            self.joy_directions[direction] = False
         self.shoot_pressed = False
 
     def consume_shoot(self) -> bool:

--- a/src/managers/input_handler.py
+++ b/src/managers/input_handler.py
@@ -6,11 +6,12 @@ from src.utils.constants import Direction
 AXIS_DEADZONE: float = 0.5
 
 # Raw joystick API (fallback for controllers not in SDL's GameController DB)
+JOY_AXIS_X: int = 0
+JOY_AXIS_Y: int = 1
 JOY_SHOOT_BUTTONS: tuple[int, ...] = (0, 1)
 JOY_START_BUTTON: int = 7
 
 # SDL GameController API (normalized IDs for recognized controllers like Xbox)
-# D-pad is reported as buttons, not hat, on recognized controllers.
 CTRL_DPAD_BUTTONS: dict[int, Direction] = {
     pygame.CONTROLLER_BUTTON_DPAD_UP: Direction.UP,
     pygame.CONTROLLER_BUTTON_DPAD_DOWN: Direction.DOWN,
@@ -22,6 +23,14 @@ CTRL_SHOOT_BUTTONS: tuple[int, ...] = (
     pygame.CONTROLLER_BUTTON_B,
 )
 CTRL_START_BUTTON: int = pygame.CONTROLLER_BUTTON_START
+
+# Direction → pygame key constant (used by GameManager for menu translation)
+DIRECTION_TO_KEY: dict[Direction, int] = {
+    Direction.UP: pygame.K_UP,
+    Direction.DOWN: pygame.K_DOWN,
+    Direction.LEFT: pygame.K_LEFT,
+    Direction.RIGHT: pygame.K_RIGHT,
+}
 
 
 class InputHandler:
@@ -60,29 +69,19 @@ class InputHandler:
             self.joystick.init()
             logger.info(f"Joystick connected: {self.joystick.get_name()}")
 
-    def _handle_horizontal_axis(self, value: float) -> None:
-        """Update joy_directions for a horizontal axis value."""
+    def _handle_axis(
+        self, value: float, neg_dir: Direction, pos_dir: Direction
+    ) -> None:
+        """Update joy_directions for an axis value with deadzone."""
         if value < -AXIS_DEADZONE:
-            self.joy_directions[Direction.LEFT] = True
-            self.joy_directions[Direction.RIGHT] = False
+            self.joy_directions[neg_dir] = True
+            self.joy_directions[pos_dir] = False
         elif value > AXIS_DEADZONE:
-            self.joy_directions[Direction.RIGHT] = True
-            self.joy_directions[Direction.LEFT] = False
+            self.joy_directions[pos_dir] = True
+            self.joy_directions[neg_dir] = False
         else:
-            self.joy_directions[Direction.LEFT] = False
-            self.joy_directions[Direction.RIGHT] = False
-
-    def _handle_vertical_axis(self, value: float) -> None:
-        """Update joy_directions for a vertical axis value."""
-        if value < -AXIS_DEADZONE:
-            self.joy_directions[Direction.UP] = True
-            self.joy_directions[Direction.DOWN] = False
-        elif value > AXIS_DEADZONE:
-            self.joy_directions[Direction.DOWN] = True
-            self.joy_directions[Direction.UP] = False
-        else:
-            self.joy_directions[Direction.UP] = False
-            self.joy_directions[Direction.DOWN] = False
+            self.joy_directions[neg_dir] = False
+            self.joy_directions[pos_dir] = False
 
     def handle_event(self, event: pygame.event.Event) -> None:
         """
@@ -130,7 +129,6 @@ class InputHandler:
         elif event.type == pygame.CONTROLLERBUTTONDOWN:
             if event.button in CTRL_DPAD_BUTTONS:
                 direction = CTRL_DPAD_BUTTONS[event.button]
-                # Reset all then set the pressed one
                 for d in self.joy_directions:
                     self.joy_directions[d] = False
                 self.joy_directions[direction] = True
@@ -140,11 +138,13 @@ class InputHandler:
             if event.button in CTRL_DPAD_BUTTONS:
                 direction = CTRL_DPAD_BUTTONS[event.button]
                 self.joy_directions[direction] = False
-        elif event.type == pygame.CONTROLLERAXISMOTION:
-            if event.axis == pygame.CONTROLLER_AXIS_LEFTX:
-                self._handle_horizontal_axis(event.value)
-            elif event.axis == pygame.CONTROLLER_AXIS_LEFTY:
-                self._handle_vertical_axis(event.value)
+
+        # --- Axis motion (shared: CONTROLLER_AXIS_LEFTX == 0, LEFTY == 1) ---
+        elif event.type in (pygame.CONTROLLERAXISMOTION, pygame.JOYAXISMOTION):
+            if event.axis in (pygame.CONTROLLER_AXIS_LEFTX, JOY_AXIS_X):
+                self._handle_axis(event.value, Direction.LEFT, Direction.RIGHT)
+            elif event.axis in (pygame.CONTROLLER_AXIS_LEFTY, JOY_AXIS_Y):
+                self._handle_axis(event.value, Direction.UP, Direction.DOWN)
 
         # --- Raw joystick API (unrecognized controllers) ---
         elif event.type == pygame.JOYHATMOTION:
@@ -162,11 +162,6 @@ class InputHandler:
         elif event.type == pygame.JOYBUTTONDOWN:
             if event.button in JOY_SHOOT_BUTTONS:
                 self.shoot_pressed = True
-        elif event.type == pygame.JOYAXISMOTION:
-            if event.axis == 0:
-                self._handle_horizontal_axis(event.value)
-            elif event.axis == 1:
-                self._handle_vertical_axis(event.value)
 
     def get_movement_direction(self) -> Tuple[int, int]:
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,7 +55,9 @@ def key_up_event():
 def joy_hat_event():
     """Factory fixture to create JOYHATMOTION events."""
 
-    def _joy_hat_event(value: tuple, hat: int = 0, instance_id: int = 0) -> pygame.event.Event:
+    def _joy_hat_event(
+        value: tuple, hat: int = 0, instance_id: int = 0
+    ) -> pygame.event.Event:
         return pygame.event.Event(
             pygame.JOYHATMOTION, value=value, hat=hat, instance_id=instance_id
         )
@@ -67,7 +69,9 @@ def joy_hat_event():
 def joy_axis_event():
     """Factory fixture to create JOYAXISMOTION events."""
 
-    def _joy_axis_event(axis: int, value: float, instance_id: int = 0) -> pygame.event.Event:
+    def _joy_axis_event(
+        axis: int, value: float, instance_id: int = 0
+    ) -> pygame.event.Event:
         return pygame.event.Event(
             pygame.JOYAXISMOTION, axis=axis, value=value, instance_id=instance_id
         )
@@ -92,9 +96,7 @@ def joy_device_added_event():
     """Factory fixture to create JOYDEVICEADDED events."""
 
     def _joy_device_added_event(device_index: int = 0) -> pygame.event.Event:
-        return pygame.event.Event(
-            pygame.JOYDEVICEADDED, device_index=device_index
-        )
+        return pygame.event.Event(pygame.JOYDEVICEADDED, device_index=device_index)
 
     return _joy_device_added_event
 
@@ -104,8 +106,6 @@ def joy_device_removed_event():
     """Factory fixture to create JOYDEVICEREMOVED events."""
 
     def _joy_device_removed_event(instance_id: int = 0) -> pygame.event.Event:
-        return pygame.event.Event(
-            pygame.JOYDEVICEREMOVED, instance_id=instance_id
-        )
+        return pygame.event.Event(pygame.JOYDEVICEREMOVED, instance_id=instance_id)
 
     return _joy_device_removed_event

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,3 +109,33 @@ def joy_device_removed_event():
         return pygame.event.Event(pygame.JOYDEVICEREMOVED, instance_id=instance_id)
 
     return _joy_device_removed_event
+
+
+@pytest.fixture
+def ctrl_button_down_event():
+    """Factory fixture to create CONTROLLERBUTTONDOWN events."""
+
+    def _ctrl_button_down_event(button: int) -> pygame.event.Event:
+        return pygame.event.Event(pygame.CONTROLLERBUTTONDOWN, button=button)
+
+    return _ctrl_button_down_event
+
+
+@pytest.fixture
+def ctrl_button_up_event():
+    """Factory fixture to create CONTROLLERBUTTONUP events."""
+
+    def _ctrl_button_up_event(button: int) -> pygame.event.Event:
+        return pygame.event.Event(pygame.CONTROLLERBUTTONUP, button=button)
+
+    return _ctrl_button_up_event
+
+
+@pytest.fixture
+def ctrl_axis_event():
+    """Factory fixture to create CONTROLLERAXISMOTION events."""
+
+    def _ctrl_axis_event(axis: int, value: float) -> pygame.event.Event:
+        return pygame.event.Event(pygame.CONTROLLERAXISMOTION, axis=axis, value=value)
+
+    return _ctrl_axis_event

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,3 +49,63 @@ def key_up_event():
         return pygame.event.Event(pygame.KEYUP, key=key)
 
     return _key_up_event
+
+
+@pytest.fixture
+def joy_hat_event():
+    """Factory fixture to create JOYHATMOTION events."""
+
+    def _joy_hat_event(value: tuple, hat: int = 0, instance_id: int = 0) -> pygame.event.Event:
+        return pygame.event.Event(
+            pygame.JOYHATMOTION, value=value, hat=hat, instance_id=instance_id
+        )
+
+    return _joy_hat_event
+
+
+@pytest.fixture
+def joy_axis_event():
+    """Factory fixture to create JOYAXISMOTION events."""
+
+    def _joy_axis_event(axis: int, value: float, instance_id: int = 0) -> pygame.event.Event:
+        return pygame.event.Event(
+            pygame.JOYAXISMOTION, axis=axis, value=value, instance_id=instance_id
+        )
+
+    return _joy_axis_event
+
+
+@pytest.fixture
+def joy_button_down_event():
+    """Factory fixture to create JOYBUTTONDOWN events."""
+
+    def _joy_button_down_event(button: int, instance_id: int = 0) -> pygame.event.Event:
+        return pygame.event.Event(
+            pygame.JOYBUTTONDOWN, button=button, instance_id=instance_id
+        )
+
+    return _joy_button_down_event
+
+
+@pytest.fixture
+def joy_device_added_event():
+    """Factory fixture to create JOYDEVICEADDED events."""
+
+    def _joy_device_added_event(device_index: int = 0) -> pygame.event.Event:
+        return pygame.event.Event(
+            pygame.JOYDEVICEADDED, device_index=device_index
+        )
+
+    return _joy_device_added_event
+
+
+@pytest.fixture
+def joy_device_removed_event():
+    """Factory fixture to create JOYDEVICEREMOVED events."""
+
+    def _joy_device_removed_event(instance_id: int = 0) -> pygame.event.Event:
+        return pygame.event.Event(
+            pygame.JOYDEVICEREMOVED, instance_id=instance_id
+        )
+
+    return _joy_device_removed_event

--- a/tests/integration/test_controller.py
+++ b/tests/integration/test_controller.py
@@ -6,46 +6,52 @@ from src.states.game_state import GameState
 
 
 class TestControllerGameplay:
-    """Test controller input during gameplay."""
+    """Test controller input during gameplay with SDL GameController API."""
 
-    def test_dpad_moves_player(self) -> None:
-        """D-pad hat input moves the player tank."""
+    def test_ctrl_dpad_moves_player(self) -> None:
+        """Controller D-pad UP moves the player tank up."""
         gm = GameManager()
         gm._reset_game()
         gm.state = GameState.RUNNING
         initial_y = gm.player_tank.y
 
-        hat_event = pygame.event.Event(
-            pygame.JOYHATMOTION, value=(0, 1), hat=0, instance_id=0
+        event = pygame.event.Event(
+            pygame.CONTROLLERBUTTONDOWN,
+            button=pygame.CONTROLLER_BUTTON_DPAD_UP,
         )
-        gm.input_handler.handle_event(hat_event)
+        gm.input_handler.handle_event(event)
         gm.update()
 
         assert gm.player_tank.y < initial_y
 
-    def test_stick_moves_player(self) -> None:
-        """Analog stick input moves the player tank."""
+    def test_ctrl_stick_moves_player(self) -> None:
+        """Controller left stick UP moves the player tank up."""
         gm = GameManager()
         gm._reset_game()
         gm.state = GameState.RUNNING
         initial_y = gm.player_tank.y
 
-        axis_event = pygame.event.Event(
-            pygame.JOYAXISMOTION, axis=1, value=-0.8, instance_id=0
+        event = pygame.event.Event(
+            pygame.CONTROLLERAXISMOTION,
+            axis=pygame.CONTROLLER_AXIS_LEFTY,
+            value=-0.8,
         )
-        gm.input_handler.handle_event(axis_event)
+        gm.input_handler.handle_event(event)
         gm.update()
 
         assert gm.player_tank.y < initial_y
 
-    def test_button_fires_bullet(self) -> None:
-        """Controller button fires a bullet."""
+    def test_ctrl_a_button_fires_bullet(self) -> None:
+        """Controller A button fires a bullet."""
         gm = GameManager()
         gm._reset_game()
         gm.state = GameState.RUNNING
 
-        button_event = pygame.event.Event(pygame.JOYBUTTONDOWN, button=0, instance_id=0)
-        gm.input_handler.handle_event(button_event)
+        event = pygame.event.Event(
+            pygame.CONTROLLERBUTTONDOWN,
+            button=pygame.CONTROLLER_BUTTON_A,
+        )
+        gm.input_handler.handle_event(event)
         gm.update()
 
         assert len(gm.bullets) > 0
@@ -64,29 +70,64 @@ class TestControllerGameplay:
         assert gm.player_tank.y < initial_y
 
 
+class TestRawJoystickGameplay:
+    """Test raw joystick input (fallback for unrecognized controllers)."""
+
+    def test_hat_moves_player(self) -> None:
+        """Raw joystick hat moves the player tank."""
+        gm = GameManager()
+        gm._reset_game()
+        gm.state = GameState.RUNNING
+        initial_y = gm.player_tank.y
+
+        event = pygame.event.Event(
+            pygame.JOYHATMOTION, value=(0, 1), hat=0, instance_id=0
+        )
+        gm.input_handler.handle_event(event)
+        gm.update()
+
+        assert gm.player_tank.y < initial_y
+
+    def test_raw_button_fires_bullet(self) -> None:
+        """Raw joystick button 0 fires a bullet."""
+        gm = GameManager()
+        gm._reset_game()
+        gm.state = GameState.RUNNING
+
+        event = pygame.event.Event(pygame.JOYBUTTONDOWN, button=0, instance_id=0)
+        gm.input_handler.handle_event(event)
+        gm.update()
+
+        assert len(gm.bullets) > 0
+
+
 class TestControllerMenuNavigation:
     """Test controller input in menus."""
 
-    def test_dpad_navigates_title_screen(self) -> None:
-        """D-pad navigates title screen menu items."""
+    def test_ctrl_dpad_navigates_title_screen(self) -> None:
+        """Controller D-pad navigates title screen menu items."""
         gm = GameManager()
         initial_selection = gm._title_selection
 
-        hat_down = pygame.event.Event(
-            pygame.JOYHATMOTION, value=(0, -1), hat=0, instance_id=0
+        event = pygame.event.Event(
+            pygame.CONTROLLERBUTTONDOWN,
+            button=pygame.CONTROLLER_BUTTON_DPAD_DOWN,
         )
-        translated = gm._translate_joy_event(hat_down)
+        translated = gm._translate_joy_event(event)
         gm._handle_title_input(translated)
 
         assert gm._title_selection != initial_selection
 
-    def test_button_confirms_title_selection(self) -> None:
-        """A button confirms the selected title screen option."""
+    def test_ctrl_a_confirms_title_selection(self) -> None:
+        """Controller A button confirms the selected title screen option."""
         gm = GameManager()
         gm._title_selection = 0  # 1 Player
 
-        btn = pygame.event.Event(pygame.JOYBUTTONDOWN, button=0, instance_id=0)
-        translated = gm._translate_joy_event(btn)
+        event = pygame.event.Event(
+            pygame.CONTROLLERBUTTONDOWN,
+            button=pygame.CONTROLLER_BUTTON_A,
+        )
+        translated = gm._translate_joy_event(event)
         gm._handle_title_input(translated)
 
         assert gm.state != GameState.TITLE_SCREEN

--- a/tests/integration/test_controller.py
+++ b/tests/integration/test_controller.py
@@ -1,0 +1,92 @@
+"""Integration tests for controller/gamepad support."""
+
+import pygame
+from src.managers.game_manager import GameManager
+from src.states.game_state import GameState
+
+
+class TestControllerGameplay:
+    """Test controller input during gameplay."""
+
+    def test_dpad_moves_player(self) -> None:
+        """D-pad hat input moves the player tank."""
+        gm = GameManager()
+        gm._reset_game()
+        gm.state = GameState.RUNNING
+        initial_y = gm.player_tank.y
+
+        hat_event = pygame.event.Event(
+            pygame.JOYHATMOTION, value=(0, 1), hat=0, instance_id=0
+        )
+        gm.input_handler.handle_event(hat_event)
+        gm.update()
+
+        assert gm.player_tank.y < initial_y
+
+    def test_stick_moves_player(self) -> None:
+        """Analog stick input moves the player tank."""
+        gm = GameManager()
+        gm._reset_game()
+        gm.state = GameState.RUNNING
+        initial_y = gm.player_tank.y
+
+        axis_event = pygame.event.Event(
+            pygame.JOYAXISMOTION, axis=1, value=-0.8, instance_id=0
+        )
+        gm.input_handler.handle_event(axis_event)
+        gm.update()
+
+        assert gm.player_tank.y < initial_y
+
+    def test_button_fires_bullet(self) -> None:
+        """Controller button fires a bullet."""
+        gm = GameManager()
+        gm._reset_game()
+        gm.state = GameState.RUNNING
+
+        button_event = pygame.event.Event(pygame.JOYBUTTONDOWN, button=0, instance_id=0)
+        gm.input_handler.handle_event(button_event)
+        gm.update()
+
+        assert len(gm.bullets) > 0
+
+    def test_keyboard_still_works(self) -> None:
+        """Keyboard input still works alongside controller."""
+        gm = GameManager()
+        gm._reset_game()
+        gm.state = GameState.RUNNING
+        initial_y = gm.player_tank.y
+
+        key_event = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_UP)
+        gm.input_handler.handle_event(key_event)
+        gm.update()
+
+        assert gm.player_tank.y < initial_y
+
+
+class TestControllerMenuNavigation:
+    """Test controller input in menus."""
+
+    def test_dpad_navigates_title_screen(self) -> None:
+        """D-pad navigates title screen menu items."""
+        gm = GameManager()
+        initial_selection = gm._title_selection
+
+        hat_down = pygame.event.Event(
+            pygame.JOYHATMOTION, value=(0, -1), hat=0, instance_id=0
+        )
+        translated = gm._translate_joy_event(hat_down)
+        gm._handle_title_input(translated)
+
+        assert gm._title_selection != initial_selection
+
+    def test_button_confirms_title_selection(self) -> None:
+        """A button confirms the selected title screen option."""
+        gm = GameManager()
+        gm._title_selection = 0  # 1 Player
+
+        btn = pygame.event.Event(pygame.JOYBUTTONDOWN, button=0, instance_id=0)
+        translated = gm._translate_joy_event(btn)
+        gm._handle_title_input(translated)
+
+        assert gm.state != GameState.TITLE_SCREEN

--- a/tests/unit/managers/test_game_manager.py
+++ b/tests/unit/managers/test_game_manager.py
@@ -40,7 +40,6 @@ class TestGameManager:
         pygame.init()
         manager = GameManager()
         manager._reset_game()
-        pygame.event.clear()  # Drain controller/joystick startup events
         yield manager
         pygame.quit()
 
@@ -49,7 +48,6 @@ class TestGameManager:
         """Create a GameManager at the title screen (no _reset_game)."""
         pygame.init()
         manager = GameManager()
-        pygame.event.clear()  # Drain controller/joystick startup events
         yield manager
         pygame.quit()
 
@@ -353,7 +351,6 @@ class TestGameManagerSoundWiring:
         pygame.init()
         manager = GameManager()
         manager._reset_game()
-        pygame.event.clear()  # Drain controller/joystick startup events
         yield manager
         pygame.quit()
 
@@ -362,7 +359,6 @@ class TestGameManagerSoundWiring:
         """Create a GameManager at the title screen (no _reset_game)."""
         pygame.init()
         manager = GameManager()
-        pygame.event.clear()  # Drain controller/joystick startup events
         yield manager
         pygame.quit()
 

--- a/tests/unit/managers/test_game_manager.py
+++ b/tests/unit/managers/test_game_manager.py
@@ -40,6 +40,7 @@ class TestGameManager:
         pygame.init()
         manager = GameManager()
         manager._reset_game()
+        pygame.event.clear()  # Drain controller/joystick startup events
         yield manager
         pygame.quit()
 
@@ -48,6 +49,7 @@ class TestGameManager:
         """Create a GameManager at the title screen (no _reset_game)."""
         pygame.init()
         manager = GameManager()
+        pygame.event.clear()  # Drain controller/joystick startup events
         yield manager
         pygame.quit()
 
@@ -267,6 +269,58 @@ class TestGameManager:
             event = pygame.event.Event(pygame.JOYBUTTONDOWN, button=5, instance_id=0)
             assert game_manager._translate_joy_event(event) is None
 
+        # --- SDL GameController API tests ---
+
+        def test_translate_ctrl_dpad_up(self, game_manager):
+            """Controller D-pad UP translates to K_UP."""
+            event = pygame.event.Event(
+                pygame.CONTROLLERBUTTONDOWN,
+                button=pygame.CONTROLLER_BUTTON_DPAD_UP,
+            )
+            assert game_manager._translate_joy_event(event) == pygame.K_UP
+
+        def test_translate_ctrl_dpad_down(self, game_manager):
+            """Controller D-pad DOWN translates to K_DOWN."""
+            event = pygame.event.Event(
+                pygame.CONTROLLERBUTTONDOWN,
+                button=pygame.CONTROLLER_BUTTON_DPAD_DOWN,
+            )
+            assert game_manager._translate_joy_event(event) == pygame.K_DOWN
+
+        def test_translate_ctrl_a_confirm(self, game_manager):
+            """Controller A button translates to K_RETURN."""
+            event = pygame.event.Event(
+                pygame.CONTROLLERBUTTONDOWN,
+                button=pygame.CONTROLLER_BUTTON_A,
+            )
+            assert game_manager._translate_joy_event(event) == pygame.K_RETURN
+
+        def test_translate_ctrl_start(self, game_manager):
+            """Controller Start button translates to K_ESCAPE."""
+            event = pygame.event.Event(
+                pygame.CONTROLLERBUTTONDOWN,
+                button=pygame.CONTROLLER_BUTTON_START,
+            )
+            assert game_manager._translate_joy_event(event) == pygame.K_ESCAPE
+
+        def test_translate_ctrl_axis_up(self, game_manager):
+            """Controller left stick up translates to K_UP."""
+            event = pygame.event.Event(
+                pygame.CONTROLLERAXISMOTION,
+                axis=pygame.CONTROLLER_AXIS_LEFTY,
+                value=-0.8,
+            )
+            assert game_manager._translate_joy_event(event) == pygame.K_UP
+
+        def test_translate_ctrl_axis_deadzone(self, game_manager):
+            """Controller axis within deadzone returns None."""
+            event = pygame.event.Event(
+                pygame.CONTROLLERAXISMOTION,
+                axis=pygame.CONTROLLER_AXIS_LEFTX,
+                value=0.3,
+            )
+            assert game_manager._translate_joy_event(event) is None
+
 
 class TestGameManagerSoundWiring:
     @pytest.fixture
@@ -299,6 +353,7 @@ class TestGameManagerSoundWiring:
         pygame.init()
         manager = GameManager()
         manager._reset_game()
+        pygame.event.clear()  # Drain controller/joystick startup events
         yield manager
         pygame.quit()
 
@@ -307,6 +362,7 @@ class TestGameManagerSoundWiring:
         """Create a GameManager at the title screen (no _reset_game)."""
         pygame.init()
         manager = GameManager()
+        pygame.event.clear()  # Drain controller/joystick startup events
         yield manager
         pygame.quit()
 

--- a/tests/unit/managers/test_game_manager.py
+++ b/tests/unit/managers/test_game_manager.py
@@ -174,6 +174,79 @@ class TestGameManager:
         game_manager.spawn_manager.update.assert_not_called()
         game_manager.collision_response_handler.process_collisions.assert_not_called()
 
+    class TestControllerMenuInput:
+        """Tests for controller input in menus."""
+
+        def test_translate_hat_up(self, game_manager):
+            """Hat UP translates to K_UP."""
+            event = pygame.event.Event(pygame.JOYHATMOTION, value=(0, 1), hat=0, instance_id=0)
+            assert game_manager._translate_joy_event(event) == pygame.K_UP
+
+        def test_translate_hat_down(self, game_manager):
+            """Hat DOWN translates to K_DOWN."""
+            event = pygame.event.Event(pygame.JOYHATMOTION, value=(0, -1), hat=0, instance_id=0)
+            assert game_manager._translate_joy_event(event) == pygame.K_DOWN
+
+        def test_translate_hat_left(self, game_manager):
+            """Hat LEFT translates to K_LEFT."""
+            event = pygame.event.Event(pygame.JOYHATMOTION, value=(-1, 0), hat=0, instance_id=0)
+            assert game_manager._translate_joy_event(event) == pygame.K_LEFT
+
+        def test_translate_hat_right(self, game_manager):
+            """Hat RIGHT translates to K_RIGHT."""
+            event = pygame.event.Event(pygame.JOYHATMOTION, value=(1, 0), hat=0, instance_id=0)
+            assert game_manager._translate_joy_event(event) == pygame.K_RIGHT
+
+        def test_translate_hat_neutral_returns_none(self, game_manager):
+            """Hat (0,0) returns None."""
+            event = pygame.event.Event(pygame.JOYHATMOTION, value=(0, 0), hat=0, instance_id=0)
+            assert game_manager._translate_joy_event(event) is None
+
+        def test_translate_button_0_confirm(self, game_manager):
+            """Button 0 translates to K_RETURN."""
+            event = pygame.event.Event(pygame.JOYBUTTONDOWN, button=0, instance_id=0)
+            assert game_manager._translate_joy_event(event) == pygame.K_RETURN
+
+        def test_translate_button_1_confirm(self, game_manager):
+            """Button 1 translates to K_RETURN."""
+            event = pygame.event.Event(pygame.JOYBUTTONDOWN, button=1, instance_id=0)
+            assert game_manager._translate_joy_event(event) == pygame.K_RETURN
+
+        def test_translate_start_button(self, game_manager):
+            """Button 7 (Start) translates to K_ESCAPE."""
+            event = pygame.event.Event(pygame.JOYBUTTONDOWN, button=7, instance_id=0)
+            assert game_manager._translate_joy_event(event) == pygame.K_ESCAPE
+
+        def test_translate_axis_up(self, game_manager):
+            """Axis 1 negative (up) translates to K_UP."""
+            event = pygame.event.Event(pygame.JOYAXISMOTION, axis=1, value=-0.8, instance_id=0)
+            assert game_manager._translate_joy_event(event) == pygame.K_UP
+
+        def test_translate_axis_down(self, game_manager):
+            """Axis 1 positive (down) translates to K_DOWN."""
+            event = pygame.event.Event(pygame.JOYAXISMOTION, axis=1, value=0.8, instance_id=0)
+            assert game_manager._translate_joy_event(event) == pygame.K_DOWN
+
+        def test_translate_axis_left(self, game_manager):
+            """Axis 0 negative (left) translates to K_LEFT."""
+            event = pygame.event.Event(pygame.JOYAXISMOTION, axis=0, value=-0.8, instance_id=0)
+            assert game_manager._translate_joy_event(event) == pygame.K_LEFT
+
+        def test_translate_axis_right(self, game_manager):
+            """Axis 0 positive (right) translates to K_RIGHT."""
+            event = pygame.event.Event(pygame.JOYAXISMOTION, axis=0, value=0.8, instance_id=0)
+            assert game_manager._translate_joy_event(event) == pygame.K_RIGHT
+
+        def test_translate_axis_deadzone(self, game_manager):
+            """Axis within deadzone returns None."""
+            event = pygame.event.Event(pygame.JOYAXISMOTION, axis=0, value=0.3, instance_id=0)
+            assert game_manager._translate_joy_event(event) is None
+
+        def test_translate_unmapped_button(self, game_manager):
+            """Unmapped button returns None."""
+            event = pygame.event.Event(pygame.JOYBUTTONDOWN, button=5, instance_id=0)
+            assert game_manager._translate_joy_event(event) is None
+
 
 class TestGameManagerSoundWiring:
     @pytest.fixture

--- a/tests/unit/managers/test_game_manager.py
+++ b/tests/unit/managers/test_game_manager.py
@@ -179,27 +179,37 @@ class TestGameManager:
 
         def test_translate_hat_up(self, game_manager):
             """Hat UP translates to K_UP."""
-            event = pygame.event.Event(pygame.JOYHATMOTION, value=(0, 1), hat=0, instance_id=0)
+            event = pygame.event.Event(
+                pygame.JOYHATMOTION, value=(0, 1), hat=0, instance_id=0
+            )
             assert game_manager._translate_joy_event(event) == pygame.K_UP
 
         def test_translate_hat_down(self, game_manager):
             """Hat DOWN translates to K_DOWN."""
-            event = pygame.event.Event(pygame.JOYHATMOTION, value=(0, -1), hat=0, instance_id=0)
+            event = pygame.event.Event(
+                pygame.JOYHATMOTION, value=(0, -1), hat=0, instance_id=0
+            )
             assert game_manager._translate_joy_event(event) == pygame.K_DOWN
 
         def test_translate_hat_left(self, game_manager):
             """Hat LEFT translates to K_LEFT."""
-            event = pygame.event.Event(pygame.JOYHATMOTION, value=(-1, 0), hat=0, instance_id=0)
+            event = pygame.event.Event(
+                pygame.JOYHATMOTION, value=(-1, 0), hat=0, instance_id=0
+            )
             assert game_manager._translate_joy_event(event) == pygame.K_LEFT
 
         def test_translate_hat_right(self, game_manager):
             """Hat RIGHT translates to K_RIGHT."""
-            event = pygame.event.Event(pygame.JOYHATMOTION, value=(1, 0), hat=0, instance_id=0)
+            event = pygame.event.Event(
+                pygame.JOYHATMOTION, value=(1, 0), hat=0, instance_id=0
+            )
             assert game_manager._translate_joy_event(event) == pygame.K_RIGHT
 
         def test_translate_hat_neutral_returns_none(self, game_manager):
             """Hat (0,0) returns None."""
-            event = pygame.event.Event(pygame.JOYHATMOTION, value=(0, 0), hat=0, instance_id=0)
+            event = pygame.event.Event(
+                pygame.JOYHATMOTION, value=(0, 0), hat=0, instance_id=0
+            )
             assert game_manager._translate_joy_event(event) is None
 
         def test_translate_button_0_confirm(self, game_manager):
@@ -219,27 +229,37 @@ class TestGameManager:
 
         def test_translate_axis_up(self, game_manager):
             """Axis 1 negative (up) translates to K_UP."""
-            event = pygame.event.Event(pygame.JOYAXISMOTION, axis=1, value=-0.8, instance_id=0)
+            event = pygame.event.Event(
+                pygame.JOYAXISMOTION, axis=1, value=-0.8, instance_id=0
+            )
             assert game_manager._translate_joy_event(event) == pygame.K_UP
 
         def test_translate_axis_down(self, game_manager):
             """Axis 1 positive (down) translates to K_DOWN."""
-            event = pygame.event.Event(pygame.JOYAXISMOTION, axis=1, value=0.8, instance_id=0)
+            event = pygame.event.Event(
+                pygame.JOYAXISMOTION, axis=1, value=0.8, instance_id=0
+            )
             assert game_manager._translate_joy_event(event) == pygame.K_DOWN
 
         def test_translate_axis_left(self, game_manager):
             """Axis 0 negative (left) translates to K_LEFT."""
-            event = pygame.event.Event(pygame.JOYAXISMOTION, axis=0, value=-0.8, instance_id=0)
+            event = pygame.event.Event(
+                pygame.JOYAXISMOTION, axis=0, value=-0.8, instance_id=0
+            )
             assert game_manager._translate_joy_event(event) == pygame.K_LEFT
 
         def test_translate_axis_right(self, game_manager):
             """Axis 0 positive (right) translates to K_RIGHT."""
-            event = pygame.event.Event(pygame.JOYAXISMOTION, axis=0, value=0.8, instance_id=0)
+            event = pygame.event.Event(
+                pygame.JOYAXISMOTION, axis=0, value=0.8, instance_id=0
+            )
             assert game_manager._translate_joy_event(event) == pygame.K_RIGHT
 
         def test_translate_axis_deadzone(self, game_manager):
             """Axis within deadzone returns None."""
-            event = pygame.event.Event(pygame.JOYAXISMOTION, axis=0, value=0.3, instance_id=0)
+            event = pygame.event.Event(
+                pygame.JOYAXISMOTION, axis=0, value=0.3, instance_id=0
+            )
             assert game_manager._translate_joy_event(event) is None
 
         def test_translate_unmapped_button(self, game_manager):
@@ -518,18 +538,14 @@ class TestPauseAndOptionsStateMachine:
         game_manager.handle_events()
         assert game_manager.state == GameState.GAME_OVER_ANIMATION
 
-    def test_esc_during_game_complete_does_nothing(
-        self, game_manager, key_down_event
-    ):
+    def test_esc_during_game_complete_does_nothing(self, game_manager, key_down_event):
         """ESC during GAME_COMPLETE does nothing."""
         game_manager.state = GameState.GAME_COMPLETE
         pygame.event.post(key_down_event(pygame.K_ESCAPE))
         game_manager.handle_events()
         assert game_manager.state == GameState.GAME_COMPLETE
 
-    def test_esc_during_victory_does_nothing(
-        self, game_manager, key_down_event
-    ):
+    def test_esc_during_victory_does_nothing(self, game_manager, key_down_event):
         """ESC during VICTORY does nothing."""
         game_manager.state = GameState.VICTORY
         pygame.event.post(key_down_event(pygame.K_ESCAPE))
@@ -640,9 +656,7 @@ class TestPauseAndOptionsStateMachine:
         gm.handle_events()
         assert gm._pause_selection == 3
 
-    def test_pause_plays_menu_select_on_navigation(
-        self, game_manager, key_down_event
-    ):
+    def test_pause_plays_menu_select_on_navigation(self, game_manager, key_down_event):
         """Navigating pause menu plays menu_select sound."""
         gm = game_manager
         gm.state = GameState.PAUSED

--- a/tests/unit/managers/test_input_handler.py
+++ b/tests/unit/managers/test_input_handler.py
@@ -274,3 +274,64 @@ class TestJoystickReset:
         handler.reset()
         assert all(not v for v in handler.joy_directions.values())
         assert not handler.shoot_pressed
+
+
+class TestJoystickHat:
+    """Tests for D-pad (hat) input handling."""
+
+    def test_hat_up(self, handler, joy_hat_event) -> None:
+        """Hat UP sets joy_directions UP."""
+        handler.handle_event(joy_hat_event((0, 1)))
+        assert handler.joy_directions[Direction.UP]
+        assert not handler.joy_directions[Direction.DOWN]
+
+    def test_hat_down(self, handler, joy_hat_event) -> None:
+        """Hat DOWN sets joy_directions DOWN."""
+        handler.handle_event(joy_hat_event((0, -1)))
+        assert handler.joy_directions[Direction.DOWN]
+
+    def test_hat_left(self, handler, joy_hat_event) -> None:
+        """Hat LEFT sets joy_directions LEFT."""
+        handler.handle_event(joy_hat_event((-1, 0)))
+        assert handler.joy_directions[Direction.LEFT]
+
+    def test_hat_right(self, handler, joy_hat_event) -> None:
+        """Hat RIGHT sets joy_directions RIGHT."""
+        handler.handle_event(joy_hat_event((1, 0)))
+        assert handler.joy_directions[Direction.RIGHT]
+
+    def test_hat_release(self, handler, joy_hat_event) -> None:
+        """Hat (0,0) clears all joy_directions."""
+        handler.handle_event(joy_hat_event((0, 1)))
+        assert handler.joy_directions[Direction.UP]
+        handler.handle_event(joy_hat_event((0, 0)))
+        assert all(not v for v in handler.joy_directions.values())
+
+    def test_hat_diagonal_prefers_vertical(self, handler, joy_hat_event) -> None:
+        """Diagonal hat values pick vertical axis (NES behavior)."""
+        handler.handle_event(joy_hat_event((1, 1)))
+        assert handler.joy_directions[Direction.UP]
+        assert not handler.joy_directions[Direction.RIGHT]
+
+        handler.handle_event(joy_hat_event((-1, -1)))
+        assert handler.joy_directions[Direction.DOWN]
+        assert not handler.joy_directions[Direction.LEFT]
+
+    def test_hat_merges_with_keyboard(
+        self, handler, key_down_event, joy_hat_event
+    ) -> None:
+        """get_movement_direction merges keyboard and joystick (OR logic)."""
+        handler.handle_event(key_down_event(pygame.K_UP))
+        handler.handle_event(joy_hat_event((1, 0)))
+        dx, dy = handler.get_movement_direction()
+        # keyboard UP (-1 dy) + joystick RIGHT (+1 dx)
+        assert dx == 1
+        assert dy == -1
+
+    def test_hat_direction_replaces_previous(self, handler, joy_hat_event) -> None:
+        """New hat direction replaces previous (only one joy direction active)."""
+        handler.handle_event(joy_hat_event((0, 1)))
+        assert handler.joy_directions[Direction.UP]
+        handler.handle_event(joy_hat_event((1, 0)))
+        assert handler.joy_directions[Direction.RIGHT]
+        assert not handler.joy_directions[Direction.UP]

--- a/tests/unit/managers/test_input_handler.py
+++ b/tests/unit/managers/test_input_handler.py
@@ -377,3 +377,22 @@ class TestJoystickAxis:
         """Axes beyond 0 and 1 (triggers, right stick) are ignored."""
         handler.handle_event(joy_axis_event(axis=2, value=1.0))
         assert all(not v for v in handler.joy_directions.values())
+
+
+class TestJoystickButtons:
+    """Tests for joystick button input handling."""
+
+    def test_button_0_shoots(self, handler, joy_button_down_event) -> None:
+        """Button 0 (A/Cross) triggers shoot."""
+        handler.handle_event(joy_button_down_event(button=0))
+        assert handler.shoot_pressed
+
+    def test_button_1_shoots(self, handler, joy_button_down_event) -> None:
+        """Button 1 (B/Circle) triggers shoot."""
+        handler.handle_event(joy_button_down_event(button=1))
+        assert handler.shoot_pressed
+
+    def test_other_buttons_dont_shoot(self, handler, joy_button_down_event) -> None:
+        """Other buttons do not trigger shoot."""
+        handler.handle_event(joy_button_down_event(button=3))
+        assert not handler.shoot_pressed

--- a/tests/unit/managers/test_input_handler.py
+++ b/tests/unit/managers/test_input_handler.py
@@ -335,3 +335,45 @@ class TestJoystickHat:
         handler.handle_event(joy_hat_event((1, 0)))
         assert handler.joy_directions[Direction.RIGHT]
         assert not handler.joy_directions[Direction.UP]
+
+
+class TestJoystickAxis:
+    """Tests for analog stick (axis) input handling."""
+
+    def test_axis_left(self, handler, joy_axis_event) -> None:
+        """Left stick pushed left sets LEFT direction."""
+        handler.handle_event(joy_axis_event(axis=0, value=-0.8))
+        assert handler.joy_directions[Direction.LEFT]
+
+    def test_axis_right(self, handler, joy_axis_event) -> None:
+        """Left stick pushed right sets RIGHT direction."""
+        handler.handle_event(joy_axis_event(axis=0, value=0.8))
+        assert handler.joy_directions[Direction.RIGHT]
+
+    def test_axis_up(self, handler, joy_axis_event) -> None:
+        """Left stick pushed up sets UP direction."""
+        handler.handle_event(joy_axis_event(axis=1, value=-0.8))
+        assert handler.joy_directions[Direction.UP]
+
+    def test_axis_down(self, handler, joy_axis_event) -> None:
+        """Left stick pushed down sets DOWN direction."""
+        handler.handle_event(joy_axis_event(axis=1, value=0.8))
+        assert handler.joy_directions[Direction.DOWN]
+
+    def test_axis_deadzone_no_direction(self, handler, joy_axis_event) -> None:
+        """Axis value within deadzone does not set direction."""
+        handler.handle_event(joy_axis_event(axis=0, value=0.3))
+        assert not handler.joy_directions[Direction.RIGHT]
+        assert not handler.joy_directions[Direction.LEFT]
+
+    def test_axis_return_to_center_releases(self, handler, joy_axis_event) -> None:
+        """Axis returning within deadzone releases the direction."""
+        handler.handle_event(joy_axis_event(axis=0, value=-0.8))
+        assert handler.joy_directions[Direction.LEFT]
+        handler.handle_event(joy_axis_event(axis=0, value=0.1))
+        assert not handler.joy_directions[Direction.LEFT]
+
+    def test_axis_ignores_non_stick_axes(self, handler, joy_axis_event) -> None:
+        """Axes beyond 0 and 1 (triggers, right stick) are ignored."""
+        handler.handle_event(joy_axis_event(axis=2, value=1.0))
+        assert all(not v for v in handler.joy_directions.values())

--- a/tests/unit/managers/test_input_handler.py
+++ b/tests/unit/managers/test_input_handler.py
@@ -405,3 +405,91 @@ class TestJoystickButtons:
         """Other buttons do not trigger shoot."""
         handler.handle_event(joy_button_down_event(button=3))
         assert not handler.shoot_pressed
+
+
+class TestControllerDpad:
+    """Tests for SDL GameController D-pad (button-based) input."""
+
+    def test_dpad_up(self, handler, ctrl_button_down_event) -> None:
+        """Controller D-pad UP sets joy_directions UP."""
+        handler.handle_event(ctrl_button_down_event(pygame.CONTROLLER_BUTTON_DPAD_UP))
+        assert handler.joy_directions[Direction.UP]
+
+    def test_dpad_down(self, handler, ctrl_button_down_event) -> None:
+        """Controller D-pad DOWN sets joy_directions DOWN."""
+        handler.handle_event(ctrl_button_down_event(pygame.CONTROLLER_BUTTON_DPAD_DOWN))
+        assert handler.joy_directions[Direction.DOWN]
+
+    def test_dpad_left(self, handler, ctrl_button_down_event) -> None:
+        """Controller D-pad LEFT sets joy_directions LEFT."""
+        handler.handle_event(ctrl_button_down_event(pygame.CONTROLLER_BUTTON_DPAD_LEFT))
+        assert handler.joy_directions[Direction.LEFT]
+
+    def test_dpad_right(self, handler, ctrl_button_down_event) -> None:
+        """Controller D-pad RIGHT sets joy_directions RIGHT."""
+        handler.handle_event(
+            ctrl_button_down_event(pygame.CONTROLLER_BUTTON_DPAD_RIGHT)
+        )
+        assert handler.joy_directions[Direction.RIGHT]
+
+    def test_dpad_release(
+        self, handler, ctrl_button_down_event, ctrl_button_up_event
+    ) -> None:
+        """Releasing D-pad button clears the direction."""
+        handler.handle_event(ctrl_button_down_event(pygame.CONTROLLER_BUTTON_DPAD_UP))
+        assert handler.joy_directions[Direction.UP]
+        handler.handle_event(ctrl_button_up_event(pygame.CONTROLLER_BUTTON_DPAD_UP))
+        assert not handler.joy_directions[Direction.UP]
+
+    def test_dpad_replaces_previous(self, handler, ctrl_button_down_event) -> None:
+        """New D-pad direction replaces previous."""
+        handler.handle_event(ctrl_button_down_event(pygame.CONTROLLER_BUTTON_DPAD_UP))
+        handler.handle_event(
+            ctrl_button_down_event(pygame.CONTROLLER_BUTTON_DPAD_RIGHT)
+        )
+        assert handler.joy_directions[Direction.RIGHT]
+        assert not handler.joy_directions[Direction.UP]
+
+
+class TestControllerButtons:
+    """Tests for SDL GameController button input."""
+
+    def test_a_button_shoots(self, handler, ctrl_button_down_event) -> None:
+        """Controller A button triggers shoot."""
+        handler.handle_event(ctrl_button_down_event(pygame.CONTROLLER_BUTTON_A))
+        assert handler.shoot_pressed
+
+    def test_b_button_shoots(self, handler, ctrl_button_down_event) -> None:
+        """Controller B button triggers shoot."""
+        handler.handle_event(ctrl_button_down_event(pygame.CONTROLLER_BUTTON_B))
+        assert handler.shoot_pressed
+
+
+class TestControllerAxis:
+    """Tests for SDL GameController analog stick input."""
+
+    def test_left_stick_left(self, handler, ctrl_axis_event) -> None:
+        """Left stick pushed left sets LEFT direction."""
+        handler.handle_event(ctrl_axis_event(pygame.CONTROLLER_AXIS_LEFTX, -0.8))
+        assert handler.joy_directions[Direction.LEFT]
+
+    def test_left_stick_right(self, handler, ctrl_axis_event) -> None:
+        """Left stick pushed right sets RIGHT direction."""
+        handler.handle_event(ctrl_axis_event(pygame.CONTROLLER_AXIS_LEFTX, 0.8))
+        assert handler.joy_directions[Direction.RIGHT]
+
+    def test_left_stick_up(self, handler, ctrl_axis_event) -> None:
+        """Left stick pushed up sets UP direction."""
+        handler.handle_event(ctrl_axis_event(pygame.CONTROLLER_AXIS_LEFTY, -0.8))
+        assert handler.joy_directions[Direction.UP]
+
+    def test_left_stick_down(self, handler, ctrl_axis_event) -> None:
+        """Left stick pushed down sets DOWN direction."""
+        handler.handle_event(ctrl_axis_event(pygame.CONTROLLER_AXIS_LEFTY, 0.8))
+        assert handler.joy_directions[Direction.DOWN]
+
+    def test_left_stick_deadzone(self, handler, ctrl_axis_event) -> None:
+        """Axis within deadzone sets no direction."""
+        handler.handle_event(ctrl_axis_event(pygame.CONTROLLER_AXIS_LEFTX, 0.3))
+        assert not handler.joy_directions[Direction.RIGHT]
+        assert not handler.joy_directions[Direction.LEFT]

--- a/tests/unit/managers/test_input_handler.py
+++ b/tests/unit/managers/test_input_handler.py
@@ -7,13 +7,8 @@ from src.utils.constants import Direction
 
 @pytest.fixture
 def handler() -> InputHandler:
-    """Fixture to provide an InputHandler instance for each test.
-
-    Patches pygame.joystick.get_count to return 0 so that _init_joystick()
-    does not pick up a physically connected controller during tests.
-    """
-    with patch("src.managers.input_handler.pygame.joystick.get_count", return_value=0):
-        return InputHandler()
+    """Fixture to provide an InputHandler instance for each test."""
+    return InputHandler()
 
 
 def test_initialization(handler: InputHandler) -> None:

--- a/tests/unit/managers/test_input_handler.py
+++ b/tests/unit/managers/test_input_handler.py
@@ -7,8 +7,13 @@ from src.utils.constants import Direction
 
 @pytest.fixture
 def handler() -> InputHandler:
-    """Fixture to provide an InputHandler instance for each test."""
-    return InputHandler()
+    """Fixture to provide an InputHandler instance for each test.
+
+    Patches pygame.joystick.get_count to return 0 so that _init_joystick()
+    does not pick up a physically connected controller during tests.
+    """
+    with patch("src.managers.input_handler.pygame.joystick.get_count", return_value=0):
+        return InputHandler()
 
 
 def test_initialization(handler: InputHandler) -> None:
@@ -226,7 +231,9 @@ class TestJoystickHotPlug:
     """Tests for joystick hot-plug support."""
 
     @patch("src.managers.input_handler.pygame.joystick")
-    def test_device_added(self, mock_joystick_module, handler, joy_device_added_event) -> None:
+    def test_device_added(
+        self, mock_joystick_module, handler, joy_device_added_event
+    ) -> None:
         """JOYDEVICEADDED initializes the new joystick."""
         mock_js = MagicMock()
         mock_js.get_name.return_value = "Test Controller"
@@ -255,7 +262,9 @@ class TestJoystickHotPlug:
         assert handler.joystick is None
         assert all(not v for v in handler.joy_directions.values())
 
-    def test_device_removed_wrong_instance(self, handler, joy_device_removed_event) -> None:
+    def test_device_removed_wrong_instance(
+        self, handler, joy_device_removed_event
+    ) -> None:
         """JOYDEVICEREMOVED with wrong instance_id is ignored."""
         mock_js = MagicMock()
         mock_js.get_instance_id.return_value = 0

--- a/tests/unit/managers/test_input_handler.py
+++ b/tests/unit/managers/test_input_handler.py
@@ -1,5 +1,6 @@
 import pytest
 import pygame
+from unittest.mock import patch, MagicMock
 from src.managers.input_handler import InputHandler
 from src.utils.constants import Direction
 
@@ -198,3 +199,78 @@ def test_shoot_key_not_triggered_by_movement(
     """Test that movement keys don't trigger shoot."""
     handler.handle_event(key_down_event(pygame.K_UP))
     assert not handler.shoot_pressed
+
+
+class TestJoystickInit:
+    """Tests for joystick initialization."""
+
+    def test_init_no_joystick(self, handler: InputHandler) -> None:
+        """Handler initializes with no joystick when none connected."""
+        assert handler.joystick is None
+        assert all(not v for v in handler.joy_directions.values())
+
+    @patch("src.managers.input_handler.pygame.joystick")
+    def test_init_with_joystick(self, mock_joystick_module) -> None:
+        """Handler initializes the first joystick when available."""
+        mock_js = MagicMock()
+        mock_js.get_name.return_value = "Test Controller"
+        mock_joystick_module.get_count.return_value = 1
+        mock_joystick_module.Joystick.return_value = mock_js
+        handler = InputHandler()
+        mock_joystick_module.Joystick.assert_called_once_with(0)
+        mock_js.init.assert_called_once()
+        assert handler.joystick is mock_js
+
+
+class TestJoystickHotPlug:
+    """Tests for joystick hot-plug support."""
+
+    @patch("src.managers.input_handler.pygame.joystick")
+    def test_device_added(self, mock_joystick_module, handler, joy_device_added_event) -> None:
+        """JOYDEVICEADDED initializes the new joystick."""
+        mock_js = MagicMock()
+        mock_js.get_name.return_value = "Test Controller"
+        mock_joystick_module.Joystick.return_value = mock_js
+        handler.handle_event(joy_device_added_event(device_index=0))
+        mock_joystick_module.Joystick.assert_called_once_with(0)
+        mock_js.init.assert_called_once()
+        assert handler.joystick is mock_js
+
+    def test_device_added_ignored_when_already_connected(
+        self, handler, joy_device_added_event
+    ) -> None:
+        """JOYDEVICEADDED is ignored if a joystick is already tracked."""
+        mock_js = MagicMock()
+        handler.joystick = mock_js
+        handler.handle_event(joy_device_added_event(device_index=1))
+        assert handler.joystick is mock_js  # unchanged
+
+    def test_device_removed(self, handler, joy_device_removed_event) -> None:
+        """JOYDEVICEREMOVED clears joystick and joy_directions."""
+        mock_js = MagicMock()
+        mock_js.get_instance_id.return_value = 0
+        handler.joystick = mock_js
+        handler.joy_directions[Direction.UP] = True
+        handler.handle_event(joy_device_removed_event(instance_id=0))
+        assert handler.joystick is None
+        assert all(not v for v in handler.joy_directions.values())
+
+    def test_device_removed_wrong_instance(self, handler, joy_device_removed_event) -> None:
+        """JOYDEVICEREMOVED with wrong instance_id is ignored."""
+        mock_js = MagicMock()
+        mock_js.get_instance_id.return_value = 0
+        handler.joystick = mock_js
+        handler.handle_event(joy_device_removed_event(instance_id=99))
+        assert handler.joystick is mock_js  # unchanged
+
+
+class TestJoystickReset:
+    """Tests for reset clearing joystick state."""
+
+    def test_reset_clears_joy_directions(self, handler) -> None:
+        """reset() clears joy_directions alongside keyboard directions."""
+        handler.joy_directions[Direction.UP] = True
+        assert handler.joy_directions[Direction.UP]
+        handler.reset()
+        assert all(not v for v in handler.joy_directions.values())
+        assert not handler.shoot_pressed


### PR DESCRIPTION
## Summary

- Add gamepad/controller support alongside keyboard controls (closes #121)
- Support both SDL GameController API (Xbox, PlayStation, recognized controllers) and raw joystick API (unrecognized controllers)
- Controller works in all menus (title, pause, options, game over) and during gameplay
- D-pad and left analog stick for movement, A/B buttons to shoot/confirm, Start to pause
- Hot-plug support for connecting/disconnecting controllers during gameplay

## Changes

- **`InputHandler`** — joystick/controller state tracking (`joy_directions`), D-pad (hat + button), analog stick (axis with deadzone), shoot buttons, hot-plug via `JOYDEVICEADDED`/`JOYDEVICEREMOVED`
- **`GameManager`** — `_translate_joy_event()` converts controller events to key constants for menu reuse, event routing for all game states

## Test plan

- [x] 66 new tests (unit + integration) covering both APIs
- [x] All 730 tests passing
- [x] Manually tested with Xbox One Controller on Linux (xpad driver)
- [ ] Verify controller works on title screen, pause menu, options menu
- [ ] Verify keyboard still works when controller is connected
- [ ] Verify game handles controller disconnect gracefully