### PR TITLE
Refactor menu input to use MenuAction enum

### DIFF
--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -31,6 +31,7 @@ from src.utils.constants import (
     GAME_OVER_RISE_DURATION,
     GAME_OVER_HOLD_DURATION,
     MAX_STAGE,
+    MenuAction,
 )
 from src.managers.collision_manager import CollisionManager
 from src.managers.collision_response_handler import CollisionResponseHandler
@@ -38,14 +39,7 @@ from src.managers.effect_manager import EffectManager
 from src.managers.texture_manager import TextureManager
 from src.managers.input_handler import (
     InputHandler,
-    AXIS_DEADZONE,
-    CTRL_DPAD_BUTTONS,
-    DIRECTION_TO_KEY,
-    JOY_SHOOT_BUTTONS,
     JOY_START_BUTTON,
-    JOY_AXIS_X,
-    JOY_AXIS_Y,
-    CTRL_SHOOT_BUTTONS,
     CTRL_START_BUTTON,
 )
 from src.managers.spawn_manager import SpawnManager
@@ -253,115 +247,36 @@ class GameManager:
             elif event.type == pygame.KEYDOWN:
                 if event.key == pygame.K_ESCAPE:
                     self._handle_escape()
-                elif self.state == GameState.TITLE_SCREEN:
-                    self._handle_title_input(event.key)
-                elif self.state == GameState.PAUSED:
-                    self._handle_pause_input(event.key)
-                elif self.state == GameState.OPTIONS_MENU:
-                    self._handle_options_input(event.key)
-                elif event.key == pygame.K_r and self.state in (
-                    GameState.GAME_OVER,
-                    GameState.GAME_COMPLETE,
-                ):
-                    logger.info("R key pressed, returning to title screen.")
-                    self.state = GameState.TITLE_SCREEN
-                    self._title_selection = 0
-
             elif event.type in (
-                pygame.JOYHATMOTION,
-                pygame.JOYAXISMOTION,
-                pygame.JOYBUTTONDOWN,
                 pygame.CONTROLLERBUTTONDOWN,
-                pygame.CONTROLLERAXISMOTION,
+                pygame.JOYBUTTONDOWN,
             ):
-                if self.state != GameState.RUNNING:
-                    translated_key = self._translate_joy_event(event)
-                    if translated_key is not None:
-                        if translated_key == pygame.K_ESCAPE:
-                            self._handle_escape()
-                        elif self.state == GameState.TITLE_SCREEN:
-                            self._handle_title_input(translated_key)
-                        elif self.state == GameState.PAUSED:
-                            self._handle_pause_input(translated_key)
-                        elif self.state == GameState.OPTIONS_MENU:
-                            self._handle_options_input(translated_key)
-                        elif translated_key == pygame.K_RETURN and self.state in (
-                            GameState.GAME_OVER,
-                            GameState.GAME_COMPLETE,
-                        ):
-                            logger.info(
-                                "Controller button pressed, returning to title screen."
-                            )
-                            self.state = GameState.TITLE_SCREEN
-                            self._title_selection = 0
+                if getattr(event, "button", None) in (
+                    CTRL_START_BUTTON,
+                    JOY_START_BUTTON,
+                ):
+                    self._handle_escape()
 
