### PR TITLE
Extract magic numbers to constants, use TankType enum keys

### DIFF
--- a/src/core/enemy_tank.py
+++ b/src/core/enemy_tank.py
@@ -4,11 +4,13 @@ from loguru import logger
 from .tank import Tank
 from typing import TypedDict
 from src.utils.constants import (
+    CARRIER_BLINK_CYCLE,
     Difficulty,
     Direction,
+    DIRECTION_CHANGE_RANDOM_OFFSET,
     OwnerType,
+    SHOOT_RANDOM_OFFSET,
     TankType,
-    CARRIER_BLINK_INTERVAL,
 )
 from src.managers.texture_manager import TextureManager
 
@@ -137,8 +139,8 @@ class EnemyTank(Tank):
         """Update sprite using type-specific prefix and carrier red variant."""
         if (
             self.is_carrier
-            and self.carrier_blink_timer % (CARRIER_BLINK_INTERVAL * 2)
-            >= CARRIER_BLINK_INTERVAL
+            and self.carrier_blink_timer % CARRIER_BLINK_CYCLE
+            >= CARRIER_BLINK_CYCLE / 2
         ):
             sprite_name = (
                 f"{self._sprite_prefix}_red_{self.direction}_{self.animation_frame}"
@@ -280,14 +282,14 @@ class EnemyTank(Tank):
         if self.direction_timer >= self.direction_change_interval:
             logger.trace(f"EnemyTank ({self.tank_type}) direction timer triggered.")
             self._change_direction(player_position=player_position)
-            self.direction_timer = random.uniform(0, 0.5)  # Add small random offset
+            self.direction_timer = random.uniform(0, DIRECTION_CHANGE_RANDOM_OFFSET)
 
         # Shoot periodically (reduced interval when aligned with a target)
         reduced_threshold = self.shoot_interval * self.aligned_shoot_multiplier
         if self.shoot_timer >= self.shoot_interval:
             logger.trace(f"EnemyTank ({self.tank_type}) shoot timer triggered.")
             self._wants_to_shoot = True
-            self.shoot_timer = random.uniform(0, 0.3)  # Add small random offset
+            self.shoot_timer = random.uniform(0, SHOOT_RANDOM_OFFSET)
         elif (
             self.aligned_shoot_multiplier < 1.0
             and self.shoot_timer >= reduced_threshold
@@ -301,7 +303,7 @@ class EnemyTank(Tank):
             if aligned:
                 logger.trace(f"EnemyTank ({self.tank_type}) aligned shoot triggered.")
                 self._wants_to_shoot = True
-                self.shoot_timer = random.uniform(0, 0.3)
+                self.shoot_timer = random.uniform(0, SHOOT_RANDOM_OFFSET)
 
         if not self._sliding:
             dx, dy = self.direction.delta

--- a/src/core/map.py
+++ b/src/core/map.py
@@ -5,7 +5,7 @@ from pytmx.util_pygame import load_pygame
 from loguru import logger
 from .tile import BrickVariant, Tile, TileType
 from src.managers.texture_manager import TextureManager
-from src.utils.constants import Direction, SUB_TILE_SIZE
+from src.utils.constants import Direction, SUB_TILE_SIZE, TankType
 
 
 class Map:
@@ -220,19 +220,26 @@ class Map:
                 "No 'player_spawn' object found, defaulting to bottom-center"
             )
 
-    def _read_enemy_composition(self, tiled_map: pytmx.TiledMap) -> dict[str, int]:
+    def _read_enemy_composition(
+        self, tiled_map: pytmx.TiledMap
+    ) -> dict[TankType, int]:
         """Read enemy type counts from map-level custom properties."""
         props = tiled_map.properties or {}
         composition = {
-            "basic": int(props.get("enemy_basic", 0)),
-            "fast": int(props.get("enemy_fast", 0)),
-            "power": int(props.get("enemy_power", 0)),
-            "armor": int(props.get("enemy_armor", 0)),
+            TankType.BASIC: int(props.get("enemy_basic", 0)),
+            TankType.FAST: int(props.get("enemy_fast", 0)),
+            TankType.POWER: int(props.get("enemy_power", 0)),
+            TankType.ARMOR: int(props.get("enemy_armor", 0)),
         }
         total = sum(composition.values())
         if total == 0:
             logger.warning("No enemy composition in map properties, using defaults")
-            composition = {"basic": 20, "fast": 0, "power": 0, "armor": 0}
+            composition = {
+                TankType.BASIC: 20,
+                TankType.FAST: 0,
+                TankType.POWER: 0,
+                TankType.ARMOR: 0,
+            }
         return composition
 
     def _build_derived_tile_lists(self) -> None:

--- a/src/core/player_tank.py
+++ b/src/core/player_tank.py
@@ -4,6 +4,8 @@ from .tank import Tank
 from src.managers.texture_manager import TextureManager
 from src.utils.constants import (
     Direction,
+    INITIAL_PLAYER_LIVES,
+    MAX_STAR_LEVEL,
     OwnerType,
     BULLET_SPEED,
     SPAWN_INVINCIBILITY_DURATION,
@@ -48,7 +50,7 @@ class PlayerTank(Tank):
             tile_size,
             None,
             health=1,
-            lives=3,
+            lives=INITIAL_PLAYER_LIVES,
             owner_type=OwnerType.PLAYER,
             map_width_px=map_width_px,
             map_height_px=map_height_px,
@@ -62,14 +64,14 @@ class PlayerTank(Tank):
 
     def apply_star(self) -> None:
         """Apply a star upgrade (up to tier 3)."""
-        if self.star_level < 3:
+        if self.star_level < MAX_STAR_LEVEL:
             self.star_level += 1
         self._apply_star_stats()
         self._update_sprite()
 
     def restore_star_level(self, level: int) -> None:
         """Restore star level (e.g., after stage load). Clamps to 0-3."""
-        self.star_level = max(0, min(3, level))
+        self.star_level = max(0, min(MAX_STAR_LEVEL, level))
         self._apply_star_stats()
         self._update_sprite()
 

--- a/src/core/power_up.py
+++ b/src/core/power_up.py
@@ -5,6 +5,7 @@ import pygame
 from src.core.game_object import GameObject
 from src.managers.texture_manager import TextureManager
 from src.utils.constants import (
+    POWERUP_BLINK_CYCLE,
     POWERUP_BLINK_INTERVAL,
     POWERUP_TIMEOUT,
     TILE_SIZE,
@@ -43,7 +44,7 @@ class PowerUp(GameObject):
         """Draw the power-up with blinking effect."""
         if not self.active:
             return
-        if self.blink_timer % (POWERUP_BLINK_INTERVAL * 2) < POWERUP_BLINK_INTERVAL:
+        if self.blink_timer % POWERUP_BLINK_CYCLE < POWERUP_BLINK_INTERVAL:
             super().draw(surface)
 
     def collect(self) -> PowerUpType:

--- a/src/core/tank.py
+++ b/src/core/tank.py
@@ -14,6 +14,7 @@ from src.utils.constants import (
     TANK_HEIGHT,
     TANK_ANIMATION_DISTANCE,
     TANK_ALIGN_THRESHOLD,
+    TANK_BLINK_INTERVAL,
     BULLET_WIDTH,
     BULLET_HEIGHT,
     BULLET_SPEED,
@@ -83,7 +84,7 @@ class Tank(GameObject):
         self.invincibility_timer: float = 0
         self.invincibility_duration: float = 0
         self.blink_timer: float = 0
-        self.blink_interval: float = 0.2  # Blink every 0.2 seconds during invincibility
+        self.blink_interval: float = TANK_BLINK_INTERVAL
         self.animation_frame: int = 1  # Start with frame 1
         self._on_ice: bool = False
         self._sliding: bool = False

--- a/src/managers/effect_manager.py
+++ b/src/managers/effect_manager.py
@@ -6,14 +6,11 @@ from src.managers.texture_manager import TextureManager
 from src.utils.constants import (
     ATLAS_BG_COLOR,
     EffectType,
-    TILE_SIZE,
+    LARGE_EXPLOSION_SIZE,
     SMALL_EXPLOSION_FRAME_DURATION,
     LARGE_EXPLOSION_FRAME_DURATION,
     SPAWN_FRAME_DURATION,
 )
-
-# Size of scaled-up explosion frames for large explosions
-_LARGE_EXPLOSION_SIZE = TILE_SIZE * 2
 
 
 class EffectManager:
@@ -58,7 +55,7 @@ class EffectManager:
 
         small_frames = [frame_1, frame_2, frame_3]
 
-        size = (_LARGE_EXPLOSION_SIZE, _LARGE_EXPLOSION_SIZE)
+        size = (LARGE_EXPLOSION_SIZE, LARGE_EXPLOSION_SIZE)
         large_frames = small_frames + [
             pygame.transform.scale(frame_2, size),
             pygame.transform.scale(frame_3, size),

--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -9,7 +9,9 @@ from src.core.bullet import Bullet
 from src.states.game_state import GameState
 from src.utils.constants import (
     Difficulty,
+    ENEMY_SPAWN_INTERVAL,
     OwnerType,
+    VOLUME_ADJUSTMENT_STEP,
     WINDOW_TITLE,
     FPS,
     TILE_SIZE,
@@ -23,6 +25,7 @@ from src.utils.constants import (
     CLOCK_FREEZE_DURATION,
     SHOVEL_DURATION,
     SHOVEL_WARNING_DURATION,
+    SHOVEL_FLASH_CYCLE,
     SHOVEL_FLASH_INTERVAL,
     EffectType,
     CURTAIN_CLOSE_DURATION,
@@ -188,7 +191,7 @@ class GameManager:
             texture_manager=self.texture_manager,
             game_map=self.map,
             enemy_composition=self.map.enemy_composition,
-            spawn_interval=5.0,
+            spawn_interval=ENEMY_SPAWN_INTERVAL,
             player_tank=self.player_tank,
             effect_manager=self.effect_manager,
             difficulty=self.settings_manager.difficulty,
@@ -373,7 +376,10 @@ class GameManager:
                     self.settings_manager.difficulty = Difficulty.NORMAL
                 self.sound_manager.play_menu_select()
             elif self._options_selection == 1:
-                delta = -0.1 if action == MenuAction.LEFT else 0.1
+                if action == MenuAction.LEFT:
+                    delta = -VOLUME_ADJUSTMENT_STEP
+                else:
+                    delta = VOLUME_ADJUSTMENT_STEP
                 self.settings_manager.master_volume = max(
                     0.0, min(1.0, self.settings_manager.master_volume + delta)
                 )
@@ -664,7 +670,7 @@ class GameManager:
         if self.shovel_timer <= SHOVEL_WARNING_DURATION:
             self._shovel_flash_timer += dt
             should_show_steel = (
-                self._shovel_flash_timer % (SHOVEL_FLASH_INTERVAL * 2)
+                self._shovel_flash_timer % SHOVEL_FLASH_CYCLE
                 < SHOVEL_FLASH_INTERVAL
             )
             if should_show_steel != self._shovel_flash_showing_steel:

--- a/src/managers/renderer.py
+++ b/src/managers/renderer.py
@@ -1,7 +1,18 @@
 import pygame
 from typing import List, Optional, Sequence, Tuple
 from src.states.game_state import GameState
-from src.utils.constants import WHITE, BLACK, RED, GREEN, GRAY, Difficulty
+from src.utils.constants import (
+    WHITE,
+    BLACK,
+    RED,
+    GREEN,
+    GRAY,
+    Difficulty,
+    FONT_SIZE_LARGE,
+    FONT_SIZE_SMALL,
+    PAUSE_OVERLAY_ALPHA,
+    DARK_OVERLAY_ALPHA,
+)
 from src.utils.paths import resource_path
 
 
@@ -39,8 +50,8 @@ class Renderer:
             (logical_width, logical_height)
         )
         font_path = resource_path("assets/fonts/PressStart2P-Regular.ttf")
-        self.font: pygame.font.Font = pygame.font.Font(font_path, 24)
-        self.small_font: pygame.font.Font = pygame.font.Font(font_path, 12)
+        self.font: pygame.font.Font = pygame.font.Font(font_path, FONT_SIZE_LARGE)
+        self.small_font: pygame.font.Font = pygame.font.Font(font_path, FONT_SIZE_SMALL)
 
         self.map_offset_x: int = (logical_width - map_width_px) // 2
         self.map_offset_y: int = (logical_height - map_height_px) // 2
@@ -62,11 +73,11 @@ class Renderer:
         self._pause_overlay: pygame.Surface = pygame.Surface(
             (logical_width, logical_height), pygame.SRCALPHA
         )
-        self._pause_overlay.fill((0, 0, 0, 160))
+        self._pause_overlay.fill((0, 0, 0, PAUSE_OVERLAY_ALPHA))
         self._dark_overlay: pygame.Surface = pygame.Surface(
             (logical_width, logical_height), pygame.SRCALPHA
         )
-        self._dark_overlay.fill((0, 0, 0, 128))
+        self._dark_overlay.fill((0, 0, 0, DARK_OVERLAY_ALPHA))
 
     def render(
         self,

--- a/src/managers/sound_manager.py
+++ b/src/managers/sound_manager.py
@@ -3,6 +3,7 @@
 import pygame
 from loguru import logger
 
+from src.utils.constants import AUDIO_MIXER_CHANNELS, SOUND_FADEOUT_MS
 from src.utils.paths import resource_path
 
 
@@ -32,7 +33,7 @@ class SoundManager:
 
         try:
             pygame.mixer.init()
-            pygame.mixer.set_num_channels(16)
+            pygame.mixer.set_num_channels(AUDIO_MIXER_CHANNELS)
         except pygame.error:
             logger.warning("Audio mixer failed to initialize; sounds disabled.")
             return
@@ -128,10 +129,10 @@ class SoundManager:
         """Stop a looping sound with short fadeout to avoid audio pops."""
         channel = self._looping_channels.pop(name, None)
         if channel is not None:
-            channel.fadeout(50)
+            channel.fadeout(SOUND_FADEOUT_MS)
 
     def stop_loops(self) -> None:
         """Stop all looping sounds. Does not affect one-shot sounds."""
         for channel in self._looping_channels.values():
-            channel.fadeout(50)
+            channel.fadeout(SOUND_FADEOUT_MS)
         self._looping_channels.clear()

--- a/src/managers/spawn_manager.py
+++ b/src/managers/spawn_manager.py
@@ -16,6 +16,7 @@ from src.utils.constants import (
     EffectType,
     POWERUP_CARRIER_INDICES,
     TILE_SIZE,
+    TILE_SIZE_HALF,
     TankType,
 )
 
@@ -38,7 +39,7 @@ class SpawnManager:
         self,
         texture_manager: TextureManager,
         game_map: Map,
-        enemy_composition: dict[str, int],
+        enemy_composition: dict[TankType, int],
         spawn_interval: float,
         player_tank: PlayerTank,
         effect_manager: Optional[EffectManager] = None,
@@ -49,8 +50,7 @@ class SpawnManager:
         Args:
             texture_manager: TextureManager for loading enemy sprites.
             game_map: The game map (spawn points, dimensions, collision).
-            enemy_composition: Dict with keys "basic", "fast", "power", "armor"
-                mapping to enemy counts for this stage.
+            enemy_composition: Dict mapping TankType to enemy counts for this stage.
             spawn_interval: Seconds between spawn attempts.
             player_tank: The player tank (for collision checking on initial spawn).
             effect_manager: EffectManager for spawn animations (optional).
@@ -82,22 +82,22 @@ class SpawnManager:
         # Initial spawn
         self.spawn_enemy(player_tank, game_map)
 
-    def _build_spawn_queue(self, enemy_composition: dict[str, int]) -> List[TankType]:
+    def _build_spawn_queue(
+        self, enemy_composition: dict[TankType, int]
+    ) -> List[TankType]:
         """Build a shuffled list of enemy types from the composition dict.
 
         Args:
-            enemy_composition: Dict with keys "basic", "fast", "power", "armor"
-                mapping to enemy counts.
+            enemy_composition: Dict mapping TankType to enemy counts.
 
         Returns:
             Shuffled list of TankType enum members.
         """
-        queue: List[TankType] = (
-            [TankType.BASIC] * enemy_composition["basic"]
-            + [TankType.FAST] * enemy_composition["fast"]
-            + [TankType.POWER] * enemy_composition["power"]
-            + [TankType.ARMOR] * enemy_composition["armor"]
-        )
+        queue: List[TankType] = [
+            tank_type
+            for tank_type, count in enemy_composition.items()
+            for _ in range(count)
+        ]
         random.shuffle(queue)
         return queue
 
@@ -156,8 +156,8 @@ class SpawnManager:
 
         if self._effect_manager is not None:
             # Play spawn animation, materialize tank when it finishes
-            center_x = float(x + TILE_SIZE // 2)
-            center_y = float(y + TILE_SIZE // 2)
+            center_x = float(x + TILE_SIZE_HALF)
+            center_y = float(y + TILE_SIZE_HALF)
             effect = self._effect_manager.spawn(EffectType.SPAWN, center_x, center_y)
             self._pending_spawns.append(
                 _PendingSpawn(

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -120,6 +120,7 @@ SHIELD_FLICKER_INTERVAL: float = 0.1
 SHIELD_FAST_FLICKER_INTERVAL: float = 0.04
 STAR_BULLET_SPEED_MULTIPLIER: float = 2.0
 STAR_MAX_BULLETS: int = 2
+MAX_STAR_LEVEL: int = 3
 CURTAIN_CLOSE_DURATION: float = 0.75
 CURTAIN_OPEN_DURATION: float = 0.75
 CURTAIN_STAGE_DISPLAY: float = 1.5
@@ -127,6 +128,11 @@ MAX_STAGE: int = 35
 VICTORY_PAUSE_DURATION: float = 1.0
 GAME_OVER_RISE_DURATION: float = 2.0
 GAME_OVER_HOLD_DURATION: float = 1.0
+
+# Pre-computed blink/flash cycles (2x the interval)
+POWERUP_BLINK_CYCLE: float = POWERUP_BLINK_INTERVAL * 2
+CARRIER_BLINK_CYCLE: float = CARRIER_BLINK_INTERVAL * 2
+SHOVEL_FLASH_CYCLE: float = SHOVEL_FLASH_INTERVAL * 2
 
 
 # Window settings
@@ -139,6 +145,7 @@ FPS: int = 60
 SOURCE_TILE_SIZE: int = 8  # Original size for loading sprites
 SUB_TILE_SIZE: int = 16  # Rendered tile size for the map grid
 TILE_SIZE: int = 32  # Entity size (tanks) and visual tile size
+TILE_SIZE_HALF: int = TILE_SIZE // 2
 
 # Logical surface (fixed size, map centered inside with gray border)
 LOGICAL_WIDTH: int = 512
@@ -158,7 +165,9 @@ TANK_WIDTH: int = TILE_SIZE
 TANK_HEIGHT: int = TILE_SIZE
 TANK_ANIMATION_DISTANCE: float = 4  # pixels traveled between animation frame toggles
 TANK_ALIGN_THRESHOLD: float = 4.0  # max px offset for steering assist
+TANK_BLINK_INTERVAL: float = 0.2  # blink interval during invincibility
 ICE_SLIDE_DISTANCE: float = 32.0  # pixels a tank slides after leaving ice
+INITIAL_PLAYER_LIVES: int = 3
 
 # Atlas background color used as colorkey for transparency
 ATLAS_BG_COLOR: tuple[int, int, int] = (0, 0, 1)
@@ -168,6 +177,25 @@ BULLET_SPEED: float = 180  # pixels per second (was 3, multiplied by FPS interna
 BULLET_SIZE: int = 4  # Visual size of bullet sprites after extraction
 BULLET_WIDTH: int = BULLET_SIZE
 BULLET_HEIGHT: int = BULLET_SIZE
+
+# Enemy AI settings
+ENEMY_SPAWN_INTERVAL: float = 5.0
+DIRECTION_CHANGE_RANDOM_OFFSET: float = 0.5
+SHOOT_RANDOM_OFFSET: float = 0.3
+
+# UI settings
+FONT_SIZE_LARGE: int = 24
+FONT_SIZE_SMALL: int = 12
+PAUSE_OVERLAY_ALPHA: int = 160
+DARK_OVERLAY_ALPHA: int = 128
+VOLUME_ADJUSTMENT_STEP: float = 0.1
+
+# Audio settings
+AUDIO_MIXER_CHANNELS: int = 16
+SOUND_FADEOUT_MS: int = 50
+
+# Derived size constants
+LARGE_EXPLOSION_SIZE: int = TILE_SIZE * 2
 
 # Effect settings
 SMALL_EXPLOSION_FRAME_DURATION: float = 0.067  # ~0.2s total for 3 frames

--- a/tests/unit/core/test_map.py
+++ b/tests/unit/core/test_map.py
@@ -1,6 +1,7 @@
 import pytest
 from src.core.map import Map
 from src.core.tile import TileType
+from src.utils.constants import TankType
 from src.utils.paths import resource_path
 
 TEST_MAP_PATH = "tests/assets/test_map.tmx"
@@ -193,10 +194,10 @@ class TestEnemyCompositionFromTMX:
 
     def test_enemy_composition_values(self, game_map):
         comp = game_map.enemy_composition
-        assert comp["basic"] == 18
-        assert comp["fast"] == 2
-        assert comp["power"] == 0
-        assert comp["armor"] == 0
+        assert comp[TankType.BASIC] == 18
+        assert comp[TankType.FAST] == 2
+        assert comp[TankType.POWER] == 0
+        assert comp[TankType.ARMOR] == 0
 
     def test_enemy_composition_sum(self, game_map):
         comp = game_map.enemy_composition
@@ -267,10 +268,10 @@ infinite="0" nextlayerid="2" nextobjectid="1">
         try:
             game_map = Map(tmx_path, mock_texture_manager)
             assert game_map.enemy_composition == {
-                "basic": 20,
-                "fast": 0,
-                "power": 0,
-                "armor": 0,
+                TankType.BASIC: 20,
+                TankType.FAST: 0,
+                TankType.POWER: 0,
+                TankType.ARMOR: 0,
             }
         finally:
             os.remove(tmx_path)

--- a/tests/unit/managers/test_spawn_manager.py
+++ b/tests/unit/managers/test_spawn_manager.py
@@ -5,7 +5,14 @@ from src.managers.spawn_manager import SpawnManager
 from src.managers.effect_manager import EffectManager
 from src.core.effect import Effect
 from src.core.enemy_tank import EnemyTank
-from src.utils.constants import EffectType, TILE_SIZE, SUB_TILE_SIZE
+from src.utils.constants import EffectType, TILE_SIZE, SUB_TILE_SIZE, TankType
+
+_DEFAULT_COMPOSITION = {
+    TankType.BASIC: 18,
+    TankType.FAST: 2,
+    TankType.POWER: 0,
+    TankType.ARMOR: 0,
+}
 
 
 class TestSpawnManager:
@@ -51,7 +58,7 @@ class TestSpawnManager:
         manager = SpawnManager(
             texture_manager=mock_texture_manager,
             game_map=mock_game_map,
-            enemy_composition={"basic": 18, "fast": 2, "power": 0, "armor": 0},
+            enemy_composition=_DEFAULT_COMPOSITION,
             spawn_interval=5.0,
             player_tank=mock_player_tank,
         )
@@ -208,7 +215,7 @@ class TestSpawnManager:
         manager = SpawnManager(
             texture_manager=mock_texture_manager,
             game_map=mock_game_map,
-            enemy_composition={"basic": 18, "fast": 2, "power": 0, "armor": 0},
+            enemy_composition=_DEFAULT_COMPOSITION,
             spawn_interval=5.0,
             player_tank=mock_player_tank,
         )
@@ -223,7 +230,12 @@ class TestSpawnManager:
         manager = SpawnManager(
             texture_manager=mock_texture_manager,
             game_map=mock_game_map,
-            enemy_composition={"basic": 2, "fast": 5, "power": 10, "armor": 3},
+            enemy_composition={
+                TankType.BASIC: 2,
+                TankType.FAST: 5,
+                TankType.POWER: 10,
+                TankType.ARMOR: 3,
+            },
             spawn_interval=5.0,
             player_tank=mock_player_tank,
         )
@@ -237,7 +249,7 @@ class TestSpawnManager:
         manager = SpawnManager(
             texture_manager=mock_texture_manager,
             game_map=mock_game_map,
-            enemy_composition={"basic": 18, "fast": 2, "power": 0, "armor": 0},
+            enemy_composition=_DEFAULT_COMPOSITION,
             spawn_interval=5.0,
             player_tank=mock_player_tank,
         )
@@ -254,7 +266,12 @@ class TestSpawnManager:
         manager = SpawnManager(
             texture_manager=mock_texture_manager,
             game_map=mock_game_map,
-            enemy_composition={"basic": 20, "fast": 0, "power": 0, "armor": 0},
+            enemy_composition={
+                TankType.BASIC: 20,
+                TankType.FAST: 0,
+                TankType.POWER: 0,
+                TankType.ARMOR: 0,
+            },
             spawn_interval=5.0,
             player_tank=mock_player_tank,
         )
@@ -305,7 +322,7 @@ class TestSpawnAnimation:
         return SpawnManager(
             texture_manager=mock_texture_manager,
             game_map=mock_game_map,
-            enemy_composition={"basic": 18, "fast": 2, "power": 0, "armor": 0},
+            enemy_composition=_DEFAULT_COMPOSITION,
             spawn_interval=5.0,
             player_tank=mock_player_tank,
             effect_manager=mock_effect_manager,
@@ -411,7 +428,7 @@ class TestSpawnManagerCarrier:
         return SpawnManager(
             texture_manager=mock_texture_manager,
             game_map=mock_game_map,
-            enemy_composition={"basic": 18, "fast": 2, "power": 0, "armor": 0},
+            enemy_composition=_DEFAULT_COMPOSITION,
             spawn_interval=5.0,
             player_tank=mock_player_tank,
         )
@@ -452,7 +469,7 @@ class TestSpawnManagerCarrier:
         manager = SpawnManager(
             texture_manager=mock_texture_manager,
             game_map=mock_game_map,
-            enemy_composition={"basic": 18, "fast": 2, "power": 0, "armor": 0},
+            enemy_composition=_DEFAULT_COMPOSITION,
             spawn_interval=5.0,
             player_tank=mock_player_tank,
             effect_manager=mock_effect_manager,


### PR DESCRIPTION
## Summary
- Extract hardcoded configuration values (spawn interval, font sizes, overlay alphas, blink intervals, audio settings, star/lives limits) into `src/utils/constants.py`
- Add pre-computed blink cycle constants to avoid repeated multiplication in hot paths
- Replace stringly-typed `enemy_composition` dict keys with `TankType` enum values across `map.py`, `spawn_manager.py`, and tests

## Test plan
- [x] All 773 tests pass
- [x] Ruff linting clean