### PR TITLE
Read per-level properties from Tiled maps

### DIFF
--- a/assets/battle-city.tiled-project
+++ b/assets/battle-city.tiled-project
@@ -49,6 +49,17 @@
                 "enemy_spawn"
             ],
             "valuesAsFlags": false
+        },
+        {
+            "id": 4,
+            "name": "Difficulty",
+            "storageType": "string",
+            "type": "enum",
+            "values": [
+                "easy",
+                "normal"
+            ],
+            "valuesAsFlags": false
         }
     ]
 }

--- a/src/core/map.py
+++ b/src/core/map.py
@@ -215,7 +215,13 @@ class Map:
             grid_x = int(obj.x // tmx_tw)
             grid_y = int(obj.y // tmx_th)
 
-            if obj.name == "player_spawn":
+            # Prefer spawn_point_type property, fall back to object name
+            obj_props = obj.properties if hasattr(obj, "properties") else {}
+            spawn_type = obj_props.get("spawn_point_type") if obj_props else None
+            if spawn_type is None:
+                spawn_type = obj.name
+
+            if spawn_type == "player_spawn":
                 self.player_spawn = (grid_x, grid_y)
                 player_spawn_found = True
             else:

--- a/src/core/map.py
+++ b/src/core/map.py
@@ -5,7 +5,14 @@ from pytmx.util_pygame import load_pygame
 from loguru import logger
 from .tile import BrickVariant, Tile, TileType
 from src.managers.texture_manager import TextureManager
-from src.utils.constants import Direction, SUB_TILE_SIZE, TankType
+from src.utils.constants import (
+    Difficulty,
+    Direction,
+    ENEMY_SPAWN_INTERVAL,
+    POWERUP_CARRIER_INDICES,
+    SUB_TILE_SIZE,
+    TankType,
+)
 
 
 class Map:
@@ -139,7 +146,7 @@ class Map:
         self._load_spawn_points(tiled_map)
 
         # Read enemy composition from map-level properties
-        self.enemy_composition = self._read_enemy_composition(tiled_map)
+        self._read_level_properties(tiled_map)
 
     def _scan_tileset(self, tiled_map: pytmx.TiledMap) -> None:
         """Scan the tileset for brick variant sprites and collision defaults.
@@ -220,11 +227,16 @@ class Map:
                 "No 'player_spawn' object found, defaulting to bottom-center"
             )
 
-    def _read_enemy_composition(
-        self, tiled_map: pytmx.TiledMap
-    ) -> dict[TankType, int]:
-        """Read enemy type counts from map-level custom properties."""
+    def _read_level_properties(self, tiled_map: pytmx.TiledMap) -> None:
+        """Read per-level properties from TMX map-level custom properties.
+
+        Reads enemy composition, spawn interval, difficulty override,
+        and power-up carrier indices. All properties fall back to
+        sensible defaults when absent.
+        """
         props = tiled_map.properties or {}
+
+        # Enemy composition (existing logic)
         composition = {
             TankType.BASIC: int(props.get("enemy_basic", 0)),
             TankType.FAST: int(props.get("enemy_fast", 0)),
@@ -240,7 +252,42 @@ class Map:
                 TankType.POWER: 0,
                 TankType.ARMOR: 0,
             }
-        return composition
+        self.enemy_composition = composition
+
+        # Spawn interval
+        self.spawn_interval: float = float(
+            props.get("spawn_interval", ENEMY_SPAWN_INTERVAL)
+        )
+
+        # Difficulty override
+        diff_str = props.get("difficulty")
+        if diff_str is not None:
+            try:
+                self.difficulty_override: Optional[Difficulty] = Difficulty(
+                    str(diff_str).strip()
+                )
+            except ValueError:
+                logger.warning(
+                    f"Invalid difficulty value '{diff_str}', ignoring override"
+                )
+                self.difficulty_override = None
+        else:
+            self.difficulty_override = None
+
+        # Power-up carrier indices
+        carriers_str = props.get("powerup_carriers")
+        if carriers_str:
+            try:
+                self.powerup_carrier_indices: tuple[int, ...] = tuple(
+                    int(s.strip()) for s in str(carriers_str).split(",")
+                )
+            except ValueError:
+                logger.warning(
+                    f"Invalid powerup_carriers '{carriers_str}', using defaults"
+                )
+                self.powerup_carrier_indices = POWERUP_CARRIER_INDICES
+        else:
+            self.powerup_carrier_indices = POWERUP_CARRIER_INDICES
 
     def _build_derived_tile_lists(self) -> None:
         """Build the lists of animated, drawable, and overlay tiles."""

--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -497,12 +497,8 @@ class GameManager:
         bullet_blocking_tiles: List[Tile] = self.map.get_bullet_blocking_tiles()
         player_base: Optional[Tile] = self.map.get_base()
 
-        player_bullets = [
-            b for b in self.bullets if b.owner_type == OwnerType.PLAYER
-        ]
-        enemy_bullets = [
-            b for b in self.bullets if b.owner_type == OwnerType.ENEMY
-        ]
+        player_bullets = [b for b in self.bullets if b.owner_type == OwnerType.PLAYER]
+        enemy_bullets = [b for b in self.bullets if b.owner_type == OwnerType.ENEMY]
 
         active_power_ups = self.power_up_manager.get_power_ups()
 
@@ -675,8 +671,7 @@ class GameManager:
         if self.shovel_timer <= SHOVEL_WARNING_DURATION:
             self._shovel_flash_timer += dt
             should_show_steel = (
-                self._shovel_flash_timer % SHOVEL_FLASH_CYCLE
-                < SHOVEL_FLASH_INTERVAL
+                self._shovel_flash_timer % SHOVEL_FLASH_CYCLE < SHOVEL_FLASH_INTERVAL
             )
             if should_show_steel != self._shovel_flash_showing_steel:
                 self._shovel_flash_showing_steel = should_show_steel

--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -9,7 +9,6 @@ from src.core.bullet import Bullet
 from src.states.game_state import GameState
 from src.utils.constants import (
     Difficulty,
-    ENEMY_SPAWN_INTERVAL,
     OwnerType,
     VOLUME_ADJUSTMENT_STEP,
     WINDOW_TITLE,
@@ -187,14 +186,20 @@ class GameManager:
         )
 
         # SpawnManager
+        effective_difficulty = (
+            self.map.difficulty_override
+            if self.map.difficulty_override is not None
+            else self.settings_manager.difficulty
+        )
         self.spawn_manager = SpawnManager(
             texture_manager=self.texture_manager,
             game_map=self.map,
             enemy_composition=self.map.enemy_composition,
-            spawn_interval=ENEMY_SPAWN_INTERVAL,
+            spawn_interval=self.map.spawn_interval,
             player_tank=self.player_tank,
             effect_manager=self.effect_manager,
-            difficulty=self.settings_manager.difficulty,
+            difficulty=effective_difficulty,
+            powerup_carrier_indices=self.map.powerup_carrier_indices,
         )
 
         self.bullets: List[Bullet] = []

--- a/src/managers/spawn_manager.py
+++ b/src/managers/spawn_manager.py
@@ -44,6 +44,7 @@ class SpawnManager:
         player_tank: PlayerTank,
         effect_manager: Optional[EffectManager] = None,
         difficulty: Difficulty = Difficulty.NORMAL,
+        powerup_carrier_indices: Optional[tuple[int, ...]] = None,
     ) -> None:
         """Initialize the SpawnManager.
 
@@ -55,6 +56,8 @@ class SpawnManager:
             player_tank: The player tank (for collision checking on initial spawn).
             effect_manager: EffectManager for spawn animations (optional).
             difficulty: AI difficulty level for spawned enemies.
+            powerup_carrier_indices: Tuple of spawn indices that carry powerups.
+                Falls back to POWERUP_CARRIER_INDICES constant when not provided.
         """
         self.tile_size = TILE_SIZE
         self._difficulty = difficulty
@@ -69,6 +72,11 @@ class SpawnManager:
         self.total_enemy_spawns: int = 0
         self.spawn_timer: float = 0.0
         self._effect_manager = effect_manager
+        self._powerup_carrier_indices: tuple[int, ...] = (
+            powerup_carrier_indices
+            if powerup_carrier_indices is not None
+            else POWERUP_CARRIER_INDICES
+        )
         self._pending_spawns: List[_PendingSpawn] = []
 
         # Set class-level base position for AI targeting
@@ -152,7 +160,7 @@ class SpawnManager:
 
         tank_type = self._spawn_queue.pop()
         self.total_enemy_spawns += 1
-        is_carrier = (self.total_enemy_spawns - 1) in POWERUP_CARRIER_INDICES
+        is_carrier = (self.total_enemy_spawns - 1) in self._powerup_carrier_indices
 
         if self._effect_manager is not None:
             # Play spawn animation, materialize tank when it finishes

--- a/tests/assets/test_map.tmx
+++ b/tests/assets/test_map.tmx
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <map version="1.10" tiledversion="1.11.2" orientation="orthogonal" renderorder="right-down" width="10" height="10" tilewidth="8" tileheight="8" infinite="0" nextlayerid="3" nextobjectid="3">
- <properties><property name="enemy_basic" type="int" value="18" /><property name="enemy_fast" type="int" value="2" /><property name="enemy_power" type="int" value="0" /><property name="enemy_armor" type="int" value="0" /></properties><tileset firstgid="1" source="../../assets/sprites/sprites.tsx" />
+ <properties><property name="enemy_basic" type="int" value="18" /><property name="enemy_fast" type="int" value="2" /><property name="enemy_power" type="int" value="0" /><property name="enemy_armor" type="int" value="0" /><property name="spawn_interval" type="float" value="3.5"/><property name="difficulty" value="easy"/><property name="powerup_carriers" value="2,7,14"/></properties><tileset firstgid="1" source="../../assets/sprites/sprites.tsx" />
  <layer id="1" name="Tile Layer 1" width="10" height="10">
   <data encoding="csv">
 483,483,0,0,0,0,0,0,483,483,

--- a/tests/unit/core/test_map.py
+++ b/tests/unit/core/test_map.py
@@ -1,7 +1,12 @@
 import pytest
 from src.core.map import Map
 from src.core.tile import TileType
-from src.utils.constants import TankType
+from src.utils.constants import (
+    Difficulty,
+    ENEMY_SPAWN_INTERVAL,
+    POWERUP_CARRIER_INDICES,
+    TankType,
+)
 from src.utils.paths import resource_path
 
 TEST_MAP_PATH = "tests/assets/test_map.tmx"
@@ -273,6 +278,116 @@ infinite="0" nextlayerid="2" nextobjectid="1">
                 TankType.POWER: 0,
                 TankType.ARMOR: 0,
             }
+        finally:
+            os.remove(tmx_path)
+
+
+class TestLevelPropertiesFromTMX:
+    """Verify Map reads per-level properties from TMX map properties."""
+
+    @pytest.fixture
+    def game_map(self, mock_texture_manager):
+        return Map(TEST_MAP_PATH, mock_texture_manager)
+
+    def test_spawn_interval_from_map(self, game_map):
+        assert game_map.spawn_interval == 3.5
+
+    def test_difficulty_override_from_map(self, game_map):
+        assert game_map.difficulty_override == Difficulty.EASY
+
+    def test_powerup_carrier_indices_from_map(self, game_map):
+        assert game_map.powerup_carrier_indices == (2, 7, 14)
+
+
+class TestLevelPropertiesFallback:
+    """Verify fallback when map has no level properties."""
+
+    def test_missing_spawn_interval_defaults(self, mock_texture_manager):
+        """Map without spawn_interval falls back to ENEMY_SPAWN_INTERVAL."""
+        import os
+
+        tmx_content = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.10" tiledversion="1.11.2" orientation="orthogonal" \
+renderorder="right-down" width="2" height="2" tilewidth="8" tileheight="8" \
+infinite="0" nextlayerid="2" nextobjectid="1">
+ <tileset firstgid="1" source="../../assets/sprites/sprites.tsx"/>
+ <layer id="1" name="Tile Layer 1" width="2" height="2">
+  <data encoding="csv">
+0,0,
+0,0
+</data>
+ </layer>
+</map>
+"""
+        tmx_path = "tests/assets/no_level_props.tmx"
+        with open(tmx_path, "w") as f:
+            f.write(tmx_content)
+        try:
+            game_map = Map(tmx_path, mock_texture_manager)
+            assert game_map.spawn_interval == ENEMY_SPAWN_INTERVAL
+            assert game_map.difficulty_override is None
+            assert game_map.powerup_carrier_indices == POWERUP_CARRIER_INDICES
+        finally:
+            os.remove(tmx_path)
+
+    def test_invalid_difficulty_falls_back(self, mock_texture_manager):
+        """Map with invalid difficulty string falls back to None."""
+        import os
+
+        tmx_content = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.10" tiledversion="1.11.2" orientation="orthogonal" \
+renderorder="right-down" width="2" height="2" tilewidth="8" tileheight="8" \
+infinite="0" nextlayerid="2" nextobjectid="1">
+ <properties>
+  <property name="difficulty" value="hard"/>
+ </properties>
+ <tileset firstgid="1" source="../../assets/sprites/sprites.tsx"/>
+ <layer id="1" name="Tile Layer 1" width="2" height="2">
+  <data encoding="csv">
+0,0,
+0,0
+</data>
+ </layer>
+</map>
+"""
+        tmx_path = "tests/assets/bad_difficulty.tmx"
+        with open(tmx_path, "w") as f:
+            f.write(tmx_content)
+        try:
+            game_map = Map(tmx_path, mock_texture_manager)
+            assert game_map.difficulty_override is None
+        finally:
+            os.remove(tmx_path)
+
+    def test_invalid_powerup_carriers_falls_back(self, mock_texture_manager):
+        """Map with invalid powerup_carriers string falls back to constant."""
+        import os
+
+        tmx_content = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.10" tiledversion="1.11.2" orientation="orthogonal" \
+renderorder="right-down" width="2" height="2" tilewidth="8" tileheight="8" \
+infinite="0" nextlayerid="2" nextobjectid="1">
+ <properties>
+  <property name="powerup_carriers" value="3,abc,17"/>
+ </properties>
+ <tileset firstgid="1" source="../../assets/sprites/sprites.tsx"/>
+ <layer id="1" name="Tile Layer 1" width="2" height="2">
+  <data encoding="csv">
+0,0,
+0,0
+</data>
+ </layer>
+</map>
+"""
+        tmx_path = "tests/assets/bad_carriers.tmx"
+        with open(tmx_path, "w") as f:
+            f.write(tmx_content)
+        try:
+            game_map = Map(tmx_path, mock_texture_manager)
+            assert game_map.powerup_carrier_indices == POWERUP_CARRIER_INDICES
         finally:
             os.remove(tmx_path)
 

--- a/tests/unit/core/test_map.py
+++ b/tests/unit/core/test_map.py
@@ -392,6 +392,56 @@ infinite="0" nextlayerid="2" nextobjectid="1">
             os.remove(tmx_path)
 
 
+class TestSpawnPointTypeProperty:
+    """Verify _load_spawn_points reads spawn_point_type property with name fallback."""
+
+    def test_name_based_fallback_still_works(self, mock_texture_manager):
+        """Existing maps with name-based spawn points still load correctly."""
+        game_map = Map(TEST_MAP_PATH, mock_texture_manager)
+        assert game_map.player_spawn == (4, 6)
+        assert len(game_map.spawn_points) >= 1
+
+    def test_spawn_point_type_property_used(self, mock_texture_manager):
+        """Spawn points with spawn_point_type property are correctly loaded."""
+        import os
+
+        tmx_content = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.10" tiledversion="1.11.2" orientation="orthogonal" \
+renderorder="right-down" width="2" height="2" tilewidth="8" tileheight="8" \
+infinite="0" nextlayerid="3" nextobjectid="3">
+ <tileset firstgid="1" source="../../assets/sprites/sprites.tsx"/>
+ <layer id="1" name="Tile Layer 1" width="2" height="2">
+  <data encoding="csv">
+0,0,
+0,0
+</data>
+ </layer>
+ <objectgroup id="2" name="spawn_points">
+  <object id="1" name="" x="0" y="0" width="0" height="0">
+   <properties>
+    <property name="spawn_point_type" value="enemy_spawn"/>
+   </properties>
+  </object>
+  <object id="2" name="" x="8" y="8" width="0" height="0">
+   <properties>
+    <property name="spawn_point_type" value="player_spawn"/>
+   </properties>
+  </object>
+ </objectgroup>
+</map>
+"""
+        tmx_path = "tests/assets/spawn_type_prop.tmx"
+        with open(tmx_path, "w") as f:
+            f.write(tmx_content)
+        try:
+            game_map = Map(tmx_path, mock_texture_manager)
+            assert game_map.player_spawn == (1, 1)
+            assert (0, 0) in game_map.spawn_points
+        finally:
+            os.remove(tmx_path)
+
+
 class TestGetBaseSurroundingTiles:
     @pytest.fixture
     def game_map(self, mock_texture_manager):

--- a/tests/unit/managers/test_spawn_manager.py
+++ b/tests/unit/managers/test_spawn_manager.py
@@ -493,3 +493,66 @@ class TestSpawnManagerCarrier:
         manager.update(0.0, mock_player_tank, mock_game_map)
         carrier_tanks = [t for t in manager.enemy_tanks if t.is_carrier]
         assert len(carrier_tanks) == 1
+
+
+class TestSpawnManagerCustomCarriers:
+    """Tests for custom powerup_carrier_indices parameter."""
+
+    SPAWN_POINTS = TestSpawnManager.SPAWN_POINTS
+
+    @pytest.fixture
+    def mock_player_tank(self):
+        player = MagicMock()
+        player.rect = pygame.Rect(7 * TILE_SIZE, 14 * TILE_SIZE, TILE_SIZE, TILE_SIZE)
+        return player
+
+    @pytest.fixture
+    def mock_game_map(self):
+        game_map = MagicMock()
+        game_map.get_collidable_tiles.return_value = []
+        game_map.spawn_points = self.SPAWN_POINTS
+        game_map.width_px = 16 * TILE_SIZE
+        game_map.height_px = 16 * TILE_SIZE
+        game_map.tile_size = SUB_TILE_SIZE
+        game_map.grid_to_pixels.side_effect = lambda gx, gy: (
+            gx * SUB_TILE_SIZE,
+            gy * SUB_TILE_SIZE,
+        )
+        return game_map
+
+    def test_custom_carrier_indices_used(
+        self, mock_texture_manager, mock_player_tank, mock_game_map
+    ):
+        """SpawnManager uses custom carrier indices instead of default."""
+        # Set carrier at index 1 (the 2nd enemy spawned)
+        manager = SpawnManager(
+            texture_manager=mock_texture_manager,
+            game_map=mock_game_map,
+            enemy_composition=_DEFAULT_COMPOSITION,
+            spawn_interval=5.0,
+            player_tank=mock_player_tank,
+            powerup_carrier_indices=(1,),
+        )
+        # Initial spawn is index 0 (not a carrier)
+        assert not manager.enemy_tanks[0].is_carrier
+
+        # Next spawn is index 1 (should be a carrier)
+        manager.enemy_tanks = []
+        manager.spawn_enemy(mock_player_tank, mock_game_map)
+        carrier_tanks = [t for t in manager.enemy_tanks if t.is_carrier]
+        assert len(carrier_tanks) == 1
+
+    def test_default_carrier_indices_when_not_provided(
+        self, mock_texture_manager, mock_player_tank, mock_game_map
+    ):
+        """SpawnManager falls back to POWERUP_CARRIER_INDICES when not provided."""
+        from src.utils.constants import POWERUP_CARRIER_INDICES
+
+        manager = SpawnManager(
+            texture_manager=mock_texture_manager,
+            game_map=mock_game_map,
+            enemy_composition=_DEFAULT_COMPOSITION,
+            spawn_interval=5.0,
+            player_tank=mock_player_tank,
+        )
+        assert manager._powerup_carrier_indices == POWERUP_CARRIER_INDICES

--- a/uv.lock
+++ b/uv.lock
@@ -35,7 +35,7 @@ wheels = [
 
 [[package]]
 name = "battle-city-clone"
-version = "0.10.0"
+version = "0.10.1"
 source = { virtual = "." }
 dependencies = [
     { name = "loguru" },


### PR DESCRIPTION
## Summary

- Add per-level `spawn_interval`, `difficulty`, and `powerup_carriers` map properties read from TMX files, each with backward-compatible fallbacks to existing constants
- Prefer `spawn_point_type` object property over object name when loading spawn points (falls back to name matching for existing maps)
- Accept `powerup_carrier_indices` as a parameter in `SpawnManager` instead of importing the constant directly
- Add `Difficulty` enum to `.tiled-project` property types for Tiled editor dropdown support

All 35 existing maps work unchanged — every new property has a sensible default fallback.

## Test plan

- [x] New unit tests for all three level properties (happy path + fallback/error cases)
- [x] New unit tests for SpawnPointType property usage (name fallback + property-based)
- [x] New unit tests for custom carrier indices in SpawnManager
- [x] All 783 existing tests pass with no regressions
- [x] Ruff check and format pass cleanly