-            # Forward all events to InputHandler during gameplay.
-            # Hot-plug events are forwarded in any state.
-            if self.state == GameState.RUNNING:
-                self.input_handler.handle_event(event)
-            elif event.type in (
-                pygame.JOYDEVICEADDED,
-                pygame.JOYDEVICEREMOVED,
+            self.input_handler.handle_event(event)
+
+        self._process_menu_actions()
+
+    def _process_menu_actions(self) -> None:
+        """Poll and route menu actions from InputHandler."""
+        for action in self.input_handler.consume_menu_actions():
+            if self.state == GameState.TITLE_SCREEN:
+                self._handle_title_input(action)
+            elif self.state == GameState.PAUSED:
+                self._handle_pause_input(action)
+            elif self.state == GameState.OPTIONS_MENU:
+                self._handle_options_input(action)
+            elif action == MenuAction.CONFIRM and self.state in (
+                GameState.GAME_OVER,
+                GameState.GAME_COMPLETE,
             ):
-                self.input_handler.handle_event(event)
-
-    @staticmethod
-    def _axis_to_key(value: float, neg_key: int, pos_key: int) -> Optional[int]:
-        """Translate an axis value to a key constant using deadzone."""
-        if value < -AXIS_DEADZONE:
-            return neg_key
-        elif value > AXIS_DEADZONE:
-            return pos_key
-        return None
-
-    def _translate_joy_event(self, event: pygame.event.Event) -> Optional[int]:
-        """Translate a joystick/controller event to a key constant for menus.
-
-        Handles both SDL GameController events (recognized controllers)
-        and raw joystick events (unrecognized controllers).
-
-        Returns:
-            A pygame key constant, or None if the event has no menu mapping.
-        """
-        if event.type == pygame.CONTROLLERBUTTONDOWN:
-            if event.button in CTRL_DPAD_BUTTONS:
-                return DIRECTION_TO_KEY[CTRL_DPAD_BUTTONS[event.button]]
-            elif event.button in CTRL_SHOOT_BUTTONS:
-                return pygame.K_RETURN
-            elif event.button == CTRL_START_BUTTON:
-                return pygame.K_ESCAPE
-            return None
-
-        elif event.type in (
-            pygame.CONTROLLERAXISMOTION,
-            pygame.JOYAXISMOTION,
-        ):
-            if event.axis in (pygame.CONTROLLER_AXIS_LEFTX, JOY_AXIS_X):
-                return self._axis_to_key(event.value, pygame.K_LEFT, pygame.K_RIGHT)
-            elif event.axis in (pygame.CONTROLLER_AXIS_LEFTY, JOY_AXIS_Y):
-                return self._axis_to_key(event.value, pygame.K_UP, pygame.K_DOWN)
-            return None
-
-        elif event.type == pygame.JOYHATMOTION:
-            hat_x, hat_y = event.value
-            if hat_y > 0:
-                return pygame.K_UP
-            elif hat_y < 0:
-                return pygame.K_DOWN
-            elif hat_x < 0:
-                return pygame.K_LEFT
-            elif hat_x > 0:
-                return pygame.K_RIGHT
-            return None
-
-        elif event.type == pygame.JOYBUTTONDOWN:
-            if event.button in JOY_SHOOT_BUTTONS:
-                return pygame.K_RETURN
-            elif event.button == JOY_START_BUTTON:
-                return pygame.K_ESCAPE
-            return None
-
-        return None
+                logger.info("Returning to title screen.")
+                self.state = GameState.TITLE_SCREEN
+                self._title_selection = 0
 
     def _handle_escape(self) -> None:
         """Handle ESC key based on current state.
@@ -384,21 +299,21 @@ class GameManager:
             else:
                 self.state = GameState.TITLE_SCREEN
 
-    def _handle_title_input(self, key: int) -> None:
-        """Handle keyboard input on the title screen."""
-        if key in (pygame.K_UP, pygame.K_DOWN):
+    def _handle_title_input(self, action: MenuAction) -> None:
+        """Handle menu action on the title screen."""
+        if action in (MenuAction.UP, MenuAction.DOWN):
             indices = self._SELECTABLE_MENU_INDICES
             if self._title_selection in indices:
                 pos = indices.index(self._title_selection)
             else:
                 pos = 0
-            if key == pygame.K_UP:
+            if action == MenuAction.UP:
                 pos = (pos - 1) % len(indices)
             else:
                 pos = (pos + 1) % len(indices)
             self._title_selection = indices[pos]
             self.sound_manager.play_menu_select()
-        elif key == pygame.K_RETURN:
+        elif action == MenuAction.CONFIRM:
             if self._title_selection in (0, 3):
                 self._demo_mode = self._title_selection == 3
                 label = "Demo" if self._demo_mode else "1 Player"
@@ -414,15 +329,15 @@ class GameManager:
             elif self._title_selection == 4:
                 self._quit_game()
 
-    def _handle_pause_input(self, key: int) -> None:
-        """Handle keyboard input on the pause menu."""
-        if key in (pygame.K_UP, pygame.K_DOWN):
-            if key == pygame.K_UP:
+    def _handle_pause_input(self, action: MenuAction) -> None:
+        """Handle menu action on the pause menu."""
+        if action in (MenuAction.UP, MenuAction.DOWN):
+            if action == MenuAction.UP:
                 self._pause_selection = (self._pause_selection - 1) % 4
             else:
                 self._pause_selection = (self._pause_selection + 1) % 4
             self.sound_manager.play_menu_select()
-        elif key == pygame.K_RETURN:
+        elif action == MenuAction.CONFIRM:
             if self._pause_selection == 0:
                 # RESUME
                 self.state = GameState.RUNNING
@@ -440,27 +355,27 @@ class GameManager:
                 # QUIT
                 self._quit_game()
 
-    def _handle_options_input(self, key: int) -> None:
-        """Handle keyboard input on the options menu."""
-        if key in (pygame.K_UP, pygame.K_DOWN):
-            if key == pygame.K_UP:
+    def _handle_options_input(self, action: MenuAction) -> None:
+        """Handle menu action on the options menu."""
+        if action in (MenuAction.UP, MenuAction.DOWN):
+            if action == MenuAction.UP:
                 self._options_selection = (self._options_selection - 1) % 2
             else:
                 self._options_selection = (self._options_selection + 1) % 2
             self.sound_manager.play_menu_select()
-        elif key == pygame.K_LEFT and self._options_selection == 0:
+        elif action == MenuAction.LEFT and self._options_selection == 0:
             self.settings_manager.master_volume = max(
                 0.0, self.settings_manager.master_volume - 0.1
             )
             self.sound_manager.set_master_volume(self.settings_manager.master_volume)
             self.sound_manager.play_menu_select()
-        elif key == pygame.K_RIGHT and self._options_selection == 0:
+        elif action == MenuAction.RIGHT and self._options_selection == 0:
             self.settings_manager.master_volume = min(
                 1.0, self.settings_manager.master_volume + 0.1
             )
             self.sound_manager.set_master_volume(self.settings_manager.master_volume)
             self.sound_manager.play_menu_select()
-        elif key == pygame.K_RETURN:
+        elif action == MenuAction.CONFIRM:
             if self._options_selection == 1:
                 self.settings_manager.save()
                 if self._options_from_pause:

--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -251,10 +251,7 @@ class GameManager:
                 pygame.CONTROLLERBUTTONDOWN,
                 pygame.JOYBUTTONDOWN,
             ):
-                if getattr(event, "button", None) in (
-                    CTRL_START_BUTTON,
-                    JOY_START_BUTTON,
-                ):
+                if event.button in (CTRL_START_BUTTON, JOY_START_BUTTON):
                     self._handle_escape()
 
             self.input_handler.handle_event(event)

--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -256,7 +256,8 @@ class GameManager:
 
             self.input_handler.handle_event(event)
 
-        self._process_menu_actions()
+        if self.state != GameState.RUNNING:
+            self._process_menu_actions()
 
     def _process_menu_actions(self) -> None:
         """Poll and route menu actions from InputHandler."""

--- a/src/managers/input_handler.py
+++ b/src/managers/input_handler.py
@@ -33,14 +33,6 @@ _DIRECTION_TO_MENU_ACTION: dict[Direction, MenuAction] = {
 
 _CONFIRM_KEYS: tuple[int, ...] = (pygame.K_RETURN, pygame.K_r)
 
-# Direction → pygame key constant (kept for GameManager backward compatibility)
-DIRECTION_TO_KEY: dict[Direction, int] = {
-    Direction.UP: pygame.K_UP,
-    Direction.DOWN: pygame.K_DOWN,
-    Direction.LEFT: pygame.K_LEFT,
-    Direction.RIGHT: pygame.K_RIGHT,
-}
-
 
 class InputHandler:
     """Handles keyboard and controller input for the player tank."""

--- a/src/managers/input_handler.py
+++ b/src/managers/input_handler.py
@@ -63,10 +63,8 @@ class InputHandler:
         self.joystick: Optional["pygame.joystick.JoystickType"] = None
         self._init_joystick()
         self._menu_actions: list[MenuAction] = []
-        self._axis_menu_state: dict[str, Optional[MenuAction]] = {
-            "horizontal": None,
-            "vertical": None,
-        }
+        self._axis_menu_h: Optional[MenuAction] = None
+        self._axis_menu_v: Optional[MenuAction] = None
 
     def _init_joystick(self) -> None:
         """Detect and initialize the first connected joystick."""
@@ -77,7 +75,7 @@ class InputHandler:
 
     def _emit_axis_menu_action(
         self,
-        axis_key: str,
+        horizontal: bool,
         value: float,
         neg_action: MenuAction,
         pos_action: MenuAction,
@@ -89,9 +87,12 @@ class InputHandler:
             new_state = pos_action
         else:
             new_state = None
-        prev_state = self._axis_menu_state[axis_key]
+        prev_state = self._axis_menu_h if horizontal else self._axis_menu_v
         if new_state != prev_state:
-            self._axis_menu_state[axis_key] = new_state
+            if horizontal:
+                self._axis_menu_h = new_state
+            else:
+                self._axis_menu_v = new_state
             if new_state is not None:
                 self._menu_actions.append(new_state)
 
@@ -175,31 +176,31 @@ class InputHandler:
             if event.axis in (pygame.CONTROLLER_AXIS_LEFTX, JOY_AXIS_X):
                 self._handle_axis(event.value, Direction.LEFT, Direction.RIGHT)
                 self._emit_axis_menu_action(
-                    "horizontal", event.value, MenuAction.LEFT, MenuAction.RIGHT
+                    True, event.value, MenuAction.LEFT, MenuAction.RIGHT
                 )
             elif event.axis in (pygame.CONTROLLER_AXIS_LEFTY, JOY_AXIS_Y):
                 self._handle_axis(event.value, Direction.UP, Direction.DOWN)
                 self._emit_axis_menu_action(
-                    "vertical", event.value, MenuAction.UP, MenuAction.DOWN
+                    False, event.value, MenuAction.UP, MenuAction.DOWN
                 )
 
         # --- Raw joystick API (unrecognized controllers) ---
         elif event.type == pygame.JOYHATMOTION:
             hat_x, hat_y = event.value
-            for direction in self.joy_directions:
-                self.joy_directions[direction] = False
+            for d in self.joy_directions:
+                self.joy_directions[d] = False
+            hat_dir: Optional[Direction] = None
             if hat_y > 0:
-                self.joy_directions[Direction.UP] = True
-                self._menu_actions.append(MenuAction.UP)
+                hat_dir = Direction.UP
             elif hat_y < 0:
-                self.joy_directions[Direction.DOWN] = True
-                self._menu_actions.append(MenuAction.DOWN)
+                hat_dir = Direction.DOWN
             elif hat_x > 0:
-                self.joy_directions[Direction.RIGHT] = True
-                self._menu_actions.append(MenuAction.RIGHT)
+                hat_dir = Direction.RIGHT
             elif hat_x < 0:
-                self.joy_directions[Direction.LEFT] = True
-                self._menu_actions.append(MenuAction.LEFT)
+                hat_dir = Direction.LEFT
+            if hat_dir is not None:
+                self.joy_directions[hat_dir] = True
+                self._menu_actions.append(_DIRECTION_TO_MENU_ACTION[hat_dir])
         elif event.type == pygame.JOYBUTTONDOWN:
             if event.button in JOY_SHOOT_BUTTONS:
                 self.shoot_pressed = True
@@ -235,11 +236,14 @@ class InputHandler:
         for direction in self.joy_directions:
             self.joy_directions[direction] = False
         self.shoot_pressed = False
-        self._menu_actions = []
-        self._axis_menu_state = {"horizontal": None, "vertical": None}
+        self._menu_actions.clear()
+        self._axis_menu_h = None
+        self._axis_menu_v = None
 
     def consume_menu_actions(self) -> list[MenuAction]:
         """Return pending menu actions and clear the list."""
+        if not self._menu_actions:
+            return []
         actions = self._menu_actions
         self._menu_actions = []
         return actions

--- a/src/managers/input_handler.py
+++ b/src/managers/input_handler.py
@@ -1,7 +1,7 @@
 import pygame
 from typing import Tuple, Dict, Optional
 from loguru import logger
-from src.utils.constants import Direction
+from src.utils.constants import Direction, MenuAction
 
 AXIS_DEADZONE: float = 0.5
 
@@ -24,7 +24,16 @@ CTRL_SHOOT_BUTTONS: tuple[int, ...] = (
 )
 CTRL_START_BUTTON: int = pygame.CONTROLLER_BUTTON_START
 
-# Direction → pygame key constant (used by GameManager for menu translation)
+_DIRECTION_TO_MENU_ACTION: dict[Direction, MenuAction] = {
+    Direction.UP: MenuAction.UP,
+    Direction.DOWN: MenuAction.DOWN,
+    Direction.LEFT: MenuAction.LEFT,
+    Direction.RIGHT: MenuAction.RIGHT,
+}
+
+_CONFIRM_KEYS: tuple[int, ...] = (pygame.K_RETURN, pygame.K_r)
+
+# Direction → pygame key constant (kept for GameManager backward compatibility)
 DIRECTION_TO_KEY: dict[Direction, int] = {
     Direction.UP: pygame.K_UP,
     Direction.DOWN: pygame.K_DOWN,
@@ -61,6 +70,11 @@ class InputHandler:
         }
         self.joystick: Optional["pygame.joystick.JoystickType"] = None
         self._init_joystick()
+        self._menu_actions: list[MenuAction] = []
+        self._axis_menu_state: dict[str, Optional[MenuAction]] = {
+            "horizontal": None,
+            "vertical": None,
+        }
 
     def _init_joystick(self) -> None:
         """Detect and initialize the first connected joystick."""
@@ -68,6 +82,26 @@ class InputHandler:
             self.joystick = pygame.joystick.Joystick(0)
             self.joystick.init()
             logger.info(f"Joystick connected: {self.joystick.get_name()}")
+
+    def _emit_axis_menu_action(
+        self,
+        axis_key: str,
+        value: float,
+        neg_action: MenuAction,
+        pos_action: MenuAction,
+    ) -> None:
+        """Emit a menu action when an axis crosses the deadzone threshold."""
+        if value < -AXIS_DEADZONE:
+            new_state = neg_action
+        elif value > AXIS_DEADZONE:
+            new_state = pos_action
+        else:
+            new_state = None
+        prev_state = self._axis_menu_state[axis_key]
+        if new_state != prev_state:
+            self._axis_menu_state[axis_key] = new_state
+            if new_state is not None:
+                self._menu_actions.append(new_state)
 
     def _handle_axis(
         self, value: float, neg_dir: Direction, pos_dir: Direction
@@ -100,8 +134,11 @@ class InputHandler:
                 if not self.directions[direction]:
                     logger.trace(f"Key down: {direction}")
                     self.directions[direction] = True
+                self._menu_actions.append(_DIRECTION_TO_MENU_ACTION[direction])
             if event.key == self.shoot_key:
                 self.shoot_pressed = True
+            if event.key in _CONFIRM_KEYS:
+                self._menu_actions.append(MenuAction.CONFIRM)
         elif event.type == pygame.KEYUP:
             if event.key in self.key_mappings:
                 direction = self.key_mappings[event.key]
@@ -132,8 +169,10 @@ class InputHandler:
                 for d in self.joy_directions:
                     self.joy_directions[d] = False
                 self.joy_directions[direction] = True
+                self._menu_actions.append(_DIRECTION_TO_MENU_ACTION[direction])
             elif event.button in CTRL_SHOOT_BUTTONS:
                 self.shoot_pressed = True
+                self._menu_actions.append(MenuAction.CONFIRM)
         elif event.type == pygame.CONTROLLERBUTTONUP:
             if event.button in CTRL_DPAD_BUTTONS:
                 direction = CTRL_DPAD_BUTTONS[event.button]
@@ -143,8 +182,14 @@ class InputHandler:
         elif event.type in (pygame.CONTROLLERAXISMOTION, pygame.JOYAXISMOTION):
             if event.axis in (pygame.CONTROLLER_AXIS_LEFTX, JOY_AXIS_X):
                 self._handle_axis(event.value, Direction.LEFT, Direction.RIGHT)
+                self._emit_axis_menu_action(
+                    "horizontal", event.value, MenuAction.LEFT, MenuAction.RIGHT
+                )
             elif event.axis in (pygame.CONTROLLER_AXIS_LEFTY, JOY_AXIS_Y):
                 self._handle_axis(event.value, Direction.UP, Direction.DOWN)
+                self._emit_axis_menu_action(
+                    "vertical", event.value, MenuAction.UP, MenuAction.DOWN
+                )
 
         # --- Raw joystick API (unrecognized controllers) ---
         elif event.type == pygame.JOYHATMOTION:
@@ -153,15 +198,20 @@ class InputHandler:
                 self.joy_directions[direction] = False
             if hat_y > 0:
                 self.joy_directions[Direction.UP] = True
+                self._menu_actions.append(MenuAction.UP)
             elif hat_y < 0:
                 self.joy_directions[Direction.DOWN] = True
+                self._menu_actions.append(MenuAction.DOWN)
             elif hat_x > 0:
                 self.joy_directions[Direction.RIGHT] = True
+                self._menu_actions.append(MenuAction.RIGHT)
             elif hat_x < 0:
                 self.joy_directions[Direction.LEFT] = True
+                self._menu_actions.append(MenuAction.LEFT)
         elif event.type == pygame.JOYBUTTONDOWN:
             if event.button in JOY_SHOOT_BUTTONS:
                 self.shoot_pressed = True
+                self._menu_actions.append(MenuAction.CONFIRM)
 
     def get_movement_direction(self) -> Tuple[int, int]:
         """
@@ -193,6 +243,14 @@ class InputHandler:
         for direction in self.joy_directions:
             self.joy_directions[direction] = False
         self.shoot_pressed = False
+        self._menu_actions = []
+        self._axis_menu_state = {"horizontal": None, "vertical": None}
+
+    def consume_menu_actions(self) -> list[MenuAction]:
+        """Return pending menu actions and clear the list."""
+        actions = self._menu_actions
+        self._menu_actions = []
+        return actions
 
     def consume_shoot(self) -> bool:
         """

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -69,6 +69,14 @@ ENEMY_POINTS: dict[TankType, int] = {
 }
 
 
+class MenuAction(Enum):
+    UP = auto()
+    DOWN = auto()
+    LEFT = auto()
+    RIGHT = auto()
+    CONFIRM = auto()
+
+
 class EffectType(Enum):
     SMALL_EXPLOSION = auto()
     LARGE_EXPLOSION = auto()

--- a/tests/integration/test_controller.py
+++ b/tests/integration/test_controller.py
@@ -113,8 +113,10 @@ class TestControllerMenuNavigation:
             pygame.CONTROLLERBUTTONDOWN,
             button=pygame.CONTROLLER_BUTTON_DPAD_DOWN,
         )
-        translated = gm._translate_joy_event(event)
-        gm._handle_title_input(translated)
+        gm.input_handler.handle_event(event)
+        actions = gm.input_handler.consume_menu_actions()
+        for action in actions:
+            gm._handle_title_input(action)
 
         assert gm._title_selection != initial_selection
 
@@ -127,7 +129,9 @@ class TestControllerMenuNavigation:
             pygame.CONTROLLERBUTTONDOWN,
             button=pygame.CONTROLLER_BUTTON_A,
         )
-        translated = gm._translate_joy_event(event)
-        gm._handle_title_input(translated)
+        gm.input_handler.handle_event(event)
+        actions = gm.input_handler.consume_menu_actions()
+        for action in actions:
+            gm._handle_title_input(action)
 
         assert gm.state != GameState.TITLE_SCREEN

--- a/tests/integration/test_controller.py
+++ b/tests/integration/test_controller.py
@@ -135,3 +135,15 @@ class TestControllerMenuNavigation:
             gm._handle_title_input(action)
 
         assert gm.state != GameState.TITLE_SCREEN
+
+    def test_keyboard_r_returns_from_game_over(self) -> None:
+        """Keyboard R produces MenuAction.CONFIRM in Game Over."""
+        gm = GameManager()
+        gm._reset_game()
+        gm.state = GameState.GAME_OVER
+
+        event = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_r)
+        gm.input_handler.handle_event(event)
+        gm._process_menu_actions()
+
+        assert gm.state == GameState.TITLE_SCREEN

--- a/tests/integration/test_controller.py
+++ b/tests/integration/test_controller.py
@@ -109,14 +109,13 @@ class TestControllerMenuNavigation:
         gm = GameManager()
         initial_selection = gm._title_selection
 
-        event = pygame.event.Event(
-            pygame.CONTROLLERBUTTONDOWN,
-            button=pygame.CONTROLLER_BUTTON_DPAD_DOWN,
+        pygame.event.post(
+            pygame.event.Event(
+                pygame.CONTROLLERBUTTONDOWN,
+                button=pygame.CONTROLLER_BUTTON_DPAD_DOWN,
+            )
         )
-        gm.input_handler.handle_event(event)
-        actions = gm.input_handler.consume_menu_actions()
-        for action in actions:
-            gm._handle_title_input(action)
+        gm.handle_events()
 
         assert gm._title_selection != initial_selection
 
@@ -125,25 +124,23 @@ class TestControllerMenuNavigation:
         gm = GameManager()
         gm._title_selection = 0  # 1 Player
 
-        event = pygame.event.Event(
-            pygame.CONTROLLERBUTTONDOWN,
-            button=pygame.CONTROLLER_BUTTON_A,
+        pygame.event.post(
+            pygame.event.Event(
+                pygame.CONTROLLERBUTTONDOWN,
+                button=pygame.CONTROLLER_BUTTON_A,
+            )
         )
-        gm.input_handler.handle_event(event)
-        actions = gm.input_handler.consume_menu_actions()
-        for action in actions:
-            gm._handle_title_input(action)
+        gm.handle_events()
 
         assert gm.state != GameState.TITLE_SCREEN
 
     def test_keyboard_r_returns_from_game_over(self) -> None:
-        """Keyboard R produces MenuAction.CONFIRM in Game Over."""
+        """Keyboard R returns to title from Game Over."""
         gm = GameManager()
         gm._reset_game()
         gm.state = GameState.GAME_OVER
 
-        event = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_r)
-        gm.input_handler.handle_event(event)
-        gm._process_menu_actions()
+        pygame.event.post(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_r))
+        gm.handle_events()
 
         assert gm.state == GameState.TITLE_SCREEN

--- a/tests/unit/managers/test_game_manager.py
+++ b/tests/unit/managers/test_game_manager.py
@@ -4,7 +4,7 @@ from unittest.mock import patch, MagicMock
 from src.managers.game_manager import GameManager
 from src.states.game_state import GameState
 from src.core.enemy_tank import EnemyTank
-from src.utils.constants import MAX_STAGE, VICTORY_PAUSE_DURATION
+from src.utils.constants import MAX_STAGE, MenuAction, VICTORY_PAUSE_DURATION
 
 
 class TestGameManager:
@@ -101,11 +101,14 @@ class TestGameManager:
         game_manager.handle_events()
         assert game_manager.state == GameState.VICTORY
 
-    def test_title_screen_r_does_nothing(self, game_manager_at_title, key_down_event):
-        """Test that R key does nothing on title screen."""
+    def test_title_screen_r_confirms_selection(
+        self, game_manager_at_title, key_down_event
+    ):
+        """Test that R key acts as CONFIRM on title screen."""
+        game_manager_at_title._title_selection = 0
         pygame.event.post(key_down_event(pygame.K_r))
         game_manager_at_title.handle_events()
-        assert game_manager_at_title.state == GameState.TITLE_SCREEN
+        assert game_manager_at_title.state == GameState.STAGE_CURTAIN_CLOSE
 
     def test_handle_events_quit(self, game_manager):
         """Test handling quit event sets state to EXIT."""
@@ -174,150 +177,79 @@ class TestGameManager:
         game_manager.spawn_manager.update.assert_not_called()
         game_manager.collision_response_handler.process_collisions.assert_not_called()
 
-    class TestControllerMenuInput:
-        """Tests for controller input in menus."""
+    class TestMenuActionHandlers:
+        """Tests for menu handlers accepting MenuAction."""
 
-        def test_translate_hat_up(self, game_manager):
-            """Hat UP translates to K_UP."""
-            event = pygame.event.Event(
-                pygame.JOYHATMOTION, value=(0, 1), hat=0, instance_id=0
-            )
-            assert game_manager._translate_joy_event(event) == pygame.K_UP
+        def test_title_input_down(self, game_manager_at_title):
+            """MenuAction.DOWN navigates title screen down."""
+            gm = game_manager_at_title
+            gm._title_selection = 2
+            gm._handle_title_input(MenuAction.DOWN)
+            assert gm._title_selection == 3
 
-        def test_translate_hat_down(self, game_manager):
-            """Hat DOWN translates to K_DOWN."""
-            event = pygame.event.Event(
-                pygame.JOYHATMOTION, value=(0, -1), hat=0, instance_id=0
-            )
-            assert game_manager._translate_joy_event(event) == pygame.K_DOWN
+        def test_title_input_confirm(self, game_manager_at_title):
+            """MenuAction.CONFIRM starts the game."""
+            gm = game_manager_at_title
+            gm._title_selection = 0
+            gm._handle_title_input(MenuAction.CONFIRM)
+            assert gm.state == GameState.STAGE_CURTAIN_CLOSE
 
-        def test_translate_hat_left(self, game_manager):
-            """Hat LEFT translates to K_LEFT."""
-            event = pygame.event.Event(
-                pygame.JOYHATMOTION, value=(-1, 0), hat=0, instance_id=0
-            )
-            assert game_manager._translate_joy_event(event) == pygame.K_LEFT
+        def test_pause_input_down(self, game_manager):
+            """MenuAction.DOWN navigates pause menu."""
+            game_manager.state = GameState.PAUSED
+            game_manager._pause_selection = 0
+            game_manager._handle_pause_input(MenuAction.DOWN)
+            assert game_manager._pause_selection == 1
 
-        def test_translate_hat_right(self, game_manager):
-            """Hat RIGHT translates to K_RIGHT."""
-            event = pygame.event.Event(
-                pygame.JOYHATMOTION, value=(1, 0), hat=0, instance_id=0
-            )
-            assert game_manager._translate_joy_event(event) == pygame.K_RIGHT
+        def test_pause_input_confirm_resume(self, game_manager):
+            """MenuAction.CONFIRM on Resume resumes game."""
+            game_manager.state = GameState.PAUSED
+            game_manager._pause_selection = 0
+            game_manager._handle_pause_input(MenuAction.CONFIRM)
+            assert game_manager.state == GameState.RUNNING
 
-        def test_translate_hat_neutral_returns_none(self, game_manager):
-            """Hat (0,0) returns None."""
-            event = pygame.event.Event(
-                pygame.JOYHATMOTION, value=(0, 0), hat=0, instance_id=0
-            )
-            assert game_manager._translate_joy_event(event) is None
+        def test_options_input_right(self, game_manager):
+            """MenuAction.RIGHT increases volume."""
+            game_manager.state = GameState.OPTIONS_MENU
+            game_manager._options_selection = 0
+            game_manager.settings_manager.master_volume = 0.5
+            initial_vol = game_manager.settings_manager.master_volume
+            game_manager._handle_options_input(MenuAction.RIGHT)
+            assert game_manager.settings_manager.master_volume > initial_vol
 
-        def test_translate_button_0_confirm(self, game_manager):
-            """Button 0 translates to K_RETURN."""
-            event = pygame.event.Event(pygame.JOYBUTTONDOWN, button=0, instance_id=0)
-            assert game_manager._translate_joy_event(event) == pygame.K_RETURN
+        def test_options_input_confirm_back(self, game_manager):
+            """MenuAction.CONFIRM on Back returns to previous screen."""
+            game_manager.state = GameState.OPTIONS_MENU
+            game_manager._options_selection = 1
+            game_manager._options_from_pause = False
+            game_manager._handle_options_input(MenuAction.CONFIRM)
+            assert game_manager.state == GameState.TITLE_SCREEN
 
-        def test_translate_button_1_confirm(self, game_manager):
-            """Button 1 translates to K_RETURN."""
-            event = pygame.event.Event(pygame.JOYBUTTONDOWN, button=1, instance_id=0)
-            assert game_manager._translate_joy_event(event) == pygame.K_RETURN
+        def test_game_over_confirm(self, game_manager):
+            """MenuAction.CONFIRM in GAME_OVER returns to title."""
+            game_manager.state = GameState.GAME_OVER
+            game_manager.input_handler._menu_actions = [MenuAction.CONFIRM]
+            game_manager._process_menu_actions()
+            assert game_manager.state == GameState.TITLE_SCREEN
 
-        def test_translate_start_button(self, game_manager):
-            """Button 7 (Start) translates to K_ESCAPE."""
-            event = pygame.event.Event(pygame.JOYBUTTONDOWN, button=7, instance_id=0)
-            assert game_manager._translate_joy_event(event) == pygame.K_ESCAPE
-
-        def test_translate_axis_up(self, game_manager):
-            """Axis 1 negative (up) translates to K_UP."""
-            event = pygame.event.Event(
-                pygame.JOYAXISMOTION, axis=1, value=-0.8, instance_id=0
-            )
-            assert game_manager._translate_joy_event(event) == pygame.K_UP
-
-        def test_translate_axis_down(self, game_manager):
-            """Axis 1 positive (down) translates to K_DOWN."""
-            event = pygame.event.Event(
-                pygame.JOYAXISMOTION, axis=1, value=0.8, instance_id=0
-            )
-            assert game_manager._translate_joy_event(event) == pygame.K_DOWN
-
-        def test_translate_axis_left(self, game_manager):
-            """Axis 0 negative (left) translates to K_LEFT."""
-            event = pygame.event.Event(
-                pygame.JOYAXISMOTION, axis=0, value=-0.8, instance_id=0
-            )
-            assert game_manager._translate_joy_event(event) == pygame.K_LEFT
-
-        def test_translate_axis_right(self, game_manager):
-            """Axis 0 positive (right) translates to K_RIGHT."""
-            event = pygame.event.Event(
-                pygame.JOYAXISMOTION, axis=0, value=0.8, instance_id=0
-            )
-            assert game_manager._translate_joy_event(event) == pygame.K_RIGHT
-
-        def test_translate_axis_deadzone(self, game_manager):
-            """Axis within deadzone returns None."""
-            event = pygame.event.Event(
-                pygame.JOYAXISMOTION, axis=0, value=0.3, instance_id=0
-            )
-            assert game_manager._translate_joy_event(event) is None
-
-        def test_translate_unmapped_button(self, game_manager):
-            """Unmapped button returns None."""
-            event = pygame.event.Event(pygame.JOYBUTTONDOWN, button=5, instance_id=0)
-            assert game_manager._translate_joy_event(event) is None
-
-        # --- SDL GameController API tests ---
-
-        def test_translate_ctrl_dpad_up(self, game_manager):
-            """Controller D-pad UP translates to K_UP."""
-            event = pygame.event.Event(
-                pygame.CONTROLLERBUTTONDOWN,
-                button=pygame.CONTROLLER_BUTTON_DPAD_UP,
-            )
-            assert game_manager._translate_joy_event(event) == pygame.K_UP
-
-        def test_translate_ctrl_dpad_down(self, game_manager):
-            """Controller D-pad DOWN translates to K_DOWN."""
-            event = pygame.event.Event(
-                pygame.CONTROLLERBUTTONDOWN,
-                button=pygame.CONTROLLER_BUTTON_DPAD_DOWN,
-            )
-            assert game_manager._translate_joy_event(event) == pygame.K_DOWN
-
-        def test_translate_ctrl_a_confirm(self, game_manager):
-            """Controller A button translates to K_RETURN."""
-            event = pygame.event.Event(
-                pygame.CONTROLLERBUTTONDOWN,
-                button=pygame.CONTROLLER_BUTTON_A,
-            )
-            assert game_manager._translate_joy_event(event) == pygame.K_RETURN
-
-        def test_translate_ctrl_start(self, game_manager):
-            """Controller Start button translates to K_ESCAPE."""
+        def test_start_button_triggers_escape(self, game_manager):
+            """Controller Start button triggers _handle_escape."""
+            game_manager.state = GameState.RUNNING
             event = pygame.event.Event(
                 pygame.CONTROLLERBUTTONDOWN,
                 button=pygame.CONTROLLER_BUTTON_START,
             )
-            assert game_manager._translate_joy_event(event) == pygame.K_ESCAPE
+            pygame.event.post(event)
+            game_manager.handle_events()
+            assert game_manager.state == GameState.PAUSED
 
-        def test_translate_ctrl_axis_up(self, game_manager):
-            """Controller left stick up translates to K_UP."""
-            event = pygame.event.Event(
-                pygame.CONTROLLERAXISMOTION,
-                axis=pygame.CONTROLLER_AXIS_LEFTY,
-                value=-0.8,
-            )
-            assert game_manager._translate_joy_event(event) == pygame.K_UP
-
-        def test_translate_ctrl_axis_deadzone(self, game_manager):
-            """Controller axis within deadzone returns None."""
-            event = pygame.event.Event(
-                pygame.CONTROLLERAXISMOTION,
-                axis=pygame.CONTROLLER_AXIS_LEFTX,
-                value=0.3,
-            )
-            assert game_manager._translate_joy_event(event) is None
+        def test_joy_start_button_triggers_escape(self, game_manager):
+            """Raw joystick Start button triggers _handle_escape."""
+            game_manager.state = GameState.RUNNING
+            event = pygame.event.Event(pygame.JOYBUTTONDOWN, button=7, instance_id=0)
+            pygame.event.post(event)
+            game_manager.handle_events()
+            assert game_manager.state == GameState.PAUSED
 
 
 class TestGameManagerSoundWiring:
@@ -393,7 +325,7 @@ class TestGameManagerSoundWiring:
     def test_handle_title_input_plays_menu_select(self, game_manager_at_title):
         gm = game_manager_at_title
         gm.sound_manager = MagicMock()
-        gm._handle_title_input(pygame.K_DOWN)
+        gm._handle_title_input(MenuAction.DOWN)
         gm.sound_manager.play_menu_select.assert_called()
 
 

--- a/tests/unit/managers/test_input_handler.py
+++ b/tests/unit/managers/test_input_handler.py
@@ -2,7 +2,7 @@ import pytest
 import pygame
 from unittest.mock import patch, MagicMock
 from src.managers.input_handler import InputHandler
-from src.utils.constants import Direction
+from src.utils.constants import Direction, MenuAction
 
 
 @pytest.fixture
@@ -488,3 +488,214 @@ class TestControllerAxis:
         handler.handle_event(ctrl_axis_event(pygame.CONTROLLER_AXIS_LEFTX, 0.3))
         assert not handler.joy_directions[Direction.RIGHT]
         assert not handler.joy_directions[Direction.LEFT]
+
+
+class TestMenuActions:
+    """Tests for keyboard menu action production."""
+
+    def test_key_up_produces_menu_up(self, handler, key_down_event) -> None:
+        """K_UP produces MenuAction.UP."""
+        handler.handle_event(key_down_event(pygame.K_UP))
+        assert handler.consume_menu_actions() == [MenuAction.UP]
+
+    def test_key_down_produces_menu_down(self, handler, key_down_event) -> None:
+        """K_DOWN produces MenuAction.DOWN."""
+        handler.handle_event(key_down_event(pygame.K_DOWN))
+        assert handler.consume_menu_actions() == [MenuAction.DOWN]
+
+    def test_key_left_produces_menu_left(self, handler, key_down_event) -> None:
+        """K_LEFT produces MenuAction.LEFT."""
+        handler.handle_event(key_down_event(pygame.K_LEFT))
+        assert handler.consume_menu_actions() == [MenuAction.LEFT]
+
+    def test_key_right_produces_menu_right(self, handler, key_down_event) -> None:
+        """K_RIGHT produces MenuAction.RIGHT."""
+        handler.handle_event(key_down_event(pygame.K_RIGHT))
+        assert handler.consume_menu_actions() == [MenuAction.RIGHT]
+
+    def test_key_return_produces_confirm(self, handler, key_down_event) -> None:
+        """K_RETURN produces MenuAction.CONFIRM."""
+        handler.handle_event(key_down_event(pygame.K_RETURN))
+        assert handler.consume_menu_actions() == [MenuAction.CONFIRM]
+
+    def test_key_r_produces_confirm(self, handler, key_down_event) -> None:
+        """K_r produces MenuAction.CONFIRM."""
+        handler.handle_event(key_down_event(pygame.K_r))
+        assert handler.consume_menu_actions() == [MenuAction.CONFIRM]
+
+    def test_consume_clears_list(self, handler, key_down_event) -> None:
+        """Second call to consume_menu_actions returns empty list."""
+        handler.handle_event(key_down_event(pygame.K_UP))
+        handler.consume_menu_actions()
+        assert handler.consume_menu_actions() == []
+
+    def test_multiple_actions_preserved(self, handler, key_down_event) -> None:
+        """Multiple actions accumulated before consume are returned in order."""
+        handler.handle_event(key_down_event(pygame.K_DOWN))
+        handler.handle_event(key_down_event(pygame.K_RETURN))
+        assert handler.consume_menu_actions() == [MenuAction.DOWN, MenuAction.CONFIRM]
+
+    def test_key_repeat_produces_multiple(self, handler, key_down_event) -> None:
+        """Each KEYDOWN event (including repeats) produces a MenuAction."""
+        event = key_down_event(pygame.K_UP)
+        handler.handle_event(event)
+        handler.handle_event(event)
+        handler.handle_event(event)
+        assert handler.consume_menu_actions() == [
+            MenuAction.UP,
+            MenuAction.UP,
+            MenuAction.UP,
+        ]
+
+    def test_reset_clears_menu_actions(self, handler, key_down_event) -> None:
+        """reset() clears pending menu actions."""
+        handler.handle_event(key_down_event(pygame.K_UP))
+        handler.reset()
+        assert handler.consume_menu_actions() == []
+
+
+class TestMenuActionsController:
+    """Tests for controller menu action production."""
+
+    def test_dpad_up_produces_menu_up(self, handler, ctrl_button_down_event) -> None:
+        """Controller D-pad UP produces MenuAction.UP."""
+        handler.handle_event(ctrl_button_down_event(pygame.CONTROLLER_BUTTON_DPAD_UP))
+        assert MenuAction.UP in handler.consume_menu_actions()
+
+    def test_dpad_down_produces_menu_down(
+        self, handler, ctrl_button_down_event
+    ) -> None:
+        """Controller D-pad DOWN produces MenuAction.DOWN."""
+        handler.handle_event(ctrl_button_down_event(pygame.CONTROLLER_BUTTON_DPAD_DOWN))
+        assert MenuAction.DOWN in handler.consume_menu_actions()
+
+    def test_dpad_left_produces_menu_left(
+        self, handler, ctrl_button_down_event
+    ) -> None:
+        """Controller D-pad LEFT produces MenuAction.LEFT."""
+        handler.handle_event(ctrl_button_down_event(pygame.CONTROLLER_BUTTON_DPAD_LEFT))
+        assert MenuAction.LEFT in handler.consume_menu_actions()
+
+    def test_dpad_right_produces_menu_right(
+        self, handler, ctrl_button_down_event
+    ) -> None:
+        """Controller D-pad RIGHT produces MenuAction.RIGHT."""
+        handler.handle_event(
+            ctrl_button_down_event(pygame.CONTROLLER_BUTTON_DPAD_RIGHT)
+        )
+        assert MenuAction.RIGHT in handler.consume_menu_actions()
+
+    def test_a_button_produces_confirm(self, handler, ctrl_button_down_event) -> None:
+        """Controller A button produces MenuAction.CONFIRM."""
+        handler.handle_event(ctrl_button_down_event(pygame.CONTROLLER_BUTTON_A))
+        assert MenuAction.CONFIRM in handler.consume_menu_actions()
+
+    def test_b_button_produces_confirm(self, handler, ctrl_button_down_event) -> None:
+        """Controller B button produces MenuAction.CONFIRM."""
+        handler.handle_event(ctrl_button_down_event(pygame.CONTROLLER_BUTTON_B))
+        assert MenuAction.CONFIRM in handler.consume_menu_actions()
+
+    def test_joy_hat_up_produces_menu_up(self, handler, joy_hat_event) -> None:
+        """Raw joystick hat UP produces MenuAction.UP."""
+        handler.handle_event(joy_hat_event((0, 1)))
+        assert MenuAction.UP in handler.consume_menu_actions()
+
+    def test_joy_hat_down_produces_menu_down(self, handler, joy_hat_event) -> None:
+        """Raw joystick hat DOWN produces MenuAction.DOWN."""
+        handler.handle_event(joy_hat_event((0, -1)))
+        assert MenuAction.DOWN in handler.consume_menu_actions()
+
+    def test_joy_hat_left_produces_menu_left(self, handler, joy_hat_event) -> None:
+        """Raw joystick hat LEFT produces MenuAction.LEFT."""
+        handler.handle_event(joy_hat_event((-1, 0)))
+        assert MenuAction.LEFT in handler.consume_menu_actions()
+
+    def test_joy_hat_right_produces_menu_right(self, handler, joy_hat_event) -> None:
+        """Raw joystick hat RIGHT produces MenuAction.RIGHT."""
+        handler.handle_event(joy_hat_event((1, 0)))
+        assert MenuAction.RIGHT in handler.consume_menu_actions()
+
+    def test_joy_button_0_produces_confirm(
+        self, handler, joy_button_down_event
+    ) -> None:
+        """Raw joystick button 0 produces MenuAction.CONFIRM."""
+        handler.handle_event(joy_button_down_event(button=0))
+        assert MenuAction.CONFIRM in handler.consume_menu_actions()
+
+    def test_joy_button_1_produces_confirm(
+        self, handler, joy_button_down_event
+    ) -> None:
+        """Raw joystick button 1 produces MenuAction.CONFIRM."""
+        handler.handle_event(joy_button_down_event(button=1))
+        assert MenuAction.CONFIRM in handler.consume_menu_actions()
+
+    def test_ctrl_button_up_produces_no_menu_action(
+        self, handler, ctrl_button_down_event, ctrl_button_up_event
+    ) -> None:
+        """Releasing a controller button does not produce a menu action."""
+        handler.handle_event(ctrl_button_down_event(pygame.CONTROLLER_BUTTON_DPAD_UP))
+        handler.consume_menu_actions()  # clear press action
+        handler.handle_event(ctrl_button_up_event(pygame.CONTROLLER_BUTTON_DPAD_UP))
+        assert handler.consume_menu_actions() == []
+
+
+class TestMenuActionsAxisEdgeDetection:
+    """Tests for analog stick menu action edge detection."""
+
+    def test_axis_crossing_deadzone_produces_action(
+        self, handler, joy_axis_event
+    ) -> None:
+        """Axis crossing the deadzone threshold produces a MenuAction."""
+        handler.handle_event(joy_axis_event(axis=0, value=-0.8))
+        assert MenuAction.LEFT in handler.consume_menu_actions()
+
+    def test_axis_held_does_not_repeat(self, handler, joy_axis_event) -> None:
+        """Axis held beyond deadzone does not emit repeated MenuActions."""
+        handler.handle_event(joy_axis_event(axis=0, value=-0.8))
+        handler.consume_menu_actions()  # clear initial action
+        handler.handle_event(joy_axis_event(axis=0, value=-0.9))  # still beyond DZ
+        assert handler.consume_menu_actions() == []
+
+    def test_axis_return_to_center_no_action(self, handler, joy_axis_event) -> None:
+        """Axis returning within deadzone resets state and emits no action."""
+        handler.handle_event(joy_axis_event(axis=0, value=-0.8))
+        handler.consume_menu_actions()
+        handler.handle_event(joy_axis_event(axis=0, value=0.1))
+        assert handler.consume_menu_actions() == []
+
+    def test_axis_direction_change_produces_new_action(
+        self, handler, joy_axis_event
+    ) -> None:
+        """Axis flipping direction without returning to center still emits."""
+        handler.handle_event(joy_axis_event(axis=0, value=-0.8))
+        handler.consume_menu_actions()
+        handler.handle_event(joy_axis_event(axis=0, value=0.9))
+        assert MenuAction.RIGHT in handler.consume_menu_actions()
+
+    def test_ctrl_axis_uses_edge_detection(self, handler, ctrl_axis_event) -> None:
+        """SDL GameController axis also uses edge detection."""
+        handler.handle_event(ctrl_axis_event(pygame.CONTROLLER_AXIS_LEFTX, -0.8))
+        assert MenuAction.LEFT in handler.consume_menu_actions()
+        handler.handle_event(ctrl_axis_event(pygame.CONTROLLER_AXIS_LEFTX, -0.9))
+        assert handler.consume_menu_actions() == []
+
+    def test_axis_within_deadzone_no_action(self, handler, joy_axis_event) -> None:
+        """Axis value within deadzone produces no action."""
+        handler.handle_event(joy_axis_event(axis=0, value=0.3))
+        assert handler.consume_menu_actions() == []
+
+    def test_vertical_axis_edge_detection(self, handler, joy_axis_event) -> None:
+        """Vertical axis also uses edge detection."""
+        handler.handle_event(joy_axis_event(axis=1, value=0.8))
+        assert MenuAction.DOWN in handler.consume_menu_actions()
+        handler.handle_event(joy_axis_event(axis=1, value=0.9))
+        assert handler.consume_menu_actions() == []
+
+    def test_reset_clears_axis_menu_state(self, handler, joy_axis_event) -> None:
+        """reset() clears axis edge-detection state so re-press emits action."""
+        handler.handle_event(joy_axis_event(axis=0, value=-0.8))
+        handler.consume_menu_actions()
+        handler.reset()
+        # After reset, the same axis value should produce a new action
+        handler.handle_event(joy_axis_event(axis=0, value=-0.8))
+        assert MenuAction.LEFT in handler.consume_menu_actions()


### PR DESCRIPTION
## Summary

Replaces raw key constant routing for menu input with a `MenuAction` enum. Closes #124.

- `InputHandler` produces abstract `MenuAction` values (UP, DOWN, LEFT, RIGHT, CONFIRM) from keyboard, controller, and joystick events
- `GameManager` polls `consume_menu_actions()` and routes to menu handlers — same pattern as `consume_shoot()`
- Removes `_translate_joy_event()`, `_axis_to_key()`, and 7 controller constant imports from `GameManager`
- Analog stick uses edge detection to prevent repeated menu actions from continuous axis events
- Keyboard R on Game Over now maps to `MenuAction.CONFIRM` (unified with controller A/B)
- ESC/Start button stays as direct `_handle_escape()` calls (pause/resume is game state, not menu navigation)

## Test plan

- [x] 751 tests passing (30 new InputHandler tests, 9 new GameManager tests)
- [x] Lint clean
- [ ] Verify keyboard menu navigation (arrows + Enter) works on title, pause, options
- [ ] Verify controller D-pad/stick + A/B works in all menus
- [ ] Verify keyboard key-repeat still scrolls through menu items when held
- [ ] Verify R and Enter both return to title from Game Over
- [ ] Verify ESC and Start button pause/resume during gameplay