### PR TITLE
Extract PlayerManager and PlayerInput from GameManager

### DIFF
--- a/src/core/map.py
+++ b/src/core/map.py
@@ -527,6 +527,27 @@ class Map:
             result.extend(self._cached_tiles_by_type.get(tt, []))
         return result
 
+    def is_tile_slidable(
+        self, tank_x: float, tank_y: float, tank_w: float, tank_h: float
+    ) -> bool:
+        """Check if the tile under a tank's center is slidable (ice).
+
+        Args:
+            tank_x: Tank x position in pixels.
+            tank_y: Tank y position in pixels.
+            tank_w: Tank width in pixels.
+            tank_h: Tank height in pixels.
+
+        Returns:
+            True if the tile under the tank center has is_slidable set.
+        """
+        center_x = int(tank_x + tank_w / 2)
+        center_y = int(tank_y + tank_h / 2)
+        grid_x = center_x // self.tile_size
+        grid_y = center_y // self.tile_size
+        tile = self.get_tile_at(grid_x, grid_y)
+        return tile is not None and tile.is_slidable
+
     def get_base(self) -> Optional[Tile]:
         """Find and return a player base tile, if it exists."""
         self._ensure_cache()

--- a/src/managers/collision_manager.py
+++ b/src/managers/collision_manager.py
@@ -19,7 +19,7 @@ class CollisionManager:
 
     def check_collisions(
         self,
-        player_tank: Optional[Collidable],
+        player_tanks: Sequence[Collidable],
         player_bullets: Sequence[Collidable],
         enemy_tanks: Sequence[Collidable],
         enemy_bullets: Sequence[Collidable],
@@ -32,22 +32,20 @@ class CollisionManager:
         Checks for collisions between different groups of game objects.
 
         Args:
-            player_tank: The player's tank object, or None if not present.
+            player_tanks: List of player tank objects (may be empty).
             player_bullets: A list/group of player bullet objects.
             enemy_tanks: A list/group of enemy tank objects.
             enemy_bullets: A list/group of enemy bullet objects.
             tank_blocking_tiles: Tiles that block tank movement.
             bullet_blocking_tiles: Tiles that block bullets.
             player_base: The player's base object, or None if not present.
-            power_ups: Active power-up objects to check against the player.
+            power_ups: Active power-up objects to check against players.
         """
         self._collision_events.clear()
         self._seen_pairs.clear()
 
-        # Combine tanks, handling potential None for player_tank
-        all_tanks: List[Collidable] = []
-        if player_tank:
-            all_tanks.append(player_tank)
+        # Combine tanks
+        all_tanks: List[Collidable] = list(player_tanks)
         all_tanks.extend(enemy_tanks)
 
         # Bullet collisions
@@ -60,7 +58,7 @@ class CollisionManager:
         if player_base:
             self._check_group_vs_single(player_bullets, player_base)
             self._check_group_vs_single(enemy_bullets, player_base)
-        if player_tank:
+        for player_tank in player_tanks:
             self._check_group_vs_single(enemy_bullets, player_tank)
 
         # Tank collisions
@@ -68,7 +66,7 @@ class CollisionManager:
         self._check_self_collisions(all_tanks)
 
         # Power-up collection
-        if player_tank:
+        for player_tank in player_tanks:
             for power_up in power_ups:
                 if player_tank.rect.colliderect(power_up.rect):
                     self._queue_collision(player_tank, power_up)

--- a/src/managers/collision_response_handler.py
+++ b/src/managers/collision_response_handler.py
@@ -34,6 +34,7 @@ class CollisionResponseHandler:
         add_score: Callable[[int], None] = lambda _: None,
         power_up_manager: Optional[PowerUpManager] = None,
         sound_manager: Optional[SoundManager] = None,
+        on_player_death: Optional[Callable[[PlayerTank], bool]] = None,
     ) -> None:
         self._map = game_map
         self._set_game_state = set_game_state
@@ -41,7 +42,9 @@ class CollisionResponseHandler:
         self._add_score = add_score
         self._power_up_manager = power_up_manager
         self._sound_manager = sound_manager
+        self._on_player_death = on_player_death
         self._collected_power_up_type: Optional[PowerUpType] = None
+        self._collected_power_up_player: Optional[PlayerTank] = None
 
         self._handlers: Dict[Tuple[Type, Type], Callable[[Any, Any, List], bool]] = {
             (Bullet, EnemyTank): self._handle_bullet_vs_enemy,
@@ -189,7 +192,11 @@ class CollisionResponseHandler:
                     float(player.rect.centery),
                 )
                 self._play_explosion()
-                self._set_game_state(GameState.GAME_OVER)
+                if self._on_player_death is not None:
+                    if self._on_player_death(player):
+                        self._set_game_state(GameState.GAME_OVER)
+                else:
+                    self._set_game_state(GameState.GAME_OVER)
             else:
                 player.respawn()
         return True
@@ -259,13 +266,23 @@ class CollisionResponseHandler:
             self._play_powerup()
             logger.info(f"Player collected power-up: {power_up_type.value}")
             self._collected_power_up_type = power_up_type
+            self._collected_power_up_player = player
         return True
 
-    def consume_collected_power_up(self) -> Optional[PowerUpType]:
-        """Return and clear the collected power-up type (one-shot read)."""
-        result = self._collected_power_up_type
+    def consume_collected_power_up(
+        self,
+    ) -> tuple[Optional[PowerUpType], Optional[PlayerTank]]:
+        """Return and clear the collected power-up type and player (one-shot read).
+
+        Returns:
+            Tuple of (power_up_type, collecting_player). Both None when nothing
+            was collected.
+        """
+        result_type = self._collected_power_up_type
+        result_player = self._collected_power_up_player
         self._collected_power_up_type = None
-        return result
+        self._collected_power_up_player = None
+        return result_type, result_player
 
     @staticmethod
     def _caused_collision(mover: Tank, other: Tank) -> bool:

--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -40,11 +40,8 @@ from src.managers.collision_manager import CollisionManager
 from src.managers.collision_response_handler import CollisionResponseHandler
 from src.managers.effect_manager import EffectManager
 from src.managers.texture_manager import TextureManager
-from src.managers.input_handler import (
-    InputHandler,
-    JOY_START_BUTTON,
-    CTRL_START_BUTTON,
-)
+from src.managers.input_handler import InputHandler
+from src.managers.player_input import CTRL_START_BUTTON, JOY_START_BUTTON
 from src.managers.spawn_manager import SpawnManager
 from src.managers.renderer import Renderer
 from src.managers.power_up_manager import PowerUpManager
@@ -489,10 +486,6 @@ class GameManager:
         player_base: Optional[Tile] = self.map.get_base()
 
         player_bullets = self.player_manager.get_all_bullets()
-        # Also include any player bullets in self.bullets (from _try_shoot legacy path)
-        for b in self.bullets:
-            if b.owner_type == OwnerType.PLAYER and b.active:
-                player_bullets.append(b)
         enemy_bullets = [b for b in self.bullets if b.owner_type == OwnerType.ENEMY]
 
         active_power_ups = self.power_up_manager.get_power_ups()

--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -713,11 +713,12 @@ class GameManager:
                 1.0, self._state_timer / GAME_OVER_RISE_DURATION
             )
 
+        all_bullets = self.player_manager.get_all_bullets() + self.bullets
         self.renderer.render(
             self.map,
             self.player_manager.get_active_players(),
             self.spawn_manager.enemy_tanks,
-            self.bullets,
+            all_bullets,
             self.effect_manager,
             self.state,
             self.player_manager.score,

--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -48,6 +48,7 @@ from src.managers.input_handler import (
 from src.managers.spawn_manager import SpawnManager
 from src.managers.renderer import Renderer
 from src.managers.power_up_manager import PowerUpManager
+from src.managers.player_manager import PlayerManager
 from src.managers.sound_manager import SoundManager
 from src.managers.settings_manager import SettingsManager
 from src.utils.paths import resource_path
@@ -79,6 +80,9 @@ class GameManager:
         self.sound_manager: SoundManager = SoundManager(
             master_volume=self.settings_manager.master_volume
         )
+        self.player_manager: PlayerManager = PlayerManager(
+            self.texture_manager, self.sound_manager
+        )
 
         self.state: GameState = GameState.TITLE_SCREEN
         self._title_selection: int = 0
@@ -97,6 +101,21 @@ class GameManager:
             LOGICAL_HEIGHT,
         )
 
+    @property
+    def player_tank(self) -> Optional[PlayerTank]:
+        """Return the first active player tank for backward compatibility.
+
+        Integration tests and rendering code that need a single player reference
+        can use this property. Returns None if no active players exist.
+        """
+        active = self.player_manager.get_active_players()
+        return active[0] if active else None
+
+    @property
+    def score(self) -> int:
+        """Return the player score for backward compatibility."""
+        return self.player_manager.score
+
     def _reset_game(self) -> None:
         """Start a new game and immediately enter RUNNING state (used by tests)."""
         self._new_game()
@@ -105,9 +124,8 @@ class GameManager:
     def _new_game(self) -> None:
         """Full reset for starting a new game. Does not set state."""
         self.current_stage = 1
-        self.score = 0
         self._state_timer = 0.0
-        self.player_tank = None
+        self.player_manager.reset()
         self._load_stage()
 
     @property
@@ -126,10 +144,7 @@ class GameManager:
         self.input_handler.reset()
 
         # Preserve player progress across stages
-        player_lives = self.player_tank.lives if self.player_tank is not None else 3
-        player_star_level = (
-            self.player_tank.star_level if self.player_tank is not None else 0
-        )
+        self.player_manager.preserve_state()
 
         self.collision_manager = CollisionManager()
 
@@ -160,21 +175,13 @@ class GameManager:
             game_map=self.map,
             set_game_state=self._set_game_state,
             effect_manager=self.effect_manager,
-            add_score=self._add_score,
+            add_score=self.player_manager.add_score,
             power_up_manager=self.power_up_manager,
             sound_manager=self.sound_manager,
+            on_player_death=self.player_manager.handle_player_death,
         )
 
-        start_x = self.map.player_spawn[0] * self.map.tile_size
-        start_y = self.map.player_spawn[1] * self.map.tile_size
-        self.player_tank = PlayerTank(
-            start_x,
-            start_y,
-            self.tile_size,
-            self.texture_manager,
-            map_width_px=map_width_px,
-            map_height_px=map_height_px,
-        )
+        self.player_manager.create_players(self.map)
 
         # Renderer (fixed logical surface with map centered inside)
         self.renderer = Renderer(
@@ -196,7 +203,7 @@ class GameManager:
             game_map=self.map,
             enemy_composition=self.map.enemy_composition,
             spawn_interval=self.map.spawn_interval,
-            player_tank=self.player_tank,
+            player_tanks=self.player_manager.get_active_players(),
             effect_manager=self.effect_manager,
             difficulty=effective_difficulty,
             powerup_carrier_indices=self.map.powerup_carrier_indices,
@@ -210,12 +217,11 @@ class GameManager:
         self._shovel_flash_showing_steel: bool = True
 
         # Restore player progress
-        self.player_tank.lives = player_lives
-        if player_star_level > 0:
-            self.player_tank.restore_star_level(player_star_level)
+        self.player_manager.restore_state()
 
         # Grant spawn invincibility (after progress restoration)
-        self.player_tank.activate_invincibility(SPAWN_INVINCIBILITY_DURATION)
+        for player in self.player_manager.get_active_players():
+            player.activate_invincibility(SPAWN_INVINCIBILITY_DURATION)
 
         if self._demo_mode:
             self._spawn_demo_power_ups()
@@ -263,6 +269,7 @@ class GameManager:
                     self._handle_escape()
 
             self.input_handler.handle_event(event)
+            self.player_manager.handle_event(event)
 
         if self.state != GameState.RUNNING:
             self._process_menu_actions()
@@ -441,29 +448,13 @@ class GameManager:
             return
 
         self.map.update(dt)
-        # Update player tank (stores prev position) BEFORE movement
-        self.player_tank.update(dt)
+        # Update player tanks via PlayerManager
+        self.player_manager.update(dt, self.map)
+        self.player_manager.try_shoot()
 
-        # Drive player tank from input
-        dx, dy = self.input_handler.get_movement_direction()
-        has_valid_input = (dx != 0 or dy != 0) and not (dx != 0 and dy != 0)
-
-        # Ice slide: trigger BEFORE move() so start_slide() captures the old direction
-        self.player_tank.on_ice = self._is_on_ice(self.player_tank)
-        if self.player_tank.on_ice and not self.player_tank.is_sliding:
-            if not has_valid_input or (dx, dy) != self.player_tank.direction.delta:
-                if self.player_tank.start_slide():
-                    self.sound_manager.play_ice_slide()
-
-        if has_valid_input and not self.player_tank.is_sliding:
-            self.player_tank.move(dx, dy, dt)
-        if self.input_handler.consume_shoot():
-            self._try_shoot(self.player_tank)
-
+        active_players = self.player_manager.get_active_players()
         player_pos = (
-            (self.player_tank.x, self.player_tank.y)
-            if self.player_tank and self.player_tank.health > 0
-            else None
+            (active_players[0].x, active_players[0].y) if active_players else None
         )
 
         if self.freeze_timer > 0:
@@ -476,18 +467,18 @@ class GameManager:
                     self._try_shoot(enemy)
 
         # Engine sound: plays when any tank is moving
-        any_moving = self.player_tank.is_moving or any(
+        any_moving = any(p.is_moving for p in active_players) or any(
             e.is_moving for e in self.spawn_manager.enemy_tanks
         )
         self.sound_manager.update_engine(any_moving)
 
-        # Update all bullets
+        # Update enemy bullets (player bullets managed by PlayerManager)
         for bullet in self.bullets:
             bullet.update(dt)
         # Remove inactive bullets
         self.bullets = [b for b in self.bullets if b.active]
 
-        self.spawn_manager.update(dt, self.player_tank, self.map)
+        self.spawn_manager.update(dt, active_players, self.map)
         self.power_up_manager.update(dt)
         self._tick_shovel(dt)
 
@@ -497,13 +488,17 @@ class GameManager:
         bullet_blocking_tiles: List[Tile] = self.map.get_bullet_blocking_tiles()
         player_base: Optional[Tile] = self.map.get_base()
 
-        player_bullets = [b for b in self.bullets if b.owner_type == OwnerType.PLAYER]
+        player_bullets = self.player_manager.get_all_bullets()
+        # Also include any player bullets in self.bullets (from _try_shoot legacy path)
+        for b in self.bullets:
+            if b.owner_type == OwnerType.PLAYER and b.active:
+                player_bullets.append(b)
         enemy_bullets = [b for b in self.bullets if b.owner_type == OwnerType.ENEMY]
 
         active_power_ups = self.power_up_manager.get_power_ups()
 
         self.collision_manager.check_collisions(
-            player_tank=self.player_tank,
+            player_tanks=active_players,
             player_bullets=player_bullets,
             enemy_tanks=self.spawn_manager.enemy_tanks,
             enemy_bullets=enemy_bullets,
@@ -519,13 +514,16 @@ class GameManager:
             self.spawn_manager.remove_enemy(enemy)
             if enemy.is_carrier:
                 self.power_up_manager.spawn_power_up(
-                    self.player_tank, self.spawn_manager.enemy_tanks
+                    active_players[0] if active_players else None,
+                    self.spawn_manager.enemy_tanks,
                 )
 
         # Apply deferred power-up effect
-        collected = self.collision_response_handler.consume_collected_power_up()
-        if collected is not None:
-            self._apply_power_up(collected)
+        collected_type, collected_player = (
+            self.collision_response_handler.consume_collected_power_up()
+        )
+        if collected_type is not None:
+            self._apply_power_up(collected_type, collected_player)
 
         # Powerup blink sound: plays when any powerup is active
         self.sound_manager.update_powerup_blink(bool(active_power_ups))
@@ -578,13 +576,21 @@ class GameManager:
         tile = self.map.get_tile_at(grid_x, grid_y)
         return tile is not None and tile.is_slidable
 
-    def _add_score(self, points: int) -> None:
-        """Add points to the player's score."""
-        self.score += points
+    def _apply_power_up(
+        self, power_up_type: PowerUpType, player: Optional[PlayerTank] = None
+    ) -> None:
+        """Dispatch power-up effect by type.
 
-    def _apply_power_up(self, power_up_type: PowerUpType) -> None:
-        """Dispatch power-up effect by type."""
+        Args:
+            power_up_type: The type of power-up to apply.
+            player: The player tank that collected the power-up.
+        """
         if self.state != GameState.RUNNING:
+            return
+        if player is None:
+            active = self.player_manager.get_active_players()
+            player = active[0] if active else None
+        if player is None:
             return
         handlers = {
             PowerUpType.HELMET: self._apply_helmet,
@@ -596,24 +602,24 @@ class GameManager:
         }
         handler = handlers.get(power_up_type)
         if handler:
-            handler()
+            handler(player)
         else:
             logger.warning(f"Unhandled power-up type: {power_up_type}")
 
-    def _apply_helmet(self) -> None:
+    def _apply_helmet(self, player: PlayerTank) -> None:
         """Grant temporary invincibility to the player."""
-        self.player_tank.activate_invincibility(HELMET_INVINCIBILITY_DURATION)
+        player.activate_invincibility(HELMET_INVINCIBILITY_DURATION)
         logger.info(
             f"Helmet power-up applied: player invincible "
             f"for {HELMET_INVINCIBILITY_DURATION}s"
         )
 
-    def _apply_extra_life(self) -> None:
+    def _apply_extra_life(self, player: PlayerTank) -> None:
         """Award the player one extra life."""
-        self.player_tank.lives += 1
-        logger.info(f"Extra Life power-up applied: lives now {self.player_tank.lives}")
+        player.lives += 1
+        logger.info(f"Extra Life power-up applied: lives now {player.lives}")
 
-    def _apply_bomb(self) -> None:
+    def _apply_bomb(self, player: PlayerTank) -> None:
         """Destroy all active enemies on the map without awarding points."""
         for enemy in list(self.spawn_manager.enemy_tanks):
             self.effect_manager.spawn(
@@ -624,14 +630,14 @@ class GameManager:
             self.spawn_manager.remove_enemy(enemy)
         logger.info("Bomb power-up applied: all enemies destroyed")
 
-    def _apply_clock(self) -> None:
+    def _apply_clock(self, player: PlayerTank) -> None:
         """Freeze all enemies for the clock duration."""
         self.freeze_timer = CLOCK_FREEZE_DURATION
         logger.info(
             f"Clock power-up applied: enemies frozen for {CLOCK_FREEZE_DURATION}s"
         )
 
-    def _apply_shovel(self) -> None:
+    def _apply_shovel(self, player: PlayerTank) -> None:
         """Fortify base walls with steel, restoring destroyed bricks first."""
         if not self._shovel_original_tiles:
             tiles = self.map.get_base_surrounding_tiles(include_empty=True)
@@ -680,12 +686,10 @@ class GameManager:
                         target = TileType.STEEL if should_show_steel else orig_type
                         self.map.set_tile_type(tile, target)
 
-    def _apply_star(self) -> None:
+    def _apply_star(self, player: PlayerTank) -> None:
         """Apply star upgrade to the player tank."""
-        self.player_tank.apply_star()
-        logger.info(
-            f"Star power-up applied: player at tier {self.player_tank.star_level}"
-        )
+        player.apply_star()
+        logger.info(f"Star power-up applied: player at tier {player.star_level}")
 
     def render(self) -> None:
         """Render the game state."""
@@ -723,12 +727,12 @@ class GameManager:
 
         self.renderer.render(
             self.map,
-            self.player_tank,
+            self.player_manager.get_active_players(),
             self.spawn_manager.enemy_tanks,
             self.bullets,
             self.effect_manager,
             self.state,
-            self.score,
+            self.player_manager.score,
             power_ups=self.power_up_manager.get_power_ups(),
             game_over_rise_progress=game_over_rise_progress,
         )

--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -100,17 +100,17 @@ class GameManager:
 
     @property
     def player_tank(self) -> Optional[PlayerTank]:
-        """Return the first active player tank for backward compatibility.
+        """Convenience property returning the first active player tank.
 
-        Integration tests and rendering code that need a single player reference
-        can use this property. Returns None if no active players exist.
+        Used by integration tests that need a single player reference.
+        Returns None if no active players exist.
         """
         active = self.player_manager.get_active_players()
         return active[0] if active else None
 
     @property
     def score(self) -> int:
-        """Return the player score for backward compatibility."""
+        """Convenience property delegating to player_manager.score."""
         return self.player_manager.score
 
     def _reset_game(self) -> None:
@@ -562,12 +562,7 @@ class GameManager:
 
     def _is_on_ice(self, tank) -> bool:
         """Check if the tank's center is over an ice tile."""
-        center_x = int(tank.x + tank.width / 2)
-        center_y = int(tank.y + tank.height / 2)
-        grid_x = center_x // self.map.tile_size
-        grid_y = center_y // self.map.tile_size
-        tile = self.map.get_tile_at(grid_x, grid_y)
-        return tile is not None and tile.is_slidable
+        return self.map.is_tile_slidable(tank.x, tank.y, tank.width, tank.height)
 
     def _apply_power_up(
         self, power_up_type: PowerUpType, player: Optional[PlayerTank] = None

--- a/src/managers/input_handler.py
+++ b/src/managers/input_handler.py
@@ -1,5 +1,5 @@
 import pygame
-from typing import Tuple, Dict, Optional
+from typing import Optional
 from loguru import logger
 from src.utils.constants import Direction, MenuAction
 
@@ -35,31 +35,15 @@ _CONFIRM_KEYS: tuple[int, ...] = (pygame.K_RETURN, pygame.K_r)
 
 
 class InputHandler:
-    """Handles keyboard and controller input for the player tank."""
+    """Handles keyboard and controller input for menus and system actions.
 
-    def __init__(self, shoot_key: int = pygame.K_SPACE) -> None:
+    Gameplay input (movement, shooting) is handled by PlayerInput via
+    PlayerManager. This class handles menu navigation, pause, joystick
+    hot-plug, and confirm keys.
+    """
+
+    def __init__(self) -> None:
         """Initialize the input handler."""
-        self.directions: Dict[Direction, bool] = {
-            Direction.UP: False,
-            Direction.DOWN: False,
-            Direction.LEFT: False,
-            Direction.RIGHT: False,
-        }
-        self.key_mappings: Dict[int, Direction] = {
-            pygame.K_UP: Direction.UP,
-            pygame.K_DOWN: Direction.DOWN,
-            pygame.K_LEFT: Direction.LEFT,
-            pygame.K_RIGHT: Direction.RIGHT,
-        }
-        self.shoot_key: int = shoot_key
-        self.shoot_pressed: bool = False
-        # Joystick/controller state (tracked separately from keyboard)
-        self.joy_directions: Dict[Direction, bool] = {
-            Direction.UP: False,
-            Direction.DOWN: False,
-            Direction.LEFT: False,
-            Direction.RIGHT: False,
-        }
         self.joystick: Optional["pygame.joystick.JoystickType"] = None
         self._init_joystick()
         self._menu_actions: list[MenuAction] = []
@@ -96,48 +80,27 @@ class InputHandler:
             if new_state is not None:
                 self._menu_actions.append(new_state)
 
-    def _handle_axis(
-        self, value: float, neg_dir: Direction, pos_dir: Direction
-    ) -> None:
-        """Update joy_directions for an axis value with deadzone."""
-        if value < -AXIS_DEADZONE:
-            self.joy_directions[neg_dir] = True
-            self.joy_directions[pos_dir] = False
-        elif value > AXIS_DEADZONE:
-            self.joy_directions[pos_dir] = True
-            self.joy_directions[neg_dir] = False
-        else:
-            self.joy_directions[neg_dir] = False
-            self.joy_directions[pos_dir] = False
-
     def handle_event(self, event: pygame.event.Event) -> None:
-        """
-        Handle a pygame event to update input state.
+        """Handle a pygame event to update menu and system input state.
 
         Handles keyboard, raw joystick (JOY*), and SDL GameController
-        (CONTROLLER*) events. Recognized controllers (Xbox, PlayStation)
-        emit CONTROLLER* events; unrecognized ones emit JOY* events.
+        (CONTROLLER*) events for menu navigation and system actions.
+        Gameplay input (movement, shooting) is handled by PlayerInput.
 
         Args:
             event: The pygame event to handle
         """
         if event.type == pygame.KEYDOWN:
-            if event.key in self.key_mappings:
-                direction = self.key_mappings[event.key]
-                if not self.directions[direction]:
-                    logger.trace(f"Key down: {direction}")
-                    self.directions[direction] = True
+            direction = {
+                pygame.K_UP: Direction.UP,
+                pygame.K_DOWN: Direction.DOWN,
+                pygame.K_LEFT: Direction.LEFT,
+                pygame.K_RIGHT: Direction.RIGHT,
+            }.get(event.key)
+            if direction is not None:
                 self._menu_actions.append(_DIRECTION_TO_MENU_ACTION[direction])
-            if event.key == self.shoot_key:
-                self.shoot_pressed = True
             if event.key in _CONFIRM_KEYS:
                 self._menu_actions.append(MenuAction.CONFIRM)
-        elif event.type == pygame.KEYUP:
-            if event.key in self.key_mappings:
-                direction = self.key_mappings[event.key]
-                if self.directions[direction]:
-                    logger.trace(f"Key up: {direction}")
-                    self.directions[direction] = False
 
         # --- Hot-plug (shared by both APIs) ---
         elif event.type == pygame.JOYDEVICEADDED:
@@ -152,34 +115,25 @@ class InputHandler:
             ):
                 logger.info(f"Joystick disconnected: {self.joystick.get_name()}")
                 self.joystick = None
-                for direction in self.joy_directions:
-                    self.joy_directions[direction] = False
 
         # --- SDL GameController API (recognized controllers) ---
         elif event.type == pygame.CONTROLLERBUTTONDOWN:
             if event.button in CTRL_DPAD_BUTTONS:
                 direction = CTRL_DPAD_BUTTONS[event.button]
-                for d in self.joy_directions:
-                    self.joy_directions[d] = False
-                self.joy_directions[direction] = True
                 self._menu_actions.append(_DIRECTION_TO_MENU_ACTION[direction])
             elif event.button in CTRL_SHOOT_BUTTONS:
-                self.shoot_pressed = True
                 self._menu_actions.append(MenuAction.CONFIRM)
-        elif event.type == pygame.CONTROLLERBUTTONUP:
-            if event.button in CTRL_DPAD_BUTTONS:
-                direction = CTRL_DPAD_BUTTONS[event.button]
-                self.joy_directions[direction] = False
 
         # --- Axis motion (shared: CONTROLLER_AXIS_LEFTX == 0, LEFTY == 1) ---
-        elif event.type in (pygame.CONTROLLERAXISMOTION, pygame.JOYAXISMOTION):
+        elif event.type in (
+            pygame.CONTROLLERAXISMOTION,
+            pygame.JOYAXISMOTION,
+        ):
             if event.axis in (pygame.CONTROLLER_AXIS_LEFTX, JOY_AXIS_X):
-                self._handle_axis(event.value, Direction.LEFT, Direction.RIGHT)
                 self._emit_axis_menu_action(
                     True, event.value, MenuAction.LEFT, MenuAction.RIGHT
                 )
             elif event.axis in (pygame.CONTROLLER_AXIS_LEFTY, JOY_AXIS_Y):
-                self._handle_axis(event.value, Direction.UP, Direction.DOWN)
                 self._emit_axis_menu_action(
                     False, event.value, MenuAction.UP, MenuAction.DOWN
                 )
@@ -187,8 +141,6 @@ class InputHandler:
         # --- Raw joystick API (unrecognized controllers) ---
         elif event.type == pygame.JOYHATMOTION:
             hat_x, hat_y = event.value
-            for d in self.joy_directions:
-                self.joy_directions[d] = False
             hat_dir: Optional[Direction] = None
             if hat_y > 0:
                 hat_dir = Direction.UP
@@ -199,43 +151,13 @@ class InputHandler:
             elif hat_x < 0:
                 hat_dir = Direction.LEFT
             if hat_dir is not None:
-                self.joy_directions[hat_dir] = True
                 self._menu_actions.append(_DIRECTION_TO_MENU_ACTION[hat_dir])
         elif event.type == pygame.JOYBUTTONDOWN:
             if event.button in JOY_SHOOT_BUTTONS:
-                self.shoot_pressed = True
                 self._menu_actions.append(MenuAction.CONFIRM)
-
-    def get_movement_direction(self) -> Tuple[int, int]:
-        """
-        Get the current movement direction as a vector.
-
-        Merges keyboard and joystick input (OR logic).
-
-        Returns:
-            A tuple (dx, dy) representing the movement direction
-        """
-        dx = 0
-        dy = 0
-        for direction, pressed in self.directions.items():
-            if pressed:
-                ddx, ddy = direction.delta
-                dx += ddx
-                dy += ddy
-        for direction, pressed in self.joy_directions.items():
-            if pressed:
-                ddx, ddy = direction.delta
-                dx += ddx
-                dy += ddy
-        return (dx, dy)
 
     def reset(self) -> None:
         """Reset all input state. Called between stages."""
-        for direction in self.directions:
-            self.directions[direction] = False
-        for direction in self.joy_directions:
-            self.joy_directions[direction] = False
-        self.shoot_pressed = False
         self._menu_actions.clear()
         self._axis_menu_h = None
         self._axis_menu_v = None
@@ -247,15 +169,3 @@ class InputHandler:
         actions = self._menu_actions
         self._menu_actions = []
         return actions
-
-    def consume_shoot(self) -> bool:
-        """
-        Check if shoot was pressed and reset the flag.
-
-        Returns:
-            True if shoot was pressed since last check, False otherwise.
-        """
-        if self.shoot_pressed:
-            self.shoot_pressed = False
-            return True
-        return False

--- a/src/managers/input_handler.py
+++ b/src/managers/input_handler.py
@@ -2,27 +2,14 @@ import pygame
 from typing import Optional
 from loguru import logger
 from src.utils.constants import Direction, MenuAction
-
-AXIS_DEADZONE: float = 0.5
-
-# Raw joystick API (fallback for controllers not in SDL's GameController DB)
-JOY_AXIS_X: int = 0
-JOY_AXIS_Y: int = 1
-JOY_SHOOT_BUTTONS: tuple[int, ...] = (0, 1)
-JOY_START_BUTTON: int = 7
-
-# SDL GameController API (normalized IDs for recognized controllers like Xbox)
-CTRL_DPAD_BUTTONS: dict[int, Direction] = {
-    pygame.CONTROLLER_BUTTON_DPAD_UP: Direction.UP,
-    pygame.CONTROLLER_BUTTON_DPAD_DOWN: Direction.DOWN,
-    pygame.CONTROLLER_BUTTON_DPAD_LEFT: Direction.LEFT,
-    pygame.CONTROLLER_BUTTON_DPAD_RIGHT: Direction.RIGHT,
-}
-CTRL_SHOOT_BUTTONS: tuple[int, ...] = (
-    pygame.CONTROLLER_BUTTON_A,
-    pygame.CONTROLLER_BUTTON_B,
+from src.managers.player_input import (
+    AXIS_DEADZONE,
+    CTRL_DPAD_BUTTONS,
+    CTRL_SHOOT_BUTTONS,
+    JOY_AXIS_X,
+    JOY_AXIS_Y,
+    JOY_SHOOT_BUTTONS,
 )
-CTRL_START_BUTTON: int = pygame.CONTROLLER_BUTTON_START
 
 _DIRECTION_TO_MENU_ACTION: dict[Direction, MenuAction] = {
     Direction.UP: MenuAction.UP,

--- a/src/managers/player_input.py
+++ b/src/managers/player_input.py
@@ -13,6 +13,7 @@ AXIS_DEADZONE: float = 0.5
 JOY_AXIS_X: int = 0
 JOY_AXIS_Y: int = 1
 JOY_SHOOT_BUTTONS: tuple[int, ...] = (0, 1)
+JOY_START_BUTTON: int = 7
 
 # SDL GameController API (normalized IDs for recognized controllers like Xbox)
 CTRL_DPAD_BUTTONS: dict[int, Direction] = {
@@ -25,6 +26,7 @@ CTRL_SHOOT_BUTTONS: tuple[int, ...] = (
     pygame.CONTROLLER_BUTTON_A,
     pygame.CONTROLLER_BUTTON_B,
 )
+CTRL_START_BUTTON: int = pygame.CONTROLLER_BUTTON_START
 
 
 class InputSource(Enum):

--- a/src/managers/player_input.py
+++ b/src/managers/player_input.py
@@ -1,0 +1,209 @@
+"""Per-player gameplay input encapsulation (keyboard or joystick)."""
+
+from enum import Enum, auto
+from typing import Dict, Optional
+
+import pygame
+
+from src.utils.constants import Direction
+
+AXIS_DEADZONE: float = 0.5
+
+# Raw joystick API (fallback for controllers not in SDL's GameController DB)
+JOY_AXIS_X: int = 0
+JOY_AXIS_Y: int = 1
+JOY_SHOOT_BUTTONS: tuple[int, ...] = (0, 1)
+
+# SDL GameController API (normalized IDs for recognized controllers like Xbox)
+CTRL_DPAD_BUTTONS: dict[int, Direction] = {
+    pygame.CONTROLLER_BUTTON_DPAD_UP: Direction.UP,
+    pygame.CONTROLLER_BUTTON_DPAD_DOWN: Direction.DOWN,
+    pygame.CONTROLLER_BUTTON_DPAD_LEFT: Direction.LEFT,
+    pygame.CONTROLLER_BUTTON_DPAD_RIGHT: Direction.RIGHT,
+}
+CTRL_SHOOT_BUTTONS: tuple[int, ...] = (
+    pygame.CONTROLLER_BUTTON_A,
+    pygame.CONTROLLER_BUTTON_B,
+)
+
+
+class InputSource(Enum):
+    """Input source type for a player."""
+
+    KEYBOARD = auto()
+    JOYSTICK = auto()
+
+
+class PlayerInput:
+    """Encapsulates per-player gameplay input from a keyboard or joystick.
+
+    For KEYBOARD source, handles arrow keys for direction and SPACE to shoot.
+    For JOYSTICK source, handles controller/joystick events filtered by
+    joystick_index.
+    """
+
+    def __init__(self, source: InputSource, joystick_index: int = 0) -> None:
+        """Initialize PlayerInput.
+
+        Args:
+            source: Whether this player uses KEYBOARD or JOYSTICK input.
+            joystick_index: The joystick/controller index (only used when
+                source is JOYSTICK).
+        """
+        self.source = source
+        self.joystick_index = joystick_index
+
+        self._directions: Dict[Direction, bool] = {
+            Direction.UP: False,
+            Direction.DOWN: False,
+            Direction.LEFT: False,
+            Direction.RIGHT: False,
+        }
+        self._shoot_pressed: bool = False
+
+        self._key_mappings: Dict[int, Direction] = {
+            pygame.K_UP: Direction.UP,
+            pygame.K_DOWN: Direction.DOWN,
+            pygame.K_LEFT: Direction.LEFT,
+            pygame.K_RIGHT: Direction.RIGHT,
+        }
+
+    def handle_event(self, event: pygame.event.Event) -> None:
+        """Process a pygame event and update internal input state.
+
+        Args:
+            event: The pygame event to handle.
+        """
+        if self.source == InputSource.KEYBOARD:
+            self._handle_keyboard_event(event)
+        else:
+            self._handle_joystick_event(event)
+
+    def get_movement_direction(self) -> tuple[int, int]:
+        """Return the current movement direction as a (dx, dy) vector.
+
+        Returns:
+            A tuple (dx, dy) where each component is -1, 0, or 1.
+        """
+        dx = 0
+        dy = 0
+        for direction, pressed in self._directions.items():
+            if pressed:
+                ddx, ddy = direction.delta
+                dx += ddx
+                dy += ddy
+        return (dx, dy)
+
+    def consume_shoot(self) -> bool:
+        """Return and clear the shoot flag.
+
+        Returns:
+            True if shoot was pressed since the last call, False otherwise.
+        """
+        if self._shoot_pressed:
+            self._shoot_pressed = False
+            return True
+        return False
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _handle_keyboard_event(self, event: pygame.event.Event) -> None:
+        """Handle keyboard events (KEYDOWN / KEYUP)."""
+        if event.type == pygame.KEYDOWN:
+            if event.key in self._key_mappings:
+                direction = self._key_mappings[event.key]
+                self._directions[direction] = True
+            if event.key == pygame.K_SPACE:
+                self._shoot_pressed = True
+        elif event.type == pygame.KEYUP:
+            if event.key in self._key_mappings:
+                direction = self._key_mappings[event.key]
+                self._directions[direction] = False
+
+    def _handle_joystick_event(self, event: pygame.event.Event) -> None:
+        """Handle joystick/controller events filtered by joystick_index."""
+        # --- SDL GameController API ---
+        if event.type == pygame.CONTROLLERBUTTONDOWN:
+            if event.which != self.joystick_index:
+                return
+            if event.button in CTRL_DPAD_BUTTONS:
+                direction = CTRL_DPAD_BUTTONS[event.button]
+                for d in self._directions:
+                    self._directions[d] = False
+                self._directions[direction] = True
+            elif event.button in CTRL_SHOOT_BUTTONS:
+                self._shoot_pressed = True
+
+        elif event.type == pygame.CONTROLLERBUTTONUP:
+            if event.which != self.joystick_index:
+                return
+            if event.button in CTRL_DPAD_BUTTONS:
+                direction = CTRL_DPAD_BUTTONS[event.button]
+                self._directions[direction] = False
+
+        # --- Axis motion (CONTROLLER and raw JOY share axis indices 0/1) ---
+        elif event.type in (pygame.CONTROLLERAXISMOTION, pygame.JOYAXISMOTION):
+            joy_index = self._get_joy_index(event)
+            if joy_index != self.joystick_index:
+                return
+            if event.axis in (pygame.CONTROLLER_AXIS_LEFTX, JOY_AXIS_X):
+                self._handle_axis(event.value, Direction.LEFT, Direction.RIGHT)
+            elif event.axis in (pygame.CONTROLLER_AXIS_LEFTY, JOY_AXIS_Y):
+                self._handle_axis(event.value, Direction.UP, Direction.DOWN)
+
+        # --- Raw joystick API ---
+        elif event.type == pygame.JOYHATMOTION:
+            if event.joy != self.joystick_index:
+                return
+            hat_x, hat_y = event.value
+            for d in self._directions:
+                self._directions[d] = False
+            hat_dir: Optional[Direction] = None
+            if hat_y > 0:
+                hat_dir = Direction.UP
+            elif hat_y < 0:
+                hat_dir = Direction.DOWN
+            elif hat_x > 0:
+                hat_dir = Direction.RIGHT
+            elif hat_x < 0:
+                hat_dir = Direction.LEFT
+            if hat_dir is not None:
+                self._directions[hat_dir] = True
+
+        elif event.type == pygame.JOYBUTTONDOWN:
+            if event.joy != self.joystick_index:
+                return
+            if event.button in JOY_SHOOT_BUTTONS:
+                self._shoot_pressed = True
+
+    def _handle_axis(
+        self, value: float, neg_dir: Direction, pos_dir: Direction
+    ) -> None:
+        """Update direction state for an axis value with deadzone.
+
+        Args:
+            value: The raw axis value in [-1.0, 1.0].
+            neg_dir: Direction to activate when value < -deadzone.
+            pos_dir: Direction to activate when value > +deadzone.
+        """
+        if value < -AXIS_DEADZONE:
+            self._directions[neg_dir] = True
+            self._directions[pos_dir] = False
+        elif value > AXIS_DEADZONE:
+            self._directions[pos_dir] = True
+            self._directions[neg_dir] = False
+        else:
+            self._directions[neg_dir] = False
+            self._directions[pos_dir] = False
+
+    @staticmethod
+    def _get_joy_index(event: pygame.event.Event) -> int:
+        """Return the joystick index from a CONTROLLERAXISMOTION or JOYAXISMOTION event.
+
+        CONTROLLERAXISMOTION uses ``which``; JOYAXISMOTION uses ``joy``.
+        """
+        if event.type == pygame.CONTROLLERAXISMOTION:
+            return event.which
+        return event.joy

--- a/src/managers/player_input.py
+++ b/src/managers/player_input.py
@@ -71,11 +71,16 @@ class PlayerInput:
     def handle_event(self, event: pygame.event.Event) -> None:
         """Process a pygame event and update internal input state.
 
+        Keyboard source handles both keyboard and controller/joystick events
+        (since a single player may use either input device). Joystick source
+        handles only controller/joystick events filtered by joystick_index.
+
         Args:
             event: The pygame event to handle.
         """
         if self.source == InputSource.KEYBOARD:
             self._handle_keyboard_event(event)
+            self._handle_joystick_event(event)
         else:
             self._handle_joystick_event(event)
 
@@ -126,7 +131,7 @@ class PlayerInput:
         """Handle joystick/controller events filtered by joystick_index."""
         # --- SDL GameController API ---
         if event.type == pygame.CONTROLLERBUTTONDOWN:
-            if event.which != self.joystick_index:
+            if getattr(event, "which", self.joystick_index) != self.joystick_index:
                 return
             if event.button in CTRL_DPAD_BUTTONS:
                 direction = CTRL_DPAD_BUTTONS[event.button]
@@ -137,7 +142,7 @@ class PlayerInput:
                 self._shoot_pressed = True
 
         elif event.type == pygame.CONTROLLERBUTTONUP:
-            if event.which != self.joystick_index:
+            if getattr(event, "which", self.joystick_index) != self.joystick_index:
                 return
             if event.button in CTRL_DPAD_BUTTONS:
                 direction = CTRL_DPAD_BUTTONS[event.button]
@@ -155,7 +160,7 @@ class PlayerInput:
 
         # --- Raw joystick API ---
         elif event.type == pygame.JOYHATMOTION:
-            if event.joy != self.joystick_index:
+            if getattr(event, "joy", self.joystick_index) != self.joystick_index:
                 return
             hat_x, hat_y = event.value
             for d in self._directions:
@@ -173,7 +178,7 @@ class PlayerInput:
                 self._directions[hat_dir] = True
 
         elif event.type == pygame.JOYBUTTONDOWN:
-            if event.joy != self.joystick_index:
+            if getattr(event, "joy", self.joystick_index) != self.joystick_index:
                 return
             if event.button in JOY_SHOOT_BUTTONS:
                 self._shoot_pressed = True
@@ -198,12 +203,13 @@ class PlayerInput:
             self._directions[neg_dir] = False
             self._directions[pos_dir] = False
 
-    @staticmethod
-    def _get_joy_index(event: pygame.event.Event) -> int:
+    def _get_joy_index(self, event: pygame.event.Event) -> int:
         """Return the joystick index from a CONTROLLERAXISMOTION or JOYAXISMOTION event.
 
         CONTROLLERAXISMOTION uses ``which``; JOYAXISMOTION uses ``joy``.
+        Falls back to own joystick_index when the attribute is missing
+        (e.g. manually created test events).
         """
         if event.type == pygame.CONTROLLERAXISMOTION:
-            return event.which
-        return event.joy
+            return getattr(event, "which", self.joystick_index)
+        return getattr(event, "joy", self.joystick_index)

--- a/src/managers/player_input.py
+++ b/src/managers/player_input.py
@@ -73,18 +73,16 @@ class PlayerInput:
     def handle_event(self, event: pygame.event.Event) -> None:
         """Process a pygame event and update internal input state.
 
-        Keyboard source handles both keyboard and controller/joystick events
-        (since a single player may use either input device). Joystick source
-        handles only controller/joystick events filtered by joystick_index.
+        Both keyboard and joystick events are always handled regardless of
+        source type, matching the original InputHandler behavior where keyboard
+        and joystick input were merged with OR logic. The source type only
+        affects which joystick index is used for filtering.
 
         Args:
             event: The pygame event to handle.
         """
-        if self.source == InputSource.KEYBOARD:
-            self._handle_keyboard_event(event)
-            self._handle_joystick_event(event)
-        else:
-            self._handle_joystick_event(event)
+        self._handle_keyboard_event(event)
+        self._handle_joystick_event(event)
 
     def get_movement_direction(self) -> tuple[int, int]:
         """Return the current movement direction as a (dx, dy) vector.

--- a/src/managers/player_manager.py
+++ b/src/managers/player_manager.py
@@ -1,0 +1,282 @@
+"""PlayerManager: owns player tanks, input, bullets, and score."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+import pygame
+
+from src.core.bullet import Bullet
+from src.core.player_tank import PlayerTank
+from src.managers.player_input import InputSource, PlayerInput
+
+if TYPE_CHECKING:
+    from src.core.map import Map
+    from src.managers.sound_manager import SoundManager
+    from src.managers.texture_manager import TextureManager
+
+
+class PlayerManager:
+    """Owns the player tank(s), their input bindings, bullets, and score.
+
+    Responsibilities:
+    - Create player tanks at map spawn points.
+    - Forward pygame events to PlayerInput instances.
+    - Each update: call player.update(), apply ice sliding, apply movement.
+    - On try_shoot: consume shoot input and spawn bullets up to max_bullets.
+    - Track player score.
+    """
+
+    def __init__(
+        self, texture_manager: "TextureManager", sound_manager: "SoundManager"
+    ) -> None:
+        """Initialize PlayerManager.
+
+        Args:
+            texture_manager: Texture atlas used when creating player tanks.
+            sound_manager: Sound manager used to play audio cues.
+        """
+        self._texture_manager = texture_manager
+        self._sound_manager = sound_manager
+        self._players: list[PlayerTank] = []
+        self._player_inputs: list[PlayerInput] = []
+        self._bullets: list[Bullet] = []
+        self._score: int = 0
+        self._preserved_state: dict[int, dict] = {}
+
+    # ------------------------------------------------------------------
+    # Setup
+    # ------------------------------------------------------------------
+
+    def create_players(self, game_map: "Map", two_player_mode: bool = False) -> None:
+        """Create player tank(s) at map spawn points and assign input sources.
+
+        For 1P mode: creates one PlayerTank at game_map.player_spawn.
+        Assigns a joystick input if a joystick is detected, otherwise keyboard.
+        Clears any previously stored players, inputs, and bullets.
+
+        Args:
+            game_map: The loaded Map object providing spawn position and dimensions.
+            two_player_mode: Reserved for future 2-player support (unused).
+        """
+        self._players.clear()
+        self._player_inputs.clear()
+        self._bullets.clear()
+
+        map_width_px = game_map.width * game_map.tile_size
+        map_height_px = game_map.height * game_map.tile_size
+        start_x = game_map.player_spawn[0] * game_map.tile_size
+        start_y = game_map.player_spawn[1] * game_map.tile_size
+
+        player = PlayerTank(
+            start_x,
+            start_y,
+            game_map.tile_size,
+            self._texture_manager,
+            map_width_px=map_width_px,
+            map_height_px=map_height_px,
+        )
+        self._players.append(player)
+
+        if pygame.joystick.get_count() > 0:
+            self._player_inputs.append(
+                PlayerInput(InputSource.JOYSTICK, joystick_index=0)
+            )
+        else:
+            self._player_inputs.append(PlayerInput(InputSource.KEYBOARD))
+
+    # ------------------------------------------------------------------
+    # Event forwarding
+    # ------------------------------------------------------------------
+
+    def handle_event(self, event: pygame.event.Event) -> None:
+        """Forward a pygame event to all PlayerInput instances.
+
+        Args:
+            event: The pygame event to process.
+        """
+        for pi in self._player_inputs:
+            pi.handle_event(event)
+
+    # ------------------------------------------------------------------
+    # Per-frame update
+    # ------------------------------------------------------------------
+
+    def update(self, dt: float, game_map: "Map") -> None:
+        """Process input, move players, and handle ice sliding.
+
+        For each live player:
+        1. Call player.update(dt) to advance timers.
+        2. Read movement direction from the paired PlayerInput.
+        3. Detect whether the player is on an ice tile and start sliding if needed.
+        4. Apply player.move() when there is valid (non-diagonal) input and the
+           player is not currently sliding.
+
+        Also advances all active bullets and prunes inactive ones.
+
+        Args:
+            dt: Time step in seconds.
+            game_map: Current map (used for ice tile detection).
+        """
+        for player, player_input in zip(self._players, self._player_inputs):
+            if player.health <= 0:
+                continue
+
+            player.update(dt)
+
+            dx, dy = player_input.get_movement_direction()
+            has_valid_input = (dx != 0 or dy != 0) and not (dx != 0 and dy != 0)
+
+            # Ice slide: trigger BEFORE move() so start_slide() captures old direction
+            player.on_ice = self._is_on_ice(player, game_map)
+            if player.on_ice and not player.is_sliding:
+                if not has_valid_input or (dx, dy) != player.direction.delta:
+                    if player.start_slide():
+                        self._sound_manager.play_ice_slide()
+
+            if has_valid_input and not player.is_sliding:
+                player.move(dx, dy, dt)
+
+        for bullet in self._bullets:
+            if bullet.active:
+                bullet.update(dt)
+
+        self._bullets = [b for b in self._bullets if b.active]
+
+    # ------------------------------------------------------------------
+    # Shooting
+    # ------------------------------------------------------------------
+
+    def try_shoot(self) -> None:
+        """Check shoot input for each player and fire a bullet if possible.
+
+        Respects each tank's max_bullets cap — no new bullet is created when
+        the player already has that many active bullets in flight.
+        """
+        for player, player_input in zip(self._players, self._player_inputs):
+            if player.health <= 0:
+                continue
+            if player_input.consume_shoot():
+                active_count = sum(
+                    1 for b in self._bullets if b.owner is player and b.active
+                )
+                if active_count < player.max_bullets:
+                    bullet: Optional[Bullet] = player.shoot()
+                    if bullet is not None:
+                        self._bullets.append(bullet)
+                        self._sound_manager.play_shoot()
+
+    # ------------------------------------------------------------------
+    # Accessors
+    # ------------------------------------------------------------------
+
+    def get_all_bullets(self) -> list[Bullet]:
+        """Return all active player bullets.
+
+        Returns:
+            List of active Bullet instances.
+        """
+        return [b for b in self._bullets if b.active]
+
+    def get_active_players(self) -> list[PlayerTank]:
+        """Return players that are still alive (health > 0).
+
+        Returns:
+            List of living PlayerTank instances.
+        """
+        return [p for p in self._players if p.health > 0]
+
+    @property
+    def score(self) -> int:
+        """Current player score."""
+        return self._score
+
+    def add_score(self, points: int) -> None:
+        """Increment the player score.
+
+        Args:
+            points: Number of points to add.
+        """
+        self._score += points
+
+    # ------------------------------------------------------------------
+    # State preservation
+    # ------------------------------------------------------------------
+
+    def preserve_state(self) -> None:
+        """Save player state before stage transition."""
+        self._preserved_state = {}
+        for i, player in enumerate(self._players):
+            self._preserved_state[i] = {
+                "lives": player.lives,
+                "star_level": player.star_level,
+            }
+
+    def restore_state(self) -> None:
+        """Restore player state after new tank creation."""
+        for i, player in enumerate(self._players):
+            if i in self._preserved_state:
+                state = self._preserved_state[i]
+                player.lives = state["lives"]
+                if state["star_level"] > 0:
+                    player.restore_star_level(state["star_level"])
+
+    # ------------------------------------------------------------------
+    # Death handling and game-over
+    # ------------------------------------------------------------------
+
+    def handle_player_death(self, player: PlayerTank) -> bool:
+        """Handle a player's destruction. Returns True if game should end.
+
+        Args:
+            player: The PlayerTank that was just destroyed.
+
+        Returns:
+            True if the game should end (all players eliminated), False otherwise.
+        """
+        if player.lives > 0:
+            player.respawn()
+            return False
+        # No lives left — player eliminated
+        return self.is_game_over()
+
+    def is_game_over(self) -> bool:
+        """Check if all players are eliminated (0 lives and dead).
+
+        Returns:
+            True when every player has no lives remaining and health <= 0.
+        """
+        return all(p.lives <= 0 and p.health <= 0 for p in self._players)
+
+    # ------------------------------------------------------------------
+    # Full reset
+    # ------------------------------------------------------------------
+
+    def reset(self) -> None:
+        """Full reset for starting a new game."""
+        self._players.clear()
+        self._player_inputs.clear()
+        self._bullets.clear()
+        self._score = 0
+        self._preserved_state = {}
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _is_on_ice(self, tank: PlayerTank, game_map: "Map") -> bool:
+        """Return True if the tank's centre is over a slidable (ice) tile.
+
+        Args:
+            tank: The tank to check.
+            game_map: The map providing tile information.
+
+        Returns:
+            True when the tile under the tank centre has is_slidable set.
+        """
+        center_x = int(tank.x + tank.width / 2)
+        center_y = int(tank.y + tank.height / 2)
+        grid_x = center_x // game_map.tile_size
+        grid_y = center_y // game_map.tile_size
+        tile = game_map.get_tile_at(grid_x, grid_y)
+        return tile is not None and tile.is_slidable

--- a/src/managers/player_manager.py
+++ b/src/managers/player_manager.py
@@ -171,12 +171,23 @@ class PlayerManager:
     # ------------------------------------------------------------------
 
     def get_all_bullets(self) -> list[Bullet]:
-        """Return all active player bullets.
+        """Return all player bullets (pruned to active-only by update()).
 
         Returns:
-            List of active Bullet instances.
+            Shallow copy of the internal bullet list.
         """
-        return [b for b in self._bullets if b.active]
+        return list(self._bullets)
+
+    def add_bullet(self, bullet: Bullet) -> None:
+        """Add a bullet to the player bullet list.
+
+        Useful for tests that need to inject bullets outside the normal
+        input → try_shoot flow.
+
+        Args:
+            bullet: The bullet to add.
+        """
+        self._bullets.append(bullet)
 
     def get_active_players(self) -> list[PlayerTank]:
         """Return players that are still alive (health > 0).
@@ -264,19 +275,7 @@ class PlayerManager:
     # Private helpers
     # ------------------------------------------------------------------
 
-    def _is_on_ice(self, tank: PlayerTank, game_map: "Map") -> bool:
-        """Return True if the tank's centre is over a slidable (ice) tile.
-
-        Args:
-            tank: The tank to check.
-            game_map: The map providing tile information.
-
-        Returns:
-            True when the tile under the tank centre has is_slidable set.
-        """
-        center_x = int(tank.x + tank.width / 2)
-        center_y = int(tank.y + tank.height / 2)
-        grid_x = center_x // game_map.tile_size
-        grid_y = center_y // game_map.tile_size
-        tile = game_map.get_tile_at(grid_x, grid_y)
-        return tile is not None and tile.is_slidable
+    @staticmethod
+    def _is_on_ice(tank: PlayerTank, game_map: "Map") -> bool:
+        """Return True if the tank's centre is over a slidable (ice) tile."""
+        return game_map.is_tile_slidable(tank.x, tank.y, tank.width, tank.height)

--- a/src/managers/renderer.py
+++ b/src/managers/renderer.py
@@ -80,7 +80,7 @@ class Renderer:
     def render(
         self,
         game_map,
-        player_tank,
+        player_tanks: List,
         enemy_tanks: List,
         bullets: List,
         effect_manager,
@@ -93,7 +93,7 @@ class Renderer:
 
         Args:
             game_map: The game map to draw.
-            player_tank: The player's tank.
+            player_tanks: List of player tanks.
             enemy_tanks: List of enemy tanks.
             bullets: List of bullets.
             state: Current game state.
@@ -105,7 +105,8 @@ class Renderer:
 
         game_map.draw(self.map_surface)
 
-        player_tank.draw(self.map_surface)
+        for player_tank in player_tanks:
+            player_tank.draw(self.map_surface)
         for enemy in enemy_tanks:
             enemy.draw(self.map_surface)
         for power_up in power_ups:
@@ -119,7 +120,7 @@ class Renderer:
 
         self.game_surface.blit(self.map_surface, (self.map_offset_x, self.map_offset_y))
 
-        self._draw_hud(player_tank, score)
+        self._draw_hud(player_tanks, score)
 
         if state == GameState.GAME_OVER:
             self._draw_game_over()
@@ -153,17 +154,18 @@ class Renderer:
         rect = surface.get_rect(center=(self._center_x, y))
         self.game_surface.blit(surface, rect)
 
-    def _draw_hud(self, player_tank, score: int = 0) -> None:
+    def _draw_hud(self, player_tanks: List, score: int = 0) -> None:
         """Draw the heads-up display.
 
         Args:
-            player_tank: The player's tank (used for lives).
+            player_tanks: List of player tanks (uses first player for lives).
             score: Current player score.
         """
-        if self._cached_lives != player_tank.lives:
-            self._cached_lives = player_tank.lives
+        lives = player_tanks[0].lives if player_tanks else 0
+        if self._cached_lives != lives:
+            self._cached_lives = lives
             self._cached_lives_text = self.small_font.render(
-                f"Lives: {player_tank.lives}", True, WHITE
+                f"Lives: {lives}", True, WHITE
             )
         self.game_surface.blit(self._cached_lives_text, (10, 10))
 

--- a/src/managers/spawn_manager.py
+++ b/src/managers/spawn_manager.py
@@ -41,7 +41,7 @@ class SpawnManager:
         game_map: Map,
         enemy_composition: dict[TankType, int],
         spawn_interval: float,
-        player_tank: PlayerTank,
+        player_tanks: List[PlayerTank],
         effect_manager: Optional[EffectManager] = None,
         difficulty: Difficulty = Difficulty.NORMAL,
         powerup_carrier_indices: Optional[tuple[int, ...]] = None,
@@ -53,7 +53,7 @@ class SpawnManager:
             game_map: The game map (spawn points, dimensions, collision).
             enemy_composition: Dict mapping TankType to enemy counts for this stage.
             spawn_interval: Seconds between spawn attempts.
-            player_tank: The player tank (for collision checking on initial spawn).
+            player_tanks: Player tanks for collision checking on initial spawn.
             effect_manager: EffectManager for spawn animations (optional).
             difficulty: AI difficulty level for spawned enemies.
             powerup_carrier_indices: Tuple of spawn indices that carry powerups.
@@ -88,7 +88,7 @@ class SpawnManager:
             )
 
         # Initial spawn
-        self.spawn_enemy(player_tank, game_map)
+        self.spawn_enemy(player_tanks, game_map)
 
     def _build_spawn_queue(
         self, enemy_composition: dict[TankType, int]
@@ -112,15 +112,16 @@ class SpawnManager:
     def _is_spawn_blocked(
         self,
         rect: pygame.Rect,
-        player_tank: PlayerTank,
+        player_tanks: List[PlayerTank],
         game_map: Map,
     ) -> bool:
         """Check if a spawn rect overlaps any obstacle."""
         for map_rect in game_map.get_collidable_tiles():
             if rect.colliderect(map_rect):
                 return True
-        if player_tank and rect.colliderect(player_tank.rect):
-            return True
+        for player_tank in player_tanks:
+            if player_tank and rect.colliderect(player_tank.rect):
+                return True
         for enemy in self.enemy_tanks:
             if rect.colliderect(enemy.rect):
                 return True
@@ -132,7 +133,7 @@ class SpawnManager:
                 return True
         return False
 
-    def spawn_enemy(self, player_tank: PlayerTank, game_map: Map) -> bool:
+    def spawn_enemy(self, player_tanks: List[PlayerTank], game_map: Map) -> bool:
         """Spawn a new enemy tank at a random spawn point if under the spawn limit.
 
         If an EffectManager is available, plays a spawn animation first and
@@ -140,7 +141,7 @@ class SpawnManager:
         tank appears immediately.
 
         Args:
-            player_tank: The player tank (for collision checking).
+            player_tanks: List of player tanks (for collision checking).
             game_map: The game map (for collision checking).
 
         Returns:
@@ -154,7 +155,7 @@ class SpawnManager:
         x, y = game_map.grid_to_pixels(spawn_grid_x, spawn_grid_y)
 
         temp_rect = pygame.Rect(x, y, self.tile_size, self.tile_size)
-        if self._is_spawn_blocked(temp_rect, player_tank, game_map):
+        if self._is_spawn_blocked(temp_rect, player_tanks, game_map):
             logger.warning(f"Spawn point ({x}, {y}) was blocked.")
             return False
 
@@ -203,7 +204,7 @@ class SpawnManager:
             f"{' [CARRIER]' if is_carrier else ''}"
         )
 
-    def update(self, dt: float, player_tank: PlayerTank, game_map: Map) -> None:
+    def update(self, dt: float, player_tanks: List[PlayerTank], game_map: Map) -> None:
         """Update spawn timer and attempt to spawn enemies.
 
         Also checks pending spawns and materializes tanks whose
@@ -211,7 +212,7 @@ class SpawnManager:
 
         Args:
             dt: Delta time in seconds.
-            player_tank: The player tank (for collision checking).
+            player_tanks: List of player tanks (for collision checking).
             game_map: The game map (for collision checking).
         """
         # Materialize tanks whose spawn animation is done
@@ -229,7 +230,7 @@ class SpawnManager:
         if self.spawn_timer >= self.spawn_interval:
             logger.trace("Spawn timer triggered.")
             # Reset timer only if spawn was successful
-            if self.spawn_enemy(player_tank, game_map):
+            if self.spawn_enemy(player_tanks, game_map):
                 self.spawn_timer = 0
 
     def remove_enemy(self, enemy: EnemyTank) -> None:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -66,7 +66,9 @@ def spawn_carrier(game):
             break
         game.spawn_manager.enemy_tanks = []
         game.spawn_manager._pending_spawns = []
-        game.spawn_manager.spawn_enemy(game.player_tank, game.map)
+        game.spawn_manager.spawn_enemy(
+            game.player_manager.get_active_players(), game.map
+        )
         flush_pending_spawns(game)
     carriers = [e for e in game.spawn_manager.enemy_tanks if e.is_carrier]
     assert carriers, "No carrier found"

--- a/tests/integration/test_collision_integration.py
+++ b/tests/integration/test_collision_integration.py
@@ -81,7 +81,7 @@ def test_player_bullet_vs_tile(
     player_tank.direction = Direction.UP
     bullet_obj = player_tank.shoot()
     assert bullet_obj is not None, "Bullet failed to spawn."
-    game_manager.player_manager._bullets.append(bullet_obj)
+    game_manager.player_manager.add_bullet(bullet_obj)
     bullet = bullet_obj
 
     # Simulate game time until bullet should have hit (or passed)
@@ -182,7 +182,7 @@ def test_player_bullet_destroys_enemy_tank(game_manager_fixture, mocker):
     player_tank.direction = Direction.UP
     bullet_obj = player_tank.shoot()
     assert bullet_obj is not None, "Bullet failed to spawn."
-    game_manager.player_manager._bullets.append(bullet_obj)
+    game_manager.player_manager.add_bullet(bullet_obj)
     bullet = bullet_obj
 
     # Simulate game time until bullet should have hit

--- a/tests/integration/test_collision_integration.py
+++ b/tests/integration/test_collision_integration.py
@@ -77,12 +77,12 @@ def test_player_bullet_vs_tile(
     player_tank.set_position(player_start_x, player_start_y)
     player_tank.prev_x, player_tank.prev_y = player_start_x, player_start_y
 
-    # Aim up and shoot
+    # Aim up and shoot via PlayerManager
     player_tank.direction = Direction.UP
-    game_manager._try_shoot(player_tank)
-
-    assert len(game_manager.bullets) == 1, "Bullet failed to spawn."
-    bullet = next(b for b in game_manager.bullets if b.owner is player_tank)
+    bullet_obj = player_tank.shoot()
+    assert bullet_obj is not None, "Bullet failed to spawn."
+    game_manager.player_manager._bullets.append(bullet_obj)
+    bullet = bullet_obj
 
     # Simulate game time until bullet should have hit (or passed)
     dt = 1.0 / FPS
@@ -178,12 +178,12 @@ def test_player_bullet_destroys_enemy_tank(game_manager_fixture, mocker):
     player_tank.set_position(player_start_x, player_start_y)
     player_tank.prev_x, player_tank.prev_y = player_start_x, player_start_y
 
-    # Aim up and shoot
+    # Aim up and shoot via PlayerManager
     player_tank.direction = Direction.UP
-    game_manager._try_shoot(player_tank)
-
-    assert len(game_manager.bullets) == 1, "Bullet failed to spawn."
-    bullet = next(b for b in game_manager.bullets if b.owner is player_tank)
+    bullet_obj = player_tank.shoot()
+    assert bullet_obj is not None, "Bullet failed to spawn."
+    game_manager.player_manager._bullets.append(bullet_obj)
+    bullet = bullet_obj
 
     # Simulate game time until bullet should have hit
     dt = 1.0 / FPS

--- a/tests/integration/test_collision_integration.py
+++ b/tests/integration/test_collision_integration.py
@@ -588,7 +588,7 @@ def test_player_tank_vs_enemy_tank_no_overlap(game_manager_fixture, mocker):
 
         # Run collision detection and response
         game_manager.collision_manager.check_collisions(
-            player_tank=player_tank,
+            player_tanks=[player_tank],
             player_bullets=[],
             enemy_tanks=[enemy_tank],
             enemy_bullets=[],

--- a/tests/integration/test_controller.py
+++ b/tests/integration/test_controller.py
@@ -5,6 +5,12 @@ from src.managers.game_manager import GameManager
 from src.states.game_state import GameState
 
 
+def _send_event(gm, event):
+    """Send event to both input_handler and player_manager."""
+    gm.input_handler.handle_event(event)
+    gm.player_manager.handle_event(event)
+
+
 class TestControllerGameplay:
     """Test controller input during gameplay with SDL GameController API."""
 
@@ -19,7 +25,7 @@ class TestControllerGameplay:
             pygame.CONTROLLERBUTTONDOWN,
             button=pygame.CONTROLLER_BUTTON_DPAD_UP,
         )
-        gm.input_handler.handle_event(event)
+        _send_event(gm, event)
         gm.update()
 
         assert gm.player_tank.y < initial_y
@@ -36,7 +42,7 @@ class TestControllerGameplay:
             axis=pygame.CONTROLLER_AXIS_LEFTY,
             value=-0.8,
         )
-        gm.input_handler.handle_event(event)
+        _send_event(gm, event)
         gm.update()
 
         assert gm.player_tank.y < initial_y
@@ -51,10 +57,10 @@ class TestControllerGameplay:
             pygame.CONTROLLERBUTTONDOWN,
             button=pygame.CONTROLLER_BUTTON_A,
         )
-        gm.input_handler.handle_event(event)
+        _send_event(gm, event)
         gm.update()
 
-        assert len(gm.bullets) > 0
+        assert len(gm.player_manager.get_all_bullets()) > 0
 
     def test_keyboard_still_works(self) -> None:
         """Keyboard input still works alongside controller."""
@@ -64,7 +70,7 @@ class TestControllerGameplay:
         initial_y = gm.player_tank.y
 
         key_event = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_UP)
-        gm.input_handler.handle_event(key_event)
+        _send_event(gm, key_event)
         gm.update()
 
         assert gm.player_tank.y < initial_y
@@ -83,7 +89,7 @@ class TestRawJoystickGameplay:
         event = pygame.event.Event(
             pygame.JOYHATMOTION, value=(0, 1), hat=0, instance_id=0
         )
-        gm.input_handler.handle_event(event)
+        _send_event(gm, event)
         gm.update()
 
         assert gm.player_tank.y < initial_y
@@ -95,10 +101,10 @@ class TestRawJoystickGameplay:
         gm.state = GameState.RUNNING
 
         event = pygame.event.Event(pygame.JOYBUTTONDOWN, button=0, instance_id=0)
-        gm.input_handler.handle_event(event)
+        _send_event(gm, event)
         gm.update()
 
-        assert len(gm.bullets) > 0
+        assert len(gm.player_manager.get_all_bullets()) > 0
 
 
 class TestControllerMenuNavigation:

--- a/tests/integration/test_enemy_integration.py
+++ b/tests/integration/test_enemy_integration.py
@@ -100,7 +100,7 @@ def test_enemy_spawning_rules(game_manager_fixture):
             f"Attempting spawn (Current total: {total_spawned_before}/{max_spawns})"
         )
         spawn_success = game_manager.spawn_manager.spawn_enemy(
-            game_manager.player_tank, game_manager.map
+            game_manager.player_manager.get_active_players(), game_manager.map
         )
 
         total_spawned_after = game_manager.spawn_manager.total_enemy_spawns
@@ -206,7 +206,7 @@ def test_enemy_spawn_blocked(game_manager_fixture):
 
         spawned_count_before = len(game_manager.spawn_manager.enemy_tanks)
         spawn_success = game_manager.spawn_manager.spawn_enemy(
-            game_manager.player_tank, game_manager.map
+            game_manager.player_manager.get_active_players(), game_manager.map
         )  # Attempt spawn
         spawned_count_after = len(game_manager.spawn_manager.enemy_tanks)
 

--- a/tests/integration/test_gamestate_integration.py
+++ b/tests/integration/test_gamestate_integration.py
@@ -174,7 +174,7 @@ def test_player_bullet_hits_base(game_manager_fixture):
     player_tank.direction = Direction.DOWN  # Aim down towards base
     bullet = player_tank.shoot()
     assert bullet is not None, "Player bullet failed to spawn."
-    game_manager.player_manager._bullets.append(bullet)
+    game_manager.player_manager.add_bullet(bullet)
     assert bullet.active, "Player bullet spawned inactive."
 
     # Assert initial game state is RUNNING
@@ -401,7 +401,7 @@ def test_score_accumulates_on_enemy_kill(game_manager_fixture):
     # Fire a bullet via PlayerManager
     bullet = player.shoot()
     assert bullet is not None
-    gm.player_manager._bullets.append(bullet)
+    gm.player_manager.add_bullet(bullet)
 
     # Clear other enemies to avoid interference
     gm.spawn_manager.enemy_tanks = [enemy]

--- a/tests/integration/test_gamestate_integration.py
+++ b/tests/integration/test_gamestate_integration.py
@@ -80,8 +80,9 @@ def test_player_game_over_on_zero_lives():
     # Ensure the player starts with at least 1 life for the test
     assert player_tank.lives >= 1
 
-    # Set lives to 1 to guarantee game over on next death
-    player_tank.lives = 1
+    # Set lives to 0 to guarantee game over on next death
+    # (handle_player_death checks lives > 0 to decide respawn vs game over)
+    player_tank.lives = 0
 
     # Disable spawn invincibility so damage can land
     player_tank.is_invincible = False
@@ -98,7 +99,12 @@ def test_player_game_over_on_zero_lives():
     mock_enemy_bullet.active = True  # Needs to be active to be processed
 
     # 2. Mock the player tank's take_damage to return True (fatal hit)
-    player_tank.take_damage = MagicMock(return_value=True)
+    #    Also set health to 0 since handle_player_death checks it for game over.
+    def _mock_take_damage(amount=1):
+        player_tank.health = 0
+        return True
+
+    player_tank.take_damage = MagicMock(side_effect=_mock_take_damage)
 
     # 3. Mock CollisionManager to report a collision between the mock bullet and player
     # Need to mock the instance within game_manager

--- a/tests/integration/test_gamestate_integration.py
+++ b/tests/integration/test_gamestate_integration.py
@@ -170,12 +170,11 @@ def test_player_bullet_hits_base(game_manager_fixture):
     player_tank.set_position(player_start_x, player_start_y)
     player_tank.prev_x, player_tank.prev_y = player_start_x, player_start_y
 
-    # Aim DOWN and shoot
+    # Aim DOWN and shoot via PlayerManager
     player_tank.direction = Direction.DOWN  # Aim down towards base
-    game_manager._try_shoot(player_tank)
-
-    assert len(game_manager.bullets) == 1, "Player bullet failed to spawn."
-    bullet = next(b for b in game_manager.bullets if b.owner is player_tank)
+    bullet = player_tank.shoot()
+    assert bullet is not None, "Player bullet failed to spawn."
+    game_manager.player_manager._bullets.append(bullet)
     assert bullet.active, "Player bullet spawned inactive."
 
     # Assert initial game state is RUNNING
@@ -399,10 +398,10 @@ def test_score_accumulates_on_enemy_kill(game_manager_fixture):
     player.rect.topleft = (round(player.x), round(player.y))
     player.direction = Direction.UP
 
-    # Fire a bullet
+    # Fire a bullet via PlayerManager
     bullet = player.shoot()
     assert bullet is not None
-    gm.bullets.append(bullet)
+    gm.player_manager._bullets.append(bullet)
 
     # Clear other enemies to avoid interference
     gm.spawn_manager.enemy_tanks = [enemy]

--- a/tests/integration/test_ice_slide.py
+++ b/tests/integration/test_ice_slide.py
@@ -31,11 +31,12 @@ def _move_player_to(game, px, py):
 
 
 def _set_input(game, direction):
-    """Set input handler to simulate holding a direction key."""
-    for d in game.input_handler.directions:
-        game.input_handler.directions[d] = False
+    """Set player input to simulate holding a direction key."""
+    player_input = game.player_manager._player_inputs[0]
+    for d in player_input._directions:
+        player_input._directions[d] = False
     if direction is not None:
-        game.input_handler.directions[direction] = True
+        player_input._directions[direction] = True
 
 
 def _clear_input(game):

--- a/tests/integration/test_player_integration.py
+++ b/tests/integration/test_player_integration.py
@@ -59,6 +59,7 @@ def test_player_movement(key, axis, direction_sign, expected_direction):
     # Simulate key press
     key_down_event = pygame.event.Event(pygame.KEYDOWN, key=key)
     game_manager.input_handler.handle_event(key_down_event)
+    game_manager.player_manager.handle_event(key_down_event)
 
     # Update game state
     for _ in range(num_updates):
@@ -67,6 +68,7 @@ def test_player_movement(key, axis, direction_sign, expected_direction):
     # Simulate key release
     key_up_event = pygame.event.Event(pygame.KEYUP, key=key)
     game_manager.input_handler.handle_event(key_up_event)
+    game_manager.player_manager.handle_event(key_up_event)
 
     final_pos = player_tank.get_position()
 
@@ -193,6 +195,7 @@ def test_player_movement_blocked_by_tile(
     # Simulate key press
     key_down_event = pygame.event.Event(pygame.KEYDOWN, key=key)
     game_manager.input_handler.handle_event(key_down_event)
+    game_manager.player_manager.handle_event(key_down_event)
 
     # Update game state
     for _ in range(num_updates):
@@ -201,6 +204,7 @@ def test_player_movement_blocked_by_tile(
     # Simulate key release
     key_up_event = pygame.event.Event(pygame.KEYUP, key=key)
     game_manager.input_handler.handle_event(key_up_event)
+    game_manager.player_manager.handle_event(key_up_event)
 
     final_player_rect = player_tank.rect
     # The blocking tile is a 2x2 sub-tile block; compute its combined rect

--- a/tests/unit/managers/test_collision_manager.py
+++ b/tests/unit/managers/test_collision_manager.py
@@ -66,7 +66,7 @@ class TestCollisionManager:
         """Force overlap between two objects and assert exactly one collision event."""
         obj_a.rect = obj_b.rect.copy()
         defaults = dict(
-            player_tank=None,
+            player_tanks=[],
             player_bullets=[],
             enemy_tanks=[],
             enemy_bullets=[],
@@ -88,7 +88,7 @@ class TestCollisionManager:
         """Test check_collisions when no objects overlap."""
         all_blocking = mock_objects["bricks"] + mock_objects["steel"]
         collision_manager.check_collisions(
-            player_tank=mock_objects["player"],
+            player_tanks=[mock_objects["player"]],
             player_bullets=mock_objects["p_bullets"],
             enemy_tanks=mock_objects["enemies"],
             enemy_bullets=mock_objects["e_bullets"],
@@ -104,7 +104,7 @@ class TestCollisionManager:
             collision_manager,
             mock_objects["p_bullets"][0],
             mock_objects["enemies"][0],
-            player_tank=mock_objects["player"],
+            player_tanks=[mock_objects["player"]],
             player_bullets=[mock_objects["p_bullets"][0]],
             enemy_tanks=[mock_objects["enemies"][0]],
         )
@@ -125,7 +125,7 @@ class TestCollisionManager:
             collision_manager,
             mock_objects["e_bullets"][0],
             mock_objects["player"],
-            player_tank=mock_objects["player"],
+            player_tanks=[mock_objects["player"]],
             enemy_bullets=[mock_objects["e_bullets"][0]],
         )
 
@@ -165,7 +165,7 @@ class TestCollisionManager:
             collision_manager,
             mock_objects["player"],
             mock_objects["steel"][0],
-            player_tank=mock_objects["player"],
+            player_tanks=[mock_objects["player"]],
             tank_blocking_tiles=[mock_objects["steel"][0]],
         )
 
@@ -175,7 +175,7 @@ class TestCollisionManager:
             collision_manager,
             mock_objects["player"],
             mock_objects["enemies"][0],
-            player_tank=mock_objects["player"],
+            player_tanks=[mock_objects["player"]],
             enemy_tanks=[mock_objects["enemies"][0]],
         )
 
@@ -191,7 +191,7 @@ class TestCollisionManager:
         e_bullet.rect = brick.rect.copy()
 
         collision_manager.check_collisions(
-            player_tank=None,
+            player_tanks=[],
             player_bullets=[p_bullet],
             enemy_tanks=[enemy],
             enemy_bullets=[e_bullet],
@@ -212,7 +212,7 @@ class TestCollisionManager:
 
         # First call with collision
         collision_manager.check_collisions(
-            player_tank=None,
+            player_tanks=[],
             player_bullets=[p_bullet],
             enemy_tanks=[enemy],
             enemy_bullets=[],
@@ -225,7 +225,7 @@ class TestCollisionManager:
         # Second call with no collision
         p_bullet.rect.move_ip(1000, 1000)  # Move bullet away
         collision_manager.check_collisions(
-            player_tank=None,
+            player_tanks=[],
             player_bullets=[p_bullet],
             enemy_tanks=[enemy],
             enemy_bullets=[],
@@ -269,7 +269,7 @@ class TestCollisionManager:
 
         # Pass brick in BOTH blocking tile lists (blocks tanks and bullets)
         collision_manager.check_collisions(
-            player_tank=None,
+            player_tanks=[],
             player_bullets=[p_bullet],
             enemy_tanks=[],
             enemy_bullets=[],
@@ -298,7 +298,7 @@ class TestPowerUpCollision:
 
     def _check(self, cm, player, power_ups):
         cm.check_collisions(
-            player_tank=player,
+            player_tanks=[player],
             player_bullets=[],
             enemy_tanks=[],
             enemy_bullets=[],

--- a/tests/unit/managers/test_collision_response_handler.py
+++ b/tests/unit/managers/test_collision_response_handler.py
@@ -654,20 +654,26 @@ class TestPlayerVsPowerUp:
     ):
         handler, score_tracker, pu_manager = handler_with_powerup
         handler.process_collisions([(mock_player, mock_power_up)])
-        assert handler.consume_collected_power_up() == PowerUpType.HELMET
+        power_up_type, collecting_player = handler.consume_collected_power_up()
+        assert power_up_type == PowerUpType.HELMET
+        assert collecting_player is mock_player
 
     def test_consume_clears_stored_type(
         self, handler_with_powerup, mock_player, mock_power_up
     ):
         handler, score_tracker, pu_manager = handler_with_powerup
         handler.process_collisions([(mock_player, mock_power_up)])
-        result = handler.consume_collected_power_up()
-        assert result == PowerUpType.HELMET
-        assert handler.consume_collected_power_up() is None
+        power_up_type, collecting_player = handler.consume_collected_power_up()
+        assert power_up_type == PowerUpType.HELMET
+        result_type, result_player = handler.consume_collected_power_up()
+        assert result_type is None
+        assert result_player is None
 
     def test_consume_returns_none_when_empty(self, handler_with_powerup):
         handler, score_tracker, pu_manager = handler_with_powerup
-        assert handler.consume_collected_power_up() is None
+        result_type, result_player = handler.consume_collected_power_up()
+        assert result_type is None
+        assert result_player is None
 
 
 class TestPowerBulletVsSteel:

--- a/tests/unit/managers/test_game_manager.py
+++ b/tests/unit/managers/test_game_manager.py
@@ -27,6 +27,7 @@ class TestGameManager:
             patch("src.managers.game_manager.SpawnManager"),
             patch("src.managers.game_manager.Map") as MockMap,
             patch("src.managers.game_manager.SettingsManager") as MockSM,
+            patch("src.managers.game_manager.PlayerManager") as MockPM,
         ):
             mock_tm_instance = MockTM.return_value
             mock_tm_instance.get_sprite.return_value = MagicMock(spec=pygame.Surface)
@@ -37,6 +38,16 @@ class TestGameManager:
             mock_map_instance.height = 16
             mock_map_instance.player_spawn = (4, 12)
             mock_map_instance.spawn_points = [(3, 1), (8, 1), (12, 1)]
+            mock_pm_instance = MockPM.return_value
+            mock_player = MagicMock()
+            mock_player.lives = 3
+            mock_player.health = 1
+            mock_player.x = 128
+            mock_player.y = 384
+            mock_player.is_moving = False
+            mock_pm_instance.get_active_players.return_value = [mock_player]
+            mock_pm_instance.score = 0
+            mock_pm_instance.get_all_bullets.return_value = []
             yield
 
     @pytest.fixture
@@ -151,10 +162,10 @@ class TestGameManager:
 
     def test_restart_after_game_over_resets_lives(self, game_manager):
         """Test that restarting after game over restores default lives."""
-        game_manager.player_tank.lives = 0
         game_manager.state = GameState.GAME_OVER
         game_manager._reset_game()
-        assert game_manager.player_tank.lives == 3
+        players = game_manager.player_manager.get_active_players()
+        assert players[0].lives == 3
 
     # --- Game State Tests --- #
 
@@ -165,9 +176,7 @@ class TestGameManager:
     def test_update_stops_when_not_running(self, game_manager):
         """Test that update method does nothing if state is not RUNNING."""
         game_manager.state = GameState.GAME_OVER
-        # Mock methods that should not be called during the update phase
-        # if game is not running. Collision processing happens before this check.
-        game_manager.player_tank.update = MagicMock()
+        game_manager.player_manager = MagicMock()
         # Use a real list for enemy_tanks for the update loop check
         mock_enemy = MagicMock(spec=EnemyTank)
         mock_enemy.tank_type = "basic"
@@ -177,7 +186,7 @@ class TestGameManager:
 
         game_manager.update()
 
-        game_manager.player_tank.update.assert_not_called()
+        game_manager.player_manager.update.assert_not_called()
         mock_enemy.update.assert_not_called()
         game_manager.spawn_manager.update.assert_not_called()
         game_manager.collision_response_handler.process_collisions.assert_not_called()
@@ -286,6 +295,7 @@ class TestGameManagerSoundWiring:
             patch("src.managers.game_manager.SpawnManager"),
             patch("src.managers.game_manager.Map") as MockMap,
             patch("src.managers.game_manager.SettingsManager") as MockSM,
+            patch("src.managers.game_manager.PlayerManager") as MockPM,
         ):
             mock_tm_instance = MockTM.return_value
             mock_tm_instance.get_sprite.return_value = MagicMock(spec=pygame.Surface)
@@ -296,6 +306,16 @@ class TestGameManagerSoundWiring:
             mock_map_instance.height = 16
             mock_map_instance.player_spawn = (4, 12)
             mock_map_instance.spawn_points = [(3, 1), (8, 1), (12, 1)]
+            mock_pm_instance = MockPM.return_value
+            mock_player = MagicMock()
+            mock_player.lives = 3
+            mock_player.health = 1
+            mock_player.x = 128
+            mock_player.y = 384
+            mock_player.is_moving = False
+            mock_pm_instance.get_active_players.return_value = [mock_player]
+            mock_pm_instance.score = 0
+            mock_pm_instance.get_all_bullets.return_value = []
             yield
 
     @pytest.fixture
@@ -363,6 +383,7 @@ class TestStageProgression:
             patch("src.managers.game_manager.SpawnManager"),
             patch("src.managers.game_manager.Map") as MockMap,
             patch("src.managers.game_manager.SettingsManager") as MockSM,
+            patch("src.managers.game_manager.PlayerManager") as MockPM,
         ):
             mock_tm_instance = MockTM.return_value
             mock_tm_instance.get_sprite.return_value = MagicMock(spec=pygame.Surface)
@@ -373,6 +394,16 @@ class TestStageProgression:
             mock_map_instance.height = 16
             mock_map_instance.player_spawn = (4, 12)
             mock_map_instance.spawn_points = [(3, 1), (8, 1), (12, 1)]
+            mock_pm_instance = MockPM.return_value
+            mock_player = MagicMock()
+            mock_player.lives = 3
+            mock_player.health = 1
+            mock_player.x = 128
+            mock_player.y = 384
+            mock_player.is_moving = False
+            mock_pm_instance.get_active_players.return_value = [mock_player]
+            mock_pm_instance.score = 0
+            mock_pm_instance.get_all_bullets.return_value = []
             yield
 
     @pytest.fixture
@@ -448,6 +479,7 @@ class TestPauseAndOptionsStateMachine:
             patch("src.managers.game_manager.SpawnManager"),
             patch("src.managers.game_manager.Map") as MockMap,
             patch("src.managers.game_manager.SettingsManager") as MockSM,
+            patch("src.managers.game_manager.PlayerManager") as MockPM,
         ):
             mock_tm_instance = MockTM.return_value
             mock_tm_instance.get_sprite.return_value = MagicMock(spec=pygame.Surface)
@@ -458,6 +490,16 @@ class TestPauseAndOptionsStateMachine:
             mock_map_instance.height = 16
             mock_map_instance.player_spawn = (4, 12)
             mock_map_instance.spawn_points = [(3, 1), (8, 1), (12, 1)]
+            mock_pm_instance = MockPM.return_value
+            mock_player = MagicMock()
+            mock_player.lives = 3
+            mock_player.health = 1
+            mock_player.x = 128
+            mock_player.y = 384
+            mock_player.is_moving = False
+            mock_pm_instance.get_active_players.return_value = [mock_player]
+            mock_pm_instance.score = 0
+            mock_pm_instance.get_all_bullets.return_value = []
             yield
 
     @pytest.fixture
@@ -777,17 +819,17 @@ class TestPauseAndOptionsStateMachine:
         """Update does not process game logic when PAUSED."""
         gm = game_manager
         gm.state = GameState.PAUSED
-        gm.player_tank.update = MagicMock()
+        gm.player_manager = MagicMock()
         gm.update()
-        gm.player_tank.update.assert_not_called()
+        gm.player_manager.update.assert_not_called()
 
     def test_update_does_nothing_when_in_options(self, game_manager):
         """Update does not process game logic when in OPTIONS_MENU."""
         gm = game_manager
         gm.state = GameState.OPTIONS_MENU
-        gm.player_tank.update = MagicMock()
+        gm.player_manager = MagicMock()
         gm.update()
-        gm.player_tank.update.assert_not_called()
+        gm.player_manager.update.assert_not_called()
 
     # --- Render routing ---
 

--- a/tests/unit/managers/test_game_manager_curtain.py
+++ b/tests/unit/managers/test_game_manager_curtain.py
@@ -23,23 +23,27 @@ class TestNewGameAndLoadStage:
 
     def test_new_game_resets_stage_and_score(self, game):
         assert game.current_stage == 1
-        assert game.score == 0
+        assert game.player_manager.score == 0
 
     def test_load_stage_preserves_score(self, game):
-        game.score = 500
+        game.player_manager.add_score(500)
         game._load_stage()
-        assert game.score == 500
+        assert game.player_manager.score == 500
 
     def test_load_stage_preserves_lives(self, game):
-        game.player_tank.lives = 5
+        players = game.player_manager.get_active_players()
+        players[0].lives = 5
         game._load_stage()
-        assert game.player_tank.lives == 5
+        new_players = game.player_manager.get_active_players()
+        assert new_players[0].lives == 5
 
     def test_load_stage_preserves_star_level(self, game):
-        game.player_tank.apply_star()
-        game.player_tank.apply_star()
+        players = game.player_manager.get_active_players()
+        players[0].apply_star()
+        players[0].apply_star()
         game._load_stage()
-        assert game.player_tank.star_level == 2
+        new_players = game.player_manager.get_active_players()
+        assert new_players[0].star_level == 2
 
 
 class TestCurtainTransitions:
@@ -162,9 +166,11 @@ class TestGameOverAnimation:
         """During animation, game subsystems should not update."""
         game.state = GameState.GAME_OVER_ANIMATION
         game._state_timer = 0.0
-        initial_pos = (game.player_tank.x, game.player_tank.y)
+        players = game.player_manager.get_active_players()
+        initial_pos = (players[0].x, players[0].y)
         game.update()
-        assert (game.player_tank.x, game.player_tank.y) == initial_pos
+        new_players = game.player_manager.get_active_players()
+        assert (new_players[0].x, new_players[0].y) == initial_pos
 
     def test_r_key_does_nothing_during_animation(self, game):
         """R key should not work during the rising text animation."""

--- a/tests/unit/managers/test_game_manager_powerups.py
+++ b/tests/unit/managers/test_game_manager_powerups.py
@@ -26,12 +26,13 @@ class TestPowerUpEffects:
         gm._apply_helmet = GameManager._apply_helmet.__get__(gm)
         gm._apply_extra_life = GameManager._apply_extra_life.__get__(gm)
         gm._apply_bomb = GameManager._apply_bomb.__get__(gm)
-        gm._add_score = GameManager._add_score.__get__(gm)
         gm.state = GameState.RUNNING
-        gm.score = 0
-        gm.player_tank = MagicMock()
-        gm.player_tank.lives = 3
-        gm.player_tank.is_invincible = False
+        mock_player = MagicMock()
+        mock_player.lives = 3
+        mock_player.is_invincible = False
+        gm._test_player = mock_player
+        gm.player_manager = MagicMock()
+        gm.player_manager.get_active_players.return_value = [mock_player]
         gm.spawn_manager = MagicMock()
         gm.spawn_manager.enemy_tanks = []
         gm.effect_manager = MagicMock()
@@ -40,13 +41,13 @@ class TestPowerUpEffects:
 
     def test_helmet_grants_invincibility(self, game):
         game._apply_power_up(PowerUpType.HELMET)
-        game.player_tank.activate_invincibility.assert_called_once_with(
+        game._test_player.activate_invincibility.assert_called_once_with(
             HELMET_INVINCIBILITY_DURATION
         )
 
     def test_extra_life_increments_lives(self, game):
         game._apply_power_up(PowerUpType.EXTRA_LIFE)
-        assert game.player_tank.lives == 4
+        assert game._test_player.lives == 4
 
     def test_bomb_destroys_all_enemies(self, game):
         enemies = []
@@ -56,16 +57,15 @@ class TestPowerUpEffects:
             e.rect = pygame.Rect(100, 100, TILE_SIZE, TILE_SIZE)
             enemies.append(e)
         game.spawn_manager.enemy_tanks = list(enemies)
-        game._apply_bomb()
+        game._apply_power_up(PowerUpType.BOMB)
         assert game.spawn_manager.remove_enemy.call_count == 3
-        assert game.score == 0
 
     def test_bomb_spawns_explosions(self, game):
         enemy = MagicMock()
         enemy.tank_type = TankType.BASIC
         enemy.rect = pygame.Rect(100, 100, TILE_SIZE, TILE_SIZE)
         game.spawn_manager.enemy_tanks = [enemy]
-        game._apply_bomb()
+        game._apply_power_up(PowerUpType.BOMB)
         game.effect_manager.spawn.assert_called_once_with(
             EffectType.LARGE_EXPLOSION,
             float(enemy.rect.centerx),
@@ -78,23 +78,23 @@ class TestPowerUpEffects:
         carrier.is_carrier = True
         carrier.rect = pygame.Rect(100, 100, TILE_SIZE, TILE_SIZE)
         game.spawn_manager.enemy_tanks = [carrier]
-        game._apply_bomb()
+        game._apply_power_up(PowerUpType.BOMB)
         game.spawn_manager.remove_enemy.assert_called_once_with(carrier)
         game.power_up_manager.spawn_power_up.assert_not_called()
 
     def test_power_up_not_applied_on_game_over(self, game):
         game.state = GameState.GAME_OVER
         game._apply_power_up(PowerUpType.EXTRA_LIFE)
-        assert game.player_tank.lives == 3
+        assert game._test_player.lives == 3
 
     def test_unknown_power_up_type_is_noop(self, game):
         game._apply_power_up(PowerUpType.STAR)
-        assert game.player_tank.lives == 3
+        assert game._test_player.lives == 3
 
     def test_helmet_overrides_respawn_invincibility(self, game):
-        game.player_tank.is_invincible = True
+        game._test_player.is_invincible = True
         game._apply_power_up(PowerUpType.HELMET)
-        game.player_tank.activate_invincibility.assert_called_once_with(
+        game._test_player.activate_invincibility.assert_called_once_with(
             HELMET_INVINCIBILITY_DURATION
         )
 
@@ -106,10 +106,11 @@ class TestClockEffect:
         gm._apply_power_up = GameManager._apply_power_up.__get__(gm)
         gm._apply_clock = GameManager._apply_clock.__get__(gm)
         gm.state = GameState.RUNNING
-        gm.score = 0
         gm.freeze_timer = 0.0
-        gm.player_tank = MagicMock()
-        gm.player_tank.lives = 3
+        mock_player = MagicMock()
+        mock_player.lives = 3
+        gm.player_manager = MagicMock()
+        gm.player_manager.get_active_players.return_value = [mock_player]
         return gm
 
     def test_clock_sets_freeze_timer(self, game):
@@ -130,14 +131,15 @@ class TestShovelEffect:
         gm._apply_shovel = GameManager._apply_shovel.__get__(gm)
         gm._tick_shovel = GameManager._tick_shovel.__get__(gm)
         gm.state = GameState.RUNNING
-        gm.score = 0
         gm.freeze_timer = 0.0
         gm.shovel_timer = 0.0
         gm._shovel_original_tiles = []
         gm._shovel_flash_timer = 0.0
         gm._shovel_flash_showing_steel = True
-        gm.player_tank = MagicMock()
-        gm.player_tank.lives = 3
+        mock_player = MagicMock()
+        mock_player.lives = 3
+        gm.player_manager = MagicMock()
+        gm.player_manager.get_active_players.return_value = [mock_player]
         mock_tiles = []
         for _ in range(4):
             t = MagicMock()
@@ -176,7 +178,8 @@ class TestShovelEffect:
         original_tiles = game._shovel_original_tiles
         game.shovel_timer = 5.0
         game.map.set_tile_type.reset_mock()
-        game._apply_shovel()
+        mock_player = game.player_manager.get_active_players()[0]
+        game._apply_shovel(mock_player)
         assert game.shovel_timer == SHOVEL_DURATION
         assert game._shovel_original_tiles is original_tiles
         game.map.set_tile_type.assert_not_called()

--- a/tests/unit/managers/test_input_handler.py
+++ b/tests/unit/managers/test_input_handler.py
@@ -2,7 +2,7 @@ import pytest
 import pygame
 from unittest.mock import patch, MagicMock
 from src.managers.input_handler import InputHandler
-from src.utils.constants import Direction, MenuAction
+from src.utils.constants import MenuAction
 
 
 @pytest.fixture
@@ -12,193 +12,21 @@ def handler() -> InputHandler:
 
 
 def test_initialization(handler: InputHandler) -> None:
-    """Test that the handler initializes with all directions False."""
-    assert not handler.directions[Direction.UP]
-    assert not handler.directions[Direction.DOWN]
-    assert not handler.directions[Direction.LEFT]
-    assert not handler.directions[Direction.RIGHT]
-    assert handler.get_movement_direction() == (0, 0)
+    """Test that the handler initializes with empty menu actions."""
+    assert handler.consume_menu_actions() == []
 
 
-def test_keydown_up(handler: InputHandler, key_down_event) -> None:
-    """Test handling KEYDOWN for the UP key."""
-    event = key_down_event(pygame.K_UP)
-    handler.handle_event(event)
-    assert handler.directions[Direction.UP]
-    assert not handler.directions[Direction.DOWN]
-    assert not handler.directions[Direction.LEFT]
-    assert not handler.directions[Direction.RIGHT]
-    assert handler.get_movement_direction() == (0, -1)
-
-
-def test_keydown_down(handler: InputHandler, key_down_event) -> None:
-    """Test handling KEYDOWN for the DOWN key."""
-    event = key_down_event(pygame.K_DOWN)
-    handler.handle_event(event)
-    assert not handler.directions[Direction.UP]
-    assert handler.directions[Direction.DOWN]
-    assert not handler.directions[Direction.LEFT]
-    assert not handler.directions[Direction.RIGHT]
-    assert handler.get_movement_direction() == (0, 1)
-
-
-def test_keydown_left(handler: InputHandler, key_down_event) -> None:
-    """Test handling KEYDOWN for the LEFT key."""
-    event = key_down_event(pygame.K_LEFT)
-    handler.handle_event(event)
-    assert not handler.directions[Direction.UP]
-    assert not handler.directions[Direction.DOWN]
-    assert handler.directions[Direction.LEFT]
-    assert not handler.directions[Direction.RIGHT]
-    assert handler.get_movement_direction() == (-1, 0)
-
-
-def test_keydown_right(handler: InputHandler, key_down_event) -> None:
-    """Test handling KEYDOWN for the RIGHT key."""
-    event = key_down_event(pygame.K_RIGHT)
-    handler.handle_event(event)
-    assert not handler.directions[Direction.UP]
-    assert not handler.directions[Direction.DOWN]
-    assert not handler.directions[Direction.LEFT]
-    assert handler.directions[Direction.RIGHT]
-    assert handler.get_movement_direction() == (1, 0)
-
-
-def test_keyup(handler: InputHandler, key_down_event, key_up_event) -> None:
-    """Test handling KEYUP after a KEYDOWN."""
-    # Press UP
-    handler.handle_event(key_down_event(pygame.K_UP))
-    assert handler.directions[Direction.UP]
-    assert handler.get_movement_direction() == (0, -1)
-
-    # Release UP
-    handler.handle_event(key_up_event(pygame.K_UP))
-    assert not handler.directions[Direction.UP]
-    assert handler.get_movement_direction() == (0, 0)
-
-
-def test_multiple_keys_down(handler: InputHandler, key_down_event) -> None:
-    """Test handling multiple keys pressed simultaneously."""
-    handler.handle_event(key_down_event(pygame.K_UP))
-    handler.handle_event(key_down_event(pygame.K_LEFT))
-    assert handler.directions[Direction.UP]
-    assert not handler.directions[Direction.DOWN]
-    assert handler.directions[Direction.LEFT]
-    assert not handler.directions[Direction.RIGHT]
-    assert handler.get_movement_direction() == (-1, -1)
-
-
-def test_opposite_keys_down(handler: InputHandler, key_down_event) -> None:
-    """Test handling opposite keys pressed simultaneously (should cancel out)."""
-    handler.handle_event(key_down_event(pygame.K_UP))
-    handler.handle_event(key_down_event(pygame.K_DOWN))
-    assert handler.directions[Direction.UP]
-    assert handler.directions[Direction.DOWN]
-    assert handler.get_movement_direction() == (0, 0)  # Up and Down cancel
-
-    handler.handle_event(key_down_event(pygame.K_LEFT))
-    handler.handle_event(key_down_event(pygame.K_RIGHT))
-    assert handler.directions[Direction.LEFT]
-    assert handler.directions[Direction.RIGHT]
-    assert handler.get_movement_direction() == (0, 0)  # Left and Right also cancel
-
-
-def test_key_hold_and_release(
-    handler: InputHandler, key_down_event, key_up_event
-) -> None:
-    """Test pressing, holding, and releasing keys."""
-    # Press UP and LEFT
-    handler.handle_event(key_down_event(pygame.K_UP))
-    handler.handle_event(key_down_event(pygame.K_LEFT))
-    assert handler.get_movement_direction() == (-1, -1)
-
-    # Release UP
-    handler.handle_event(key_up_event(pygame.K_UP))
-    assert not handler.directions[Direction.UP]
-    assert handler.directions[Direction.LEFT]
-    assert handler.get_movement_direction() == (-1, 0)
-
-    # Release LEFT
-    handler.handle_event(key_up_event(pygame.K_LEFT))
-    assert not handler.directions[Direction.LEFT]
-    assert handler.get_movement_direction() == (0, 0)
-
-
-def test_ignore_unmapped_keys(
-    handler: InputHandler, key_down_event, key_up_event
-) -> None:
-    """Test that keys not in the mapping are ignored."""
-    initial_directions = handler.directions.copy()
-    initial_movement = handler.get_movement_direction()
-
-    handler.handle_event(key_down_event(pygame.K_a))  # Unmapped key
-    handler.handle_event(key_up_event(pygame.K_a))  # Unmapped key
-
-    assert handler.directions == initial_directions
-    assert handler.get_movement_direction() == initial_movement
+def test_ignore_unmapped_keys(handler: InputHandler, key_down_event) -> None:
+    """Test that unmapped keys produce no menu actions."""
+    handler.handle_event(key_down_event(pygame.K_a))
+    assert handler.consume_menu_actions() == []
 
 
 def test_ignore_other_event_types(handler: InputHandler) -> None:
     """Test that non-KEYDOWN/KEYUP events are ignored."""
-    initial_directions = handler.directions.copy()
-    initial_movement = handler.get_movement_direction()
-
-    # Simulate a MOUSEBUTTONDOWN event
     mouse_event = pygame.event.Event(pygame.MOUSEBUTTONDOWN, button=1, pos=(100, 100))
     handler.handle_event(mouse_event)
-
-    assert handler.directions == initial_directions
-    assert handler.get_movement_direction() == initial_movement
-
-
-def test_repeated_keydown(handler: InputHandler, key_down_event) -> None:
-    """Test that repeated KEYDOWN events for the same key don't change state
-    after the first."""
-    event = key_down_event(pygame.K_UP)
-    handler.handle_event(event)
-    assert handler.directions[Direction.UP]
-    direction_after_first = handler.directions.copy()
-
-    # Handle the same KEYDOWN event again
-    handler.handle_event(event)
-    assert handler.directions == direction_after_first  # State should not change
-
-
-def test_repeated_keyup(handler: InputHandler, key_down_event, key_up_event) -> None:
-    """Test that repeated KEYUP events for the same key don't change state
-    after the first."""
-    # Press and release UP
-    handler.handle_event(key_down_event(pygame.K_UP))
-    handler.handle_event(key_up_event(pygame.K_UP))
-    assert not handler.directions[Direction.UP]
-    direction_after_first = handler.directions.copy()
-
-    # Handle the same KEYUP event again
-    handler.handle_event(key_up_event(pygame.K_UP))
-    assert handler.directions == direction_after_first  # State should not change
-
-
-def test_shoot_key_default(handler: InputHandler, key_down_event) -> None:
-    """Test that space bar triggers shoot_pressed."""
-    assert not handler.shoot_pressed
-    handler.handle_event(key_down_event(pygame.K_SPACE))
-    assert handler.shoot_pressed
-
-
-def test_consume_shoot(handler: InputHandler, key_down_event) -> None:
-    """Test that consume_shoot returns True once then resets."""
-    handler.handle_event(key_down_event(pygame.K_SPACE))
-    assert handler.consume_shoot() is True
-    assert handler.consume_shoot() is False
-    assert not handler.shoot_pressed
-
-
-def test_shoot_key_not_triggered_by_movement(
-    handler: InputHandler, key_down_event
-) -> None:
-    """Test that movement keys don't trigger shoot."""
-    handler.handle_event(key_down_event(pygame.K_UP))
-    assert not handler.shoot_pressed
+    assert handler.consume_menu_actions() == []
 
 
 class TestJoystickInit:
@@ -207,7 +35,6 @@ class TestJoystickInit:
     def test_init_no_joystick(self, handler: InputHandler) -> None:
         """Handler initializes with no joystick when none connected."""
         assert handler.joystick is None
-        assert all(not v for v in handler.joy_directions.values())
 
     @patch("src.managers.input_handler.pygame.joystick")
     def test_init_with_joystick(self, mock_joystick_module) -> None:
@@ -248,14 +75,12 @@ class TestJoystickHotPlug:
         assert handler.joystick is mock_js  # unchanged
 
     def test_device_removed(self, handler, joy_device_removed_event) -> None:
-        """JOYDEVICEREMOVED clears joystick and joy_directions."""
+        """JOYDEVICEREMOVED clears joystick."""
         mock_js = MagicMock()
         mock_js.get_instance_id.return_value = 0
         handler.joystick = mock_js
-        handler.joy_directions[Direction.UP] = True
         handler.handle_event(joy_device_removed_event(instance_id=0))
         assert handler.joystick is None
-        assert all(not v for v in handler.joy_directions.values())
 
     def test_device_removed_wrong_instance(
         self, handler, joy_device_removed_event
@@ -266,228 +91,6 @@ class TestJoystickHotPlug:
         handler.joystick = mock_js
         handler.handle_event(joy_device_removed_event(instance_id=99))
         assert handler.joystick is mock_js  # unchanged
-
-
-class TestJoystickReset:
-    """Tests for reset clearing joystick state."""
-
-    def test_reset_clears_joy_directions(self, handler) -> None:
-        """reset() clears joy_directions alongside keyboard directions."""
-        handler.joy_directions[Direction.UP] = True
-        assert handler.joy_directions[Direction.UP]
-        handler.reset()
-        assert all(not v for v in handler.joy_directions.values())
-        assert not handler.shoot_pressed
-
-
-class TestJoystickHat:
-    """Tests for D-pad (hat) input handling."""
-
-    def test_hat_up(self, handler, joy_hat_event) -> None:
-        """Hat UP sets joy_directions UP."""
-        handler.handle_event(joy_hat_event((0, 1)))
-        assert handler.joy_directions[Direction.UP]
-        assert not handler.joy_directions[Direction.DOWN]
-
-    def test_hat_down(self, handler, joy_hat_event) -> None:
-        """Hat DOWN sets joy_directions DOWN."""
-        handler.handle_event(joy_hat_event((0, -1)))
-        assert handler.joy_directions[Direction.DOWN]
-
-    def test_hat_left(self, handler, joy_hat_event) -> None:
-        """Hat LEFT sets joy_directions LEFT."""
-        handler.handle_event(joy_hat_event((-1, 0)))
-        assert handler.joy_directions[Direction.LEFT]
-
-    def test_hat_right(self, handler, joy_hat_event) -> None:
-        """Hat RIGHT sets joy_directions RIGHT."""
-        handler.handle_event(joy_hat_event((1, 0)))
-        assert handler.joy_directions[Direction.RIGHT]
-
-    def test_hat_release(self, handler, joy_hat_event) -> None:
-        """Hat (0,0) clears all joy_directions."""
-        handler.handle_event(joy_hat_event((0, 1)))
-        assert handler.joy_directions[Direction.UP]
-        handler.handle_event(joy_hat_event((0, 0)))
-        assert all(not v for v in handler.joy_directions.values())
-
-    def test_hat_diagonal_prefers_vertical(self, handler, joy_hat_event) -> None:
-        """Diagonal hat values pick vertical axis (NES behavior)."""
-        handler.handle_event(joy_hat_event((1, 1)))
-        assert handler.joy_directions[Direction.UP]
-        assert not handler.joy_directions[Direction.RIGHT]
-
-        handler.handle_event(joy_hat_event((-1, -1)))
-        assert handler.joy_directions[Direction.DOWN]
-        assert not handler.joy_directions[Direction.LEFT]
-
-    def test_hat_merges_with_keyboard(
-        self, handler, key_down_event, joy_hat_event
-    ) -> None:
-        """get_movement_direction merges keyboard and joystick (OR logic)."""
-        handler.handle_event(key_down_event(pygame.K_UP))
-        handler.handle_event(joy_hat_event((1, 0)))
-        dx, dy = handler.get_movement_direction()
-        # keyboard UP (-1 dy) + joystick RIGHT (+1 dx)
-        assert dx == 1
-        assert dy == -1
-
-    def test_hat_direction_replaces_previous(self, handler, joy_hat_event) -> None:
-        """New hat direction replaces previous (only one joy direction active)."""
-        handler.handle_event(joy_hat_event((0, 1)))
-        assert handler.joy_directions[Direction.UP]
-        handler.handle_event(joy_hat_event((1, 0)))
-        assert handler.joy_directions[Direction.RIGHT]
-        assert not handler.joy_directions[Direction.UP]
-
-
-class TestJoystickAxis:
-    """Tests for analog stick (axis) input handling."""
-
-    def test_axis_left(self, handler, joy_axis_event) -> None:
-        """Left stick pushed left sets LEFT direction."""
-        handler.handle_event(joy_axis_event(axis=0, value=-0.8))
-        assert handler.joy_directions[Direction.LEFT]
-
-    def test_axis_right(self, handler, joy_axis_event) -> None:
-        """Left stick pushed right sets RIGHT direction."""
-        handler.handle_event(joy_axis_event(axis=0, value=0.8))
-        assert handler.joy_directions[Direction.RIGHT]
-
-    def test_axis_up(self, handler, joy_axis_event) -> None:
-        """Left stick pushed up sets UP direction."""
-        handler.handle_event(joy_axis_event(axis=1, value=-0.8))
-        assert handler.joy_directions[Direction.UP]
-
-    def test_axis_down(self, handler, joy_axis_event) -> None:
-        """Left stick pushed down sets DOWN direction."""
-        handler.handle_event(joy_axis_event(axis=1, value=0.8))
-        assert handler.joy_directions[Direction.DOWN]
-
-    def test_axis_deadzone_no_direction(self, handler, joy_axis_event) -> None:
-        """Axis value within deadzone does not set direction."""
-        handler.handle_event(joy_axis_event(axis=0, value=0.3))
-        assert not handler.joy_directions[Direction.RIGHT]
-        assert not handler.joy_directions[Direction.LEFT]
-
-    def test_axis_return_to_center_releases(self, handler, joy_axis_event) -> None:
-        """Axis returning within deadzone releases the direction."""
-        handler.handle_event(joy_axis_event(axis=0, value=-0.8))
-        assert handler.joy_directions[Direction.LEFT]
-        handler.handle_event(joy_axis_event(axis=0, value=0.1))
-        assert not handler.joy_directions[Direction.LEFT]
-
-    def test_axis_ignores_non_stick_axes(self, handler, joy_axis_event) -> None:
-        """Axes beyond 0 and 1 (triggers, right stick) are ignored."""
-        handler.handle_event(joy_axis_event(axis=2, value=1.0))
-        assert all(not v for v in handler.joy_directions.values())
-
-
-class TestJoystickButtons:
-    """Tests for joystick button input handling."""
-
-    def test_button_0_shoots(self, handler, joy_button_down_event) -> None:
-        """Button 0 (A/Cross) triggers shoot."""
-        handler.handle_event(joy_button_down_event(button=0))
-        assert handler.shoot_pressed
-
-    def test_button_1_shoots(self, handler, joy_button_down_event) -> None:
-        """Button 1 (B/Circle) triggers shoot."""
-        handler.handle_event(joy_button_down_event(button=1))
-        assert handler.shoot_pressed
-
-    def test_other_buttons_dont_shoot(self, handler, joy_button_down_event) -> None:
-        """Other buttons do not trigger shoot."""
-        handler.handle_event(joy_button_down_event(button=3))
-        assert not handler.shoot_pressed
-
-
-class TestControllerDpad:
-    """Tests for SDL GameController D-pad (button-based) input."""
-
-    def test_dpad_up(self, handler, ctrl_button_down_event) -> None:
-        """Controller D-pad UP sets joy_directions UP."""
-        handler.handle_event(ctrl_button_down_event(pygame.CONTROLLER_BUTTON_DPAD_UP))
-        assert handler.joy_directions[Direction.UP]
-
-    def test_dpad_down(self, handler, ctrl_button_down_event) -> None:
-        """Controller D-pad DOWN sets joy_directions DOWN."""
-        handler.handle_event(ctrl_button_down_event(pygame.CONTROLLER_BUTTON_DPAD_DOWN))
-        assert handler.joy_directions[Direction.DOWN]
-
-    def test_dpad_left(self, handler, ctrl_button_down_event) -> None:
-        """Controller D-pad LEFT sets joy_directions LEFT."""
-        handler.handle_event(ctrl_button_down_event(pygame.CONTROLLER_BUTTON_DPAD_LEFT))
-        assert handler.joy_directions[Direction.LEFT]
-
-    def test_dpad_right(self, handler, ctrl_button_down_event) -> None:
-        """Controller D-pad RIGHT sets joy_directions RIGHT."""
-        handler.handle_event(
-            ctrl_button_down_event(pygame.CONTROLLER_BUTTON_DPAD_RIGHT)
-        )
-        assert handler.joy_directions[Direction.RIGHT]
-
-    def test_dpad_release(
-        self, handler, ctrl_button_down_event, ctrl_button_up_event
-    ) -> None:
-        """Releasing D-pad button clears the direction."""
-        handler.handle_event(ctrl_button_down_event(pygame.CONTROLLER_BUTTON_DPAD_UP))
-        assert handler.joy_directions[Direction.UP]
-        handler.handle_event(ctrl_button_up_event(pygame.CONTROLLER_BUTTON_DPAD_UP))
-        assert not handler.joy_directions[Direction.UP]
-
-    def test_dpad_replaces_previous(self, handler, ctrl_button_down_event) -> None:
-        """New D-pad direction replaces previous."""
-        handler.handle_event(ctrl_button_down_event(pygame.CONTROLLER_BUTTON_DPAD_UP))
-        handler.handle_event(
-            ctrl_button_down_event(pygame.CONTROLLER_BUTTON_DPAD_RIGHT)
-        )
-        assert handler.joy_directions[Direction.RIGHT]
-        assert not handler.joy_directions[Direction.UP]
-
-
-class TestControllerButtons:
-    """Tests for SDL GameController button input."""
-
-    def test_a_button_shoots(self, handler, ctrl_button_down_event) -> None:
-        """Controller A button triggers shoot."""
-        handler.handle_event(ctrl_button_down_event(pygame.CONTROLLER_BUTTON_A))
-        assert handler.shoot_pressed
-
-    def test_b_button_shoots(self, handler, ctrl_button_down_event) -> None:
-        """Controller B button triggers shoot."""
-        handler.handle_event(ctrl_button_down_event(pygame.CONTROLLER_BUTTON_B))
-        assert handler.shoot_pressed
-
-
-class TestControllerAxis:
-    """Tests for SDL GameController analog stick input."""
-
-    def test_left_stick_left(self, handler, ctrl_axis_event) -> None:
-        """Left stick pushed left sets LEFT direction."""
-        handler.handle_event(ctrl_axis_event(pygame.CONTROLLER_AXIS_LEFTX, -0.8))
-        assert handler.joy_directions[Direction.LEFT]
-
-    def test_left_stick_right(self, handler, ctrl_axis_event) -> None:
-        """Left stick pushed right sets RIGHT direction."""
-        handler.handle_event(ctrl_axis_event(pygame.CONTROLLER_AXIS_LEFTX, 0.8))
-        assert handler.joy_directions[Direction.RIGHT]
-
-    def test_left_stick_up(self, handler, ctrl_axis_event) -> None:
-        """Left stick pushed up sets UP direction."""
-        handler.handle_event(ctrl_axis_event(pygame.CONTROLLER_AXIS_LEFTY, -0.8))
-        assert handler.joy_directions[Direction.UP]
-
-    def test_left_stick_down(self, handler, ctrl_axis_event) -> None:
-        """Left stick pushed down sets DOWN direction."""
-        handler.handle_event(ctrl_axis_event(pygame.CONTROLLER_AXIS_LEFTY, 0.8))
-        assert handler.joy_directions[Direction.DOWN]
-
-    def test_left_stick_deadzone(self, handler, ctrl_axis_event) -> None:
-        """Axis within deadzone sets no direction."""
-        handler.handle_event(ctrl_axis_event(pygame.CONTROLLER_AXIS_LEFTX, 0.3))
-        assert not handler.joy_directions[Direction.RIGHT]
-        assert not handler.joy_directions[Direction.LEFT]
 
 
 class TestMenuActions:
@@ -533,7 +136,10 @@ class TestMenuActions:
         """Multiple actions accumulated before consume are returned in order."""
         handler.handle_event(key_down_event(pygame.K_DOWN))
         handler.handle_event(key_down_event(pygame.K_RETURN))
-        assert handler.consume_menu_actions() == [MenuAction.DOWN, MenuAction.CONFIRM]
+        assert handler.consume_menu_actions() == [
+            MenuAction.DOWN,
+            MenuAction.CONFIRM,
+        ]
 
     def test_key_repeat_produces_multiple(self, handler, key_down_event) -> None:
         """Each KEYDOWN event (including repeats) produces a MenuAction."""
@@ -628,15 +234,6 @@ class TestMenuActionsController:
         """Raw joystick button 1 produces MenuAction.CONFIRM."""
         handler.handle_event(joy_button_down_event(button=1))
         assert MenuAction.CONFIRM in handler.consume_menu_actions()
-
-    def test_ctrl_button_up_produces_no_menu_action(
-        self, handler, ctrl_button_down_event, ctrl_button_up_event
-    ) -> None:
-        """Releasing a controller button does not produce a menu action."""
-        handler.handle_event(ctrl_button_down_event(pygame.CONTROLLER_BUTTON_DPAD_UP))
-        handler.consume_menu_actions()  # clear press action
-        handler.handle_event(ctrl_button_up_event(pygame.CONTROLLER_BUTTON_DPAD_UP))
-        assert handler.consume_menu_actions() == []
 
 
 class TestMenuActionsAxisEdgeDetection:

--- a/tests/unit/managers/test_player_input.py
+++ b/tests/unit/managers/test_player_input.py
@@ -86,17 +86,17 @@ class TestKeyboardPlayerInput:
         assert keyboard_input.get_movement_direction() == (0, 0)
         assert keyboard_input.consume_shoot() is False
 
-    def test_ignores_joystick_events(self, keyboard_input: PlayerInput) -> None:
-        """Keyboard source ignores joystick events."""
+    def test_also_handles_joystick_events(self, keyboard_input: PlayerInput) -> None:
+        """Keyboard source also handles joystick events for single-player use."""
         keyboard_input.handle_event(
             pygame.event.Event(pygame.JOYHATMOTION, value=(0, 1), hat=0, instance_id=0)
         )
-        assert keyboard_input.get_movement_direction() == (0, 0)
+        assert keyboard_input.get_movement_direction() == (0, -1)
 
         keyboard_input.handle_event(
             pygame.event.Event(pygame.JOYBUTTONDOWN, button=0, instance_id=0)
         )
-        assert keyboard_input.consume_shoot() is False
+        assert keyboard_input.consume_shoot() is True
 
 
 class TestJoystickPlayerInput:

--- a/tests/unit/managers/test_player_input.py
+++ b/tests/unit/managers/test_player_input.py
@@ -1,0 +1,176 @@
+import pytest
+import pygame
+from src.managers.player_input import InputSource, PlayerInput
+
+
+@pytest.fixture
+def keyboard_input() -> PlayerInput:
+    """Fixture providing a keyboard-sourced PlayerInput."""
+    return PlayerInput(InputSource.KEYBOARD)
+
+
+@pytest.fixture
+def joystick_input() -> PlayerInput:
+    """Fixture providing a joystick-sourced PlayerInput (index 0)."""
+    return PlayerInput(InputSource.JOYSTICK, joystick_index=0)
+
+
+@pytest.fixture
+def joystick_input_1() -> PlayerInput:
+    """Fixture providing a joystick-sourced PlayerInput (index 1)."""
+    return PlayerInput(InputSource.JOYSTICK, joystick_index=1)
+
+
+class TestKeyboardPlayerInput:
+    def test_initial_direction_is_zero(self, keyboard_input: PlayerInput) -> None:
+        """Initial movement direction is (0, 0)."""
+        assert keyboard_input.get_movement_direction() == (0, 0)
+
+    def test_initial_shoot_is_false(self, keyboard_input: PlayerInput) -> None:
+        """Initial shoot flag is False."""
+        assert keyboard_input.consume_shoot() is False
+
+    def test_arrow_up_sets_direction(self, keyboard_input: PlayerInput) -> None:
+        """K_UP sets direction to (0, -1)."""
+        keyboard_input.handle_event(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_UP))
+        assert keyboard_input.get_movement_direction() == (0, -1)
+
+    def test_arrow_down_sets_direction(self, keyboard_input: PlayerInput) -> None:
+        """K_DOWN sets direction to (0, 1)."""
+        keyboard_input.handle_event(
+            pygame.event.Event(pygame.KEYDOWN, key=pygame.K_DOWN)
+        )
+        assert keyboard_input.get_movement_direction() == (0, 1)
+
+    def test_arrow_left_sets_direction(self, keyboard_input: PlayerInput) -> None:
+        """K_LEFT sets direction to (-1, 0)."""
+        keyboard_input.handle_event(
+            pygame.event.Event(pygame.KEYDOWN, key=pygame.K_LEFT)
+        )
+        assert keyboard_input.get_movement_direction() == (-1, 0)
+
+    def test_arrow_right_sets_direction(self, keyboard_input: PlayerInput) -> None:
+        """K_RIGHT sets direction to (1, 0)."""
+        keyboard_input.handle_event(
+            pygame.event.Event(pygame.KEYDOWN, key=pygame.K_RIGHT)
+        )
+        assert keyboard_input.get_movement_direction() == (1, 0)
+
+    def test_arrow_release_clears_direction(self, keyboard_input: PlayerInput) -> None:
+        """KEYUP for arrow key clears the direction."""
+        keyboard_input.handle_event(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_UP))
+        assert keyboard_input.get_movement_direction() == (0, -1)
+        keyboard_input.handle_event(pygame.event.Event(pygame.KEYUP, key=pygame.K_UP))
+        assert keyboard_input.get_movement_direction() == (0, 0)
+
+    def test_space_sets_shoot(self, keyboard_input: PlayerInput) -> None:
+        """SPACE KEYDOWN sets shoot flag."""
+        keyboard_input.handle_event(
+            pygame.event.Event(pygame.KEYDOWN, key=pygame.K_SPACE)
+        )
+        assert keyboard_input.consume_shoot() is True
+
+    def test_consume_shoot_clears_flag(self, keyboard_input: PlayerInput) -> None:
+        """consume_shoot returns True once then False."""
+        keyboard_input.handle_event(
+            pygame.event.Event(pygame.KEYDOWN, key=pygame.K_SPACE)
+        )
+        assert keyboard_input.consume_shoot() is True
+        assert keyboard_input.consume_shoot() is False
+
+    def test_ignores_non_gameplay_keys(self, keyboard_input: PlayerInput) -> None:
+        """Non-gameplay keys (e.g. ESCAPE) are ignored."""
+        keyboard_input.handle_event(
+            pygame.event.Event(pygame.KEYDOWN, key=pygame.K_ESCAPE)
+        )
+        assert keyboard_input.get_movement_direction() == (0, 0)
+        assert keyboard_input.consume_shoot() is False
+
+    def test_ignores_joystick_events(self, keyboard_input: PlayerInput) -> None:
+        """Keyboard source ignores joystick events."""
+        keyboard_input.handle_event(
+            pygame.event.Event(pygame.JOYHATMOTION, value=(0, 1), hat=0, instance_id=0)
+        )
+        assert keyboard_input.get_movement_direction() == (0, 0)
+
+        keyboard_input.handle_event(
+            pygame.event.Event(pygame.JOYBUTTONDOWN, button=0, instance_id=0)
+        )
+        assert keyboard_input.consume_shoot() is False
+
+
+class TestJoystickPlayerInput:
+    def test_initial_direction_is_zero(self, joystick_input: PlayerInput) -> None:
+        """Initial movement direction is (0, 0)."""
+        assert joystick_input.get_movement_direction() == (0, 0)
+
+    def test_controller_dpad_sets_direction(self, joystick_input: PlayerInput) -> None:
+        """CONTROLLERBUTTONDOWN for DPAD_UP sets direction to (0, -1)."""
+        joystick_input.handle_event(
+            pygame.event.Event(
+                pygame.CONTROLLERBUTTONDOWN,
+                button=pygame.CONTROLLER_BUTTON_DPAD_UP,
+                which=0,
+            )
+        )
+        assert joystick_input.get_movement_direction() == (0, -1)
+
+    def test_controller_shoot_button(self, joystick_input: PlayerInput) -> None:
+        """CONTROLLERBUTTONDOWN for A button sets shoot flag."""
+        joystick_input.handle_event(
+            pygame.event.Event(
+                pygame.CONTROLLERBUTTONDOWN,
+                button=pygame.CONTROLLER_BUTTON_A,
+                which=0,
+            )
+        )
+        assert joystick_input.consume_shoot() is True
+
+    def test_ignores_events_from_other_joystick(
+        self,
+        joystick_input: PlayerInput,
+        joystick_input_1: PlayerInput,
+    ) -> None:
+        """Joystick index 0 ignores events from joystick index 1."""
+        # JOYHATMOTION with joy=1 should not affect joystick_input (index 0)
+        joystick_input.handle_event(
+            pygame.event.Event(
+                pygame.JOYHATMOTION, value=(0, 1), hat=0, joy=1, instance_id=1
+            )
+        )
+        assert joystick_input.get_movement_direction() == (0, 0)
+
+        # JOYHATMOTION with joy=0 should not affect joystick_input_1 (index 1)
+        joystick_input_1.handle_event(
+            pygame.event.Event(
+                pygame.JOYHATMOTION, value=(0, 1), hat=0, joy=0, instance_id=0
+            )
+        )
+        assert joystick_input_1.get_movement_direction() == (0, 0)
+
+    def test_ignores_keyboard_events(self, joystick_input: PlayerInput) -> None:
+        """Joystick source ignores keyboard KEYDOWN events."""
+        joystick_input.handle_event(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_UP))
+        assert joystick_input.get_movement_direction() == (0, 0)
+        joystick_input.handle_event(
+            pygame.event.Event(pygame.KEYDOWN, key=pygame.K_SPACE)
+        )
+        assert joystick_input.consume_shoot() is False
+
+    def test_axis_with_deadzone(self, joystick_input: PlayerInput) -> None:
+        """Axis within deadzone sets no direction; beyond deadzone sets direction."""
+        # Within deadzone — no direction
+        joystick_input.handle_event(
+            pygame.event.Event(
+                pygame.JOYAXISMOTION, axis=0, value=0.3, joy=0, instance_id=0
+            )
+        )
+        assert joystick_input.get_movement_direction() == (0, 0)
+
+        # Beyond deadzone — sets direction
+        joystick_input.handle_event(
+            pygame.event.Event(
+                pygame.JOYAXISMOTION, axis=0, value=-0.8, joy=0, instance_id=0
+            )
+        )
+        assert joystick_input.get_movement_direction() == (-1, 0)

--- a/tests/unit/managers/test_player_input.py
+++ b/tests/unit/managers/test_player_input.py
@@ -148,14 +148,14 @@ class TestJoystickPlayerInput:
         )
         assert joystick_input_1.get_movement_direction() == (0, 0)
 
-    def test_ignores_keyboard_events(self, joystick_input: PlayerInput) -> None:
-        """Joystick source ignores keyboard KEYDOWN events."""
+    def test_also_handles_keyboard_events(self, joystick_input: PlayerInput) -> None:
+        """All sources handle keyboard input (merged OR logic)."""
         joystick_input.handle_event(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_UP))
-        assert joystick_input.get_movement_direction() == (0, 0)
+        assert joystick_input.get_movement_direction() == (0, -1)
         joystick_input.handle_event(
             pygame.event.Event(pygame.KEYDOWN, key=pygame.K_SPACE)
         )
-        assert joystick_input.consume_shoot() is False
+        assert joystick_input.consume_shoot() is True
 
     def test_axis_with_deadzone(self, joystick_input: PlayerInput) -> None:
         """Axis within deadzone sets no direction; beyond deadzone sets direction."""

--- a/tests/unit/managers/test_player_manager.py
+++ b/tests/unit/managers/test_player_manager.py
@@ -456,9 +456,9 @@ class TestPlayerManagerScore:
 
 
 class TestPlayerManagerIsOnIce:
-    def test_not_on_ice_when_no_tile(self, player_manager, mock_game_map):
-        """Returns False when get_tile_at returns None."""
-        mock_game_map.get_tile_at.return_value = None
+    def test_not_on_ice_delegates_to_map(self, player_manager, mock_game_map):
+        """Returns False when map.is_tile_slidable returns False."""
+        mock_game_map.is_tile_slidable.return_value = False
 
         player = MagicMock(spec=PlayerTank)
         player.x = 0
@@ -467,26 +467,13 @@ class TestPlayerManagerIsOnIce:
         player.height = TILE_SIZE
 
         assert player_manager._is_on_ice(player, mock_game_map) is False
+        mock_game_map.is_tile_slidable.assert_called_once_with(
+            player.x, player.y, player.width, player.height
+        )
 
-    def test_not_on_ice_when_tile_not_slidable(self, player_manager, mock_game_map):
-        """Returns False when tile.is_slidable is False."""
-        brick_tile = MagicMock(spec=Tile)
-        brick_tile.is_slidable = False
-        mock_game_map.get_tile_at.return_value = brick_tile
-
-        player = MagicMock(spec=PlayerTank)
-        player.x = 0
-        player.y = 0
-        player.width = TILE_SIZE
-        player.height = TILE_SIZE
-
-        assert player_manager._is_on_ice(player, mock_game_map) is False
-
-    def test_on_ice_when_tile_is_slidable(self, player_manager, mock_game_map):
-        """Returns True when tile.is_slidable is True."""
-        ice_tile = MagicMock(spec=Tile)
-        ice_tile.is_slidable = True
-        mock_game_map.get_tile_at.return_value = ice_tile
+    def test_on_ice_delegates_to_map(self, player_manager, mock_game_map):
+        """Returns True when map.is_tile_slidable returns True."""
+        mock_game_map.is_tile_slidable.return_value = True
 
         player = MagicMock(spec=PlayerTank)
         player.x = 0
@@ -495,25 +482,6 @@ class TestPlayerManagerIsOnIce:
         player.height = TILE_SIZE
 
         assert player_manager._is_on_ice(player, mock_game_map) is True
-
-    def test_tile_lookup_uses_tank_centre(self, player_manager, mock_game_map):
-        """The tile is looked up at the tank's centre, not origin."""
-        mock_game_map.get_tile_at.return_value = None
-        mock_game_map.tile_size = TILE_SIZE
-
-        player = MagicMock(spec=PlayerTank)
-        player.x = float(2 * TILE_SIZE)
-        player.y = float(3 * TILE_SIZE)
-        player.width = TILE_SIZE
-        player.height = TILE_SIZE
-
-        player_manager._is_on_ice(player, mock_game_map)
-
-        expected_grid_x = (2 * TILE_SIZE + TILE_SIZE // 2) // TILE_SIZE
-        expected_grid_y = (3 * TILE_SIZE + TILE_SIZE // 2) // TILE_SIZE
-        mock_game_map.get_tile_at.assert_called_once_with(
-            expected_grid_x, expected_grid_y
-        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/managers/test_player_manager.py
+++ b/tests/unit/managers/test_player_manager.py
@@ -1,0 +1,692 @@
+"""Unit tests for PlayerManager."""
+
+from __future__ import annotations
+
+import pytest
+import pygame
+from unittest.mock import MagicMock, patch
+
+from src.core.bullet import Bullet
+from src.core.map import Map
+from src.core.player_tank import PlayerTank
+from src.core.tile import Tile
+from src.managers.player_input import InputSource, PlayerInput
+from src.managers.player_manager import PlayerManager
+from src.managers.sound_manager import SoundManager
+from src.utils.constants import TILE_SIZE
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_sound_manager():
+    """Mock SoundManager."""
+    return MagicMock(spec=SoundManager)
+
+
+@pytest.fixture
+def player_manager(mock_texture_manager, mock_sound_manager):
+    """PlayerManager with mock dependencies."""
+    return PlayerManager(mock_texture_manager, mock_sound_manager)
+
+
+@pytest.fixture
+def mock_game_map():
+    """Mock Map with typical spawn / dimension attributes."""
+    game_map = MagicMock(spec=Map)
+    game_map.player_spawn = (4, 24)
+    game_map.width = 26
+    game_map.height = 26
+    game_map.tile_size = TILE_SIZE
+    # Default: no ice tile under any tank
+    game_map.get_tile_at.return_value = None
+    return game_map
+
+
+# ---------------------------------------------------------------------------
+# Helper: create a real PlayerTank backed by the mock texture manager
+# ---------------------------------------------------------------------------
+
+
+def _make_player(mock_tm, x=0, y=0, tile_size=TILE_SIZE, map_size_tiles=26):
+    """Return a real PlayerTank for use in tests."""
+    px = map_size_tiles * tile_size
+    return PlayerTank(x, y, tile_size, mock_tm, map_width_px=px, map_height_px=px)
+
+
+# ---------------------------------------------------------------------------
+# TestPlayerManagerCreation
+# ---------------------------------------------------------------------------
+
+
+class TestPlayerManagerCreation:
+    def test_initial_players_empty(self, player_manager):
+        """No players exist before create_players() is called."""
+        assert player_manager.get_active_players() == []
+
+    def test_initial_bullets_empty(self, player_manager):
+        """No bullets exist before create_players() is called."""
+        assert player_manager.get_all_bullets() == []
+
+    def test_create_players_single_player(
+        self, player_manager, mock_game_map, mock_texture_manager
+    ):
+        """create_players() produces exactly one active player."""
+        with patch("pygame.joystick.get_count", return_value=0):
+            player_manager.create_players(mock_game_map)
+
+        players = player_manager.get_active_players()
+        assert len(players) == 1
+        assert isinstance(players[0], PlayerTank)
+
+    def test_create_players_sets_correct_position(
+        self, player_manager, mock_game_map, mock_texture_manager
+    ):
+        """Player tank is placed at the map's player_spawn coordinates."""
+        mock_game_map.player_spawn = (3, 22)
+        mock_game_map.tile_size = TILE_SIZE
+
+        with patch("pygame.joystick.get_count", return_value=0):
+            player_manager.create_players(mock_game_map)
+
+        player = player_manager.get_active_players()[0]
+        expected_x = 3 * TILE_SIZE
+        expected_y = 22 * TILE_SIZE
+        assert player.x == expected_x
+        assert player.y == expected_y
+
+    def test_create_players_keyboard_when_no_joystick(
+        self, player_manager, mock_game_map
+    ):
+        """Keyboard input source is assigned when no joystick is present."""
+        with patch("pygame.joystick.get_count", return_value=0):
+            player_manager.create_players(mock_game_map)
+
+        assert player_manager._player_inputs[0].source == InputSource.KEYBOARD
+
+    def test_create_players_joystick_when_available(
+        self, player_manager, mock_game_map
+    ):
+        """Joystick input source is assigned when a joystick is detected."""
+        with patch("pygame.joystick.get_count", return_value=1):
+            player_manager.create_players(mock_game_map)
+
+        assert player_manager._player_inputs[0].source == InputSource.JOYSTICK
+
+    def test_create_players_clears_previous_state(self, player_manager, mock_game_map):
+        """Calling create_players() twice resets players, inputs, and bullets."""
+        with patch("pygame.joystick.get_count", return_value=0):
+            player_manager.create_players(mock_game_map)
+            # Manually add a bullet to the list
+            player_manager._bullets.append(MagicMock(spec=Bullet))
+            player_manager.create_players(mock_game_map)
+
+        assert len(player_manager._players) == 1
+        assert len(player_manager._bullets) == 0
+
+    def test_get_active_players_returns_living(self, player_manager, mock_game_map):
+        """get_active_players() filters out dead tanks."""
+        with patch("pygame.joystick.get_count", return_value=0):
+            player_manager.create_players(mock_game_map)
+
+        player_manager._players[0].health = 0
+        assert player_manager.get_active_players() == []
+
+    def test_get_all_bullets_empty_initially(self, player_manager, mock_game_map):
+        """No bullets exist immediately after create_players()."""
+        with patch("pygame.joystick.get_count", return_value=0):
+            player_manager.create_players(mock_game_map)
+
+        assert player_manager.get_all_bullets() == []
+
+
+# ---------------------------------------------------------------------------
+# TestPlayerManagerUpdate
+# ---------------------------------------------------------------------------
+
+
+class TestPlayerManagerUpdate:
+    @pytest.fixture(autouse=True)
+    def setup(self, player_manager, mock_game_map, mock_texture_manager):
+        """Create a single player before each test in this class."""
+        with patch("pygame.joystick.get_count", return_value=0):
+            player_manager.create_players(mock_game_map)
+        self.pm = player_manager
+        self.game_map = mock_game_map
+
+    def test_update_calls_player_update(self):
+        """player.update(dt) is called for each living player."""
+        player = MagicMock(spec=PlayerTank)
+        player.health = 1
+        player.on_ice = False
+        player.is_sliding = False
+        player.direction = MagicMock()
+        player.direction.delta = (0, 0)
+        player.x = 0.0
+        player.y = 0.0
+        player.width = TILE_SIZE
+        player.height = TILE_SIZE
+        self.pm._players = [player]
+        # Pair with a keyboard input that has no keys pressed
+        self.pm._player_inputs = [PlayerInput(InputSource.KEYBOARD)]
+
+        self.pm.update(0.016, self.game_map)
+
+        player.update.assert_called_once_with(0.016)
+
+    def test_update_skips_dead_player(self):
+        """Dead players (health == 0) are skipped entirely."""
+        player = MagicMock(spec=PlayerTank)
+        player.health = 0
+        self.pm._players = [player]
+        self.pm._player_inputs = [PlayerInput(InputSource.KEYBOARD)]
+
+        self.pm.update(0.016, self.game_map)
+
+        player.update.assert_not_called()
+
+    def test_movement_applied_on_valid_input(self, mock_texture_manager):
+        """Player.move() is called when a valid (non-diagonal) direction is active."""
+        player = MagicMock(spec=PlayerTank)
+        player.health = 1
+        player.on_ice = False
+        player.is_sliding = False
+        player.direction = MagicMock()
+        player.direction.delta = (0, -1)
+        player.x = 0.0
+        player.y = 0.0
+        player.width = TILE_SIZE
+        player.height = TILE_SIZE
+        self.pm._players = [player]
+
+        pi = PlayerInput(InputSource.KEYBOARD)
+        pi.handle_event(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_UP))
+        self.pm._player_inputs = [pi]
+
+        self.pm.update(0.016, self.game_map)
+
+        player.move.assert_called_once_with(0, -1, 0.016)
+
+    def test_diagonal_input_does_not_move(self):
+        """Diagonal input (dx and dy both non-zero) is rejected."""
+        player = MagicMock(spec=PlayerTank)
+        player.health = 1
+        player.on_ice = False
+        player.is_sliding = False
+        player.direction = MagicMock()
+        player.direction.delta = (0, 0)
+        player.x = 0.0
+        player.y = 0.0
+        player.width = TILE_SIZE
+        player.height = TILE_SIZE
+        self.pm._players = [player]
+
+        pi = PlayerInput(InputSource.KEYBOARD)
+        # Press both UP and RIGHT simultaneously
+        pi.handle_event(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_UP))
+        pi.handle_event(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_RIGHT))
+        self.pm._player_inputs = [pi]
+
+        self.pm.update(0.016, self.game_map)
+
+        player.move.assert_not_called()
+
+    def test_sliding_player_does_not_move_via_input(self):
+        """A player that is_sliding does not receive a move() call."""
+        player = MagicMock(spec=PlayerTank)
+        player.health = 1
+        player.on_ice = False
+        player.is_sliding = True
+        player.direction = MagicMock()
+        player.direction.delta = (0, -1)
+        player.x = 0.0
+        player.y = 0.0
+        player.width = TILE_SIZE
+        player.height = TILE_SIZE
+        self.pm._players = [player]
+
+        pi = PlayerInput(InputSource.KEYBOARD)
+        pi.handle_event(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_UP))
+        self.pm._player_inputs = [pi]
+
+        self.pm.update(0.016, self.game_map)
+
+        player.move.assert_not_called()
+
+    def test_ice_slide_starts_when_on_ice_and_no_valid_input(self, mock_sound_manager):
+        """start_slide() is called (and ice sound plays) when on ice with no input."""
+        player = MagicMock(spec=PlayerTank)
+        player.health = 1
+        player.is_sliding = False
+        player.direction = MagicMock()
+        player.direction.delta = (0, -1)
+
+        # Simulate ice tile under tank
+        ice_tile = MagicMock(spec=Tile)
+        ice_tile.is_slidable = True
+        self.game_map.get_tile_at.return_value = ice_tile
+        player.start_slide.return_value = True
+
+        # Mock width/height for centre calculation
+        player.x = 0
+        player.y = 0
+        player.width = TILE_SIZE
+        player.height = TILE_SIZE
+
+        self.pm._players = [player]
+        self.pm._player_inputs = [PlayerInput(InputSource.KEYBOARD)]  # no keys pressed
+
+        self.pm.update(0.016, self.game_map)
+
+        player.start_slide.assert_called_once()
+        self.pm._sound_manager.play_ice_slide.assert_called_once()
+
+    def test_bullets_updated_during_update(self):
+        """Active bullets have update(dt) called."""
+        bullet = MagicMock(spec=Bullet)
+        bullet.active = True
+        self.pm._bullets = [bullet]
+
+        self.pm.update(0.016, self.game_map)
+
+        bullet.update.assert_called_once_with(0.016)
+
+    def test_inactive_bullets_pruned_after_update(self):
+        """Inactive bullets are removed from the internal list after update."""
+        bullet = MagicMock(spec=Bullet)
+        bullet.active = False
+        self.pm._bullets = [bullet]
+
+        self.pm.update(0.016, self.game_map)
+
+        assert self.pm._bullets == []
+
+
+# ---------------------------------------------------------------------------
+# TestPlayerManagerShooting
+# ---------------------------------------------------------------------------
+
+
+class TestPlayerManagerShooting:
+    @pytest.fixture(autouse=True)
+    def setup(self, player_manager, mock_game_map):
+        """Create a single player before each test in this class."""
+        with patch("pygame.joystick.get_count", return_value=0):
+            player_manager.create_players(mock_game_map)
+        self.pm = player_manager
+
+    def test_try_shoot_creates_bullet(self, mock_sound_manager):
+        """try_shoot() appends a bullet and plays the shoot sound."""
+        player = MagicMock(spec=PlayerTank)
+        player.health = 1
+        player.max_bullets = 1
+
+        bullet = MagicMock(spec=Bullet)
+        bullet.active = True
+        bullet.owner = player
+        player.shoot.return_value = bullet
+
+        self.pm._players = [player]
+        pi = PlayerInput(InputSource.KEYBOARD)
+        pi._shoot_pressed = True  # simulate a shoot press
+        self.pm._player_inputs = [pi]
+
+        self.pm.try_shoot()
+
+        player.shoot.assert_called_once()
+        assert bullet in self.pm._bullets
+        self.pm._sound_manager.play_shoot.assert_called_once()
+
+    def test_try_shoot_no_bullet_without_input(self, mock_sound_manager):
+        """try_shoot() does nothing when shoot was not pressed."""
+        player = MagicMock(spec=PlayerTank)
+        player.health = 1
+        player.max_bullets = 1
+
+        self.pm._players = [player]
+        self.pm._player_inputs = [PlayerInput(InputSource.KEYBOARD)]
+
+        self.pm.try_shoot()
+
+        player.shoot.assert_not_called()
+        self.pm._sound_manager.play_shoot.assert_not_called()
+
+    def test_try_shoot_respects_max_bullets(self):
+        """No new bullet is created when max_bullets are already active."""
+        player = MagicMock(spec=PlayerTank)
+        player.health = 1
+        player.max_bullets = 1
+
+        existing_bullet = MagicMock(spec=Bullet)
+        existing_bullet.active = True
+        existing_bullet.owner = player
+        self.pm._bullets = [existing_bullet]
+
+        self.pm._players = [player]
+        pi = PlayerInput(InputSource.KEYBOARD)
+        pi._shoot_pressed = True
+        self.pm._player_inputs = [pi]
+
+        self.pm.try_shoot()
+
+        player.shoot.assert_not_called()
+
+    def test_try_shoot_skips_dead_player(self):
+        """Dead players cannot shoot."""
+        player = MagicMock(spec=PlayerTank)
+        player.health = 0
+        player.max_bullets = 1
+
+        self.pm._players = [player]
+        pi = PlayerInput(InputSource.KEYBOARD)
+        pi._shoot_pressed = True
+        self.pm._player_inputs = [pi]
+
+        self.pm.try_shoot()
+
+        player.shoot.assert_not_called()
+
+    def test_try_shoot_none_bullet_not_appended(self):
+        """If player.shoot() returns None the bullet list is unchanged."""
+        player = MagicMock(spec=PlayerTank)
+        player.health = 1
+        player.max_bullets = 1
+        player.shoot.return_value = None
+
+        self.pm._players = [player]
+        pi = PlayerInput(InputSource.KEYBOARD)
+        pi._shoot_pressed = True
+        self.pm._player_inputs = [pi]
+
+        self.pm.try_shoot()
+
+        assert self.pm._bullets == []
+
+
+# ---------------------------------------------------------------------------
+# TestPlayerManagerHandleEvent
+# ---------------------------------------------------------------------------
+
+
+class TestPlayerManagerHandleEvent:
+    def test_handle_event_forwarded_to_player_input(
+        self, player_manager, mock_game_map
+    ):
+        """handle_event() propagates the event to the PlayerInput."""
+        with patch("pygame.joystick.get_count", return_value=0):
+            player_manager.create_players(mock_game_map)
+
+        pi = MagicMock(spec=PlayerInput)
+        player_manager._player_inputs = [pi]
+
+        event = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_SPACE)
+        player_manager.handle_event(event)
+
+        pi.handle_event.assert_called_once_with(event)
+
+
+# ---------------------------------------------------------------------------
+# TestPlayerManagerScore
+# ---------------------------------------------------------------------------
+
+
+class TestPlayerManagerScore:
+    def test_initial_score_zero(self, player_manager):
+        """Score is 0 immediately after construction."""
+        assert player_manager.score == 0
+
+    def test_add_score_increments(self, player_manager):
+        """add_score(100) raises the score to 100."""
+        player_manager.add_score(100)
+        assert player_manager.score == 100
+
+    def test_add_score_accumulates(self, player_manager):
+        """Multiple add_score() calls accumulate correctly."""
+        player_manager.add_score(200)
+        player_manager.add_score(300)
+        assert player_manager.score == 500
+
+
+# ---------------------------------------------------------------------------
+# TestPlayerManagerIsOnIce
+# ---------------------------------------------------------------------------
+
+
+class TestPlayerManagerIsOnIce:
+    def test_not_on_ice_when_no_tile(self, player_manager, mock_game_map):
+        """Returns False when get_tile_at returns None."""
+        mock_game_map.get_tile_at.return_value = None
+
+        player = MagicMock(spec=PlayerTank)
+        player.x = 0
+        player.y = 0
+        player.width = TILE_SIZE
+        player.height = TILE_SIZE
+
+        assert player_manager._is_on_ice(player, mock_game_map) is False
+
+    def test_not_on_ice_when_tile_not_slidable(self, player_manager, mock_game_map):
+        """Returns False when tile.is_slidable is False."""
+        brick_tile = MagicMock(spec=Tile)
+        brick_tile.is_slidable = False
+        mock_game_map.get_tile_at.return_value = brick_tile
+
+        player = MagicMock(spec=PlayerTank)
+        player.x = 0
+        player.y = 0
+        player.width = TILE_SIZE
+        player.height = TILE_SIZE
+
+        assert player_manager._is_on_ice(player, mock_game_map) is False
+
+    def test_on_ice_when_tile_is_slidable(self, player_manager, mock_game_map):
+        """Returns True when tile.is_slidable is True."""
+        ice_tile = MagicMock(spec=Tile)
+        ice_tile.is_slidable = True
+        mock_game_map.get_tile_at.return_value = ice_tile
+
+        player = MagicMock(spec=PlayerTank)
+        player.x = 0
+        player.y = 0
+        player.width = TILE_SIZE
+        player.height = TILE_SIZE
+
+        assert player_manager._is_on_ice(player, mock_game_map) is True
+
+    def test_tile_lookup_uses_tank_centre(self, player_manager, mock_game_map):
+        """The tile is looked up at the tank's centre, not origin."""
+        mock_game_map.get_tile_at.return_value = None
+        mock_game_map.tile_size = TILE_SIZE
+
+        player = MagicMock(spec=PlayerTank)
+        player.x = float(2 * TILE_SIZE)
+        player.y = float(3 * TILE_SIZE)
+        player.width = TILE_SIZE
+        player.height = TILE_SIZE
+
+        player_manager._is_on_ice(player, mock_game_map)
+
+        expected_grid_x = (2 * TILE_SIZE + TILE_SIZE // 2) // TILE_SIZE
+        expected_grid_y = (3 * TILE_SIZE + TILE_SIZE // 2) // TILE_SIZE
+        mock_game_map.get_tile_at.assert_called_once_with(
+            expected_grid_x, expected_grid_y
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestPlayerManagerStatePreservation
+# ---------------------------------------------------------------------------
+
+
+class TestPlayerManagerStatePreservation:
+    def test_preserve_and_restore_lives(
+        self, player_manager, mock_game_map, mock_texture_manager
+    ):
+        """Preserved lives are restored onto a new player tank."""
+        with patch("pygame.joystick.get_count", return_value=0):
+            player_manager.create_players(mock_game_map)
+
+        player_manager._players[0].lives = 5
+        player_manager.preserve_state()
+
+        # Simulate stage transition: create fresh tanks
+        with patch("pygame.joystick.get_count", return_value=0):
+            player_manager.create_players(mock_game_map)
+
+        player_manager.restore_state()
+
+        assert player_manager._players[0].lives == 5
+
+    def test_preserve_and_restore_star_level(
+        self, player_manager, mock_game_map, mock_texture_manager
+    ):
+        """Preserved star_level is restored onto a new player tank."""
+        with patch("pygame.joystick.get_count", return_value=0):
+            player_manager.create_players(mock_game_map)
+
+        player_manager._players[0].restore_star_level(2)
+        player_manager.preserve_state()
+
+        with patch("pygame.joystick.get_count", return_value=0):
+            player_manager.create_players(mock_game_map)
+
+        player_manager.restore_state()
+
+        assert player_manager._players[0].star_level == 2
+
+    def test_restore_with_no_preserved_state(
+        self, player_manager, mock_game_map, mock_texture_manager
+    ):
+        """restore_state() with empty preserved state does not crash."""
+        with patch("pygame.joystick.get_count", return_value=0):
+            player_manager.create_players(mock_game_map)
+
+        # _preserved_state is empty by default — should not raise
+        player_manager.restore_state()
+
+        # Player remains in default state
+        assert player_manager._players[0].lives >= 0
+
+
+# ---------------------------------------------------------------------------
+# TestPlayerManagerDeathHandling
+# ---------------------------------------------------------------------------
+
+
+class TestPlayerManagerDeathHandling:
+    def test_handle_death_with_lives_respawns(self, player_manager, mock_game_map):
+        """handle_player_death calls respawn() and returns False when lives remain."""
+        player = MagicMock(spec=PlayerTank)
+        player.lives = 2
+        player.health = 0
+
+        result = player_manager.handle_player_death(player)
+
+        player.respawn.assert_called_once()
+        assert result is False
+
+    def test_handle_death_no_lives_returns_game_over(
+        self, player_manager, mock_game_map, mock_texture_manager
+    ):
+        """handle_player_death returns True when the last player is eliminated."""
+        with patch("pygame.joystick.get_count", return_value=0):
+            player_manager.create_players(mock_game_map)
+
+        player = player_manager._players[0]
+        player.lives = 0
+        player.health = 0
+
+        result = player_manager.handle_player_death(player)
+
+        assert result is True
+
+    def test_handle_death_no_lives_but_health_positive(
+        self, player_manager, mock_game_map, mock_texture_manager
+    ):
+        """Edge case: lives = 0 but health > 0 — is_game_over returns False."""
+        with patch("pygame.joystick.get_count", return_value=0):
+            player_manager.create_players(mock_game_map)
+
+        player = player_manager._players[0]
+        player.lives = 0
+        player.health = 1  # unusual state: out of lives but not fully dead
+
+        result = player_manager.handle_player_death(player)
+
+        # health > 0 means is_game_over() returns False
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# TestPlayerManagerGameOver
+# ---------------------------------------------------------------------------
+
+
+class TestPlayerManagerGameOver:
+    def test_not_game_over_when_alive(
+        self, player_manager, mock_game_map, mock_texture_manager
+    ):
+        """is_game_over() returns False when the player is still alive."""
+        with patch("pygame.joystick.get_count", return_value=0):
+            player_manager.create_players(mock_game_map)
+
+        player = player_manager._players[0]
+        player.health = 1
+        player.lives = 2
+
+        assert player_manager.is_game_over() is False
+
+    def test_game_over_when_dead_no_lives(
+        self, player_manager, mock_game_map, mock_texture_manager
+    ):
+        """is_game_over() returns True when the player is dead with no lives."""
+        with patch("pygame.joystick.get_count", return_value=0):
+            player_manager.create_players(mock_game_map)
+
+        player = player_manager._players[0]
+        player.health = 0
+        player.lives = 0
+
+        assert player_manager.is_game_over() is True
+
+    def test_not_game_over_when_has_lives(
+        self, player_manager, mock_game_map, mock_texture_manager
+    ):
+        """is_game_over() returns False when the player is dead but has lives left."""
+        with patch("pygame.joystick.get_count", return_value=0):
+            player_manager.create_players(mock_game_map)
+
+        player = player_manager._players[0]
+        player.health = 0
+        player.lives = 1  # dead this frame but can still respawn
+
+        assert player_manager.is_game_over() is False
+
+
+# ---------------------------------------------------------------------------
+# TestPlayerManagerReset
+# ---------------------------------------------------------------------------
+
+
+class TestPlayerManagerReset:
+    def test_reset_clears_all_state(
+        self, player_manager, mock_game_map, mock_texture_manager
+    ):
+        """reset() clears players, inputs, bullets, score, and preserved state."""
+        with patch("pygame.joystick.get_count", return_value=0):
+            player_manager.create_players(mock_game_map)
+
+        player_manager.add_score(500)
+        player_manager._bullets.append(MagicMock(spec=Bullet))
+        player_manager._preserved_state = {0: {"lives": 3, "star_level": 1}}
+
+        player_manager.reset()
+
+        assert player_manager._players == []
+        assert player_manager._player_inputs == []
+        assert player_manager._bullets == []
+        assert player_manager.score == 0
+        assert player_manager._preserved_state == {}

--- a/tests/unit/managers/test_renderer.py
+++ b/tests/unit/managers/test_renderer.py
@@ -74,7 +74,7 @@ class TestRendererRender:
             mock_effect_manager = MagicMock()
             renderer.render(
                 mock_map,
-                mock_player,
+                [mock_player],
                 [mock_enemy1, mock_enemy2],
                 [mock_bullet1, mock_bullet2],
                 mock_effect_manager,

--- a/tests/unit/managers/test_spawn_manager.py
+++ b/tests/unit/managers/test_spawn_manager.py
@@ -60,7 +60,7 @@ class TestSpawnManager:
             game_map=mock_game_map,
             enemy_composition=_DEFAULT_COMPOSITION,
             spawn_interval=5.0,
-            player_tank=mock_player_tank,
+            player_tanks=[mock_player_tank],
         )
         return manager
 
@@ -80,7 +80,7 @@ class TestSpawnManager:
         spawn_manager.enemy_tanks = []
         spawn_manager.total_enemy_spawns = 0
 
-        result = spawn_manager.spawn_enemy(mock_player_tank, mock_game_map)
+        result = spawn_manager.spawn_enemy([mock_player_tank], mock_game_map)
 
         assert result is True
         assert len(spawn_manager.enemy_tanks) == 1
@@ -96,7 +96,7 @@ class TestSpawnManager:
         spawn_manager.total_enemy_spawns = spawn_manager.max_enemy_spawns
 
         initial_enemies = len(spawn_manager.enemy_tanks)
-        result = spawn_manager.spawn_enemy(mock_player_tank, mock_game_map)
+        result = spawn_manager.spawn_enemy([mock_player_tank], mock_game_map)
 
         assert result is False
         assert len(spawn_manager.enemy_tanks) == initial_enemies
@@ -115,7 +115,7 @@ class TestSpawnManager:
 
         initial_enemies = len(spawn_manager.enemy_tanks)
         initial_spawns = spawn_manager.total_enemy_spawns
-        result = spawn_manager.spawn_enemy(mock_player_tank, mock_game_map)
+        result = spawn_manager.spawn_enemy([mock_player_tank], mock_game_map)
 
         assert result is False
         assert len(spawn_manager.enemy_tanks) == initial_enemies
@@ -138,7 +138,7 @@ class TestSpawnManager:
         spawn_manager.enemy_tanks = [existing_enemy]
         spawn_manager.total_enemy_spawns = 1
 
-        result = spawn_manager.spawn_enemy(mock_player_tank, mock_game_map)
+        result = spawn_manager.spawn_enemy([mock_player_tank], mock_game_map)
 
         assert result is False
         assert len(spawn_manager.enemy_tanks) == 1
@@ -153,8 +153,8 @@ class TestSpawnManager:
         with patch.object(
             spawn_manager, "spawn_enemy", return_value=True
         ) as mock_spawn:
-            spawn_manager.update(0.1, mock_player_tank, mock_game_map)
-            mock_spawn.assert_called_once_with(mock_player_tank, mock_game_map)
+            spawn_manager.update(0.1, [mock_player_tank], mock_game_map)
+            mock_spawn.assert_called_once_with([mock_player_tank], mock_game_map)
 
         # Timer should be reset after successful spawn
         # (We patched spawn_enemy so we check timer logic directly)
@@ -176,7 +176,7 @@ class TestSpawnManager:
         spawn_manager.enemy_tanks = []
         spawn_manager.total_enemy_spawns = 0
 
-        spawn_manager.update(0.0, mock_player_tank, mock_game_map)
+        spawn_manager.update(0.0, [mock_player_tank], mock_game_map)
 
         assert spawn_manager.spawn_timer == pytest.approx(0.0)
 
@@ -205,7 +205,7 @@ class TestSpawnManager:
         spawn_manager.spawn_timer = 0.0
 
         with patch.object(spawn_manager, "spawn_enemy") as mock_spawn:
-            spawn_manager.update(0.1, mock_player_tank, mock_game_map)
+            spawn_manager.update(0.1, [mock_player_tank], mock_game_map)
             mock_spawn.assert_not_called()
 
     def test_spawn_queue_built_from_composition(
@@ -217,7 +217,7 @@ class TestSpawnManager:
             game_map=mock_game_map,
             enemy_composition=_DEFAULT_COMPOSITION,
             spawn_interval=5.0,
-            player_tank=mock_player_tank,
+            player_tanks=[mock_player_tank],
         )
         # Stage 1: (18, 2, 0, 0) = 20 total
         assert manager.max_enemy_spawns == 20
@@ -237,7 +237,7 @@ class TestSpawnManager:
                 TankType.ARMOR: 3,
             },
             spawn_interval=5.0,
-            player_tank=mock_player_tank,
+            player_tanks=[mock_player_tank],
         )
         types_in_queue = set(manager._spawn_queue)
         assert len(types_in_queue) > 1
@@ -251,7 +251,7 @@ class TestSpawnManager:
             game_map=mock_game_map,
             enemy_composition=_DEFAULT_COMPOSITION,
             spawn_interval=5.0,
-            player_tank=mock_player_tank,
+            player_tanks=[mock_player_tank],
         )
         # Exhaust all 20 spawns
         for _ in range(25):  # more than 20 to test stop
@@ -273,7 +273,7 @@ class TestSpawnManager:
                 TankType.ARMOR: 0,
             },
             spawn_interval=5.0,
-            player_tank=mock_player_tank,
+            player_tanks=[mock_player_tank],
         )
         assert manager.max_enemy_spawns == 20
 
@@ -324,7 +324,7 @@ class TestSpawnAnimation:
             game_map=mock_game_map,
             enemy_composition=_DEFAULT_COMPOSITION,
             spawn_interval=5.0,
-            player_tank=mock_player_tank,
+            player_tanks=[mock_player_tank],
             effect_manager=mock_effect_manager,
         )
 
@@ -430,7 +430,7 @@ class TestSpawnManagerCarrier:
             game_map=mock_game_map,
             enemy_composition=_DEFAULT_COMPOSITION,
             spawn_interval=5.0,
-            player_tank=mock_player_tank,
+            player_tanks=[mock_player_tank],
         )
 
     def test_fourth_enemy_is_carrier(
@@ -439,11 +439,11 @@ class TestSpawnManagerCarrier:
         # Initial spawn was enemy 0 (index 0). Spawn indices 1, 2, 3.
         # Clear enemy_tanks between spawns to avoid collision blocking.
         spawn_manager.enemy_tanks = []
-        spawn_manager.spawn_enemy(mock_player_tank, mock_game_map)
+        spawn_manager.spawn_enemy([mock_player_tank], mock_game_map)
         spawn_manager.enemy_tanks = []
-        spawn_manager.spawn_enemy(mock_player_tank, mock_game_map)
+        spawn_manager.spawn_enemy([mock_player_tank], mock_game_map)
         spawn_manager.enemy_tanks = []
-        spawn_manager.spawn_enemy(mock_player_tank, mock_game_map)
+        spawn_manager.spawn_enemy([mock_player_tank], mock_game_map)
         # The 4th tank (index 3) should be the carrier
         carrier_tanks = [t for t in spawn_manager.enemy_tanks if t.is_carrier]
         assert len(carrier_tanks) == 1
@@ -451,9 +451,9 @@ class TestSpawnManagerCarrier:
     def test_non_carrier_indices(self, spawn_manager, mock_player_tank, mock_game_map):
         # Spawn indices 1 and 2 — neither should be a carrier.
         spawn_manager.enemy_tanks = []
-        spawn_manager.spawn_enemy(mock_player_tank, mock_game_map)
+        spawn_manager.spawn_enemy([mock_player_tank], mock_game_map)
         spawn_manager.enemy_tanks = []
-        spawn_manager.spawn_enemy(mock_player_tank, mock_game_map)
+        spawn_manager.spawn_enemy([mock_player_tank], mock_game_map)
         # Enemies at indices 1 and 2 should not be carriers
         carrier_tanks = [t for t in spawn_manager.enemy_tanks if t.is_carrier]
         assert len(carrier_tanks) == 0
@@ -471,26 +471,26 @@ class TestSpawnManagerCarrier:
             game_map=mock_game_map,
             enemy_composition=_DEFAULT_COMPOSITION,
             spawn_interval=5.0,
-            player_tank=mock_player_tank,
+            player_tanks=[mock_player_tank],
             effect_manager=mock_effect_manager,
         )
         # Materialize spawns 0, 1, 2 immediately, then spawn index 3 (carrier)
         # via the pending path. Clear pending+tanks between to avoid collisions.
         for _ in range(2):
             mock_effect.active = False
-            manager.update(0.0, mock_player_tank, mock_game_map)
+            manager.update(0.0, [mock_player_tank], mock_game_map)
             manager.enemy_tanks = []
             mock_effect.active = True
-            manager.spawn_enemy(mock_player_tank, mock_game_map)
+            manager.spawn_enemy([mock_player_tank], mock_game_map)
         # Now materialize spawns so far, then spawn the carrier (index 3)
         mock_effect.active = False
-        manager.update(0.0, mock_player_tank, mock_game_map)
+        manager.update(0.0, [mock_player_tank], mock_game_map)
         manager.enemy_tanks = []
         mock_effect.active = True
-        manager.spawn_enemy(mock_player_tank, mock_game_map)
+        manager.spawn_enemy([mock_player_tank], mock_game_map)
         # Complete the carrier's pending spawn animation
         mock_effect.active = False
-        manager.update(0.0, mock_player_tank, mock_game_map)
+        manager.update(0.0, [mock_player_tank], mock_game_map)
         carrier_tanks = [t for t in manager.enemy_tanks if t.is_carrier]
         assert len(carrier_tanks) == 1
 
@@ -530,7 +530,7 @@ class TestSpawnManagerCustomCarriers:
             game_map=mock_game_map,
             enemy_composition=_DEFAULT_COMPOSITION,
             spawn_interval=5.0,
-            player_tank=mock_player_tank,
+            player_tanks=[mock_player_tank],
             powerup_carrier_indices=(1,),
         )
         # Initial spawn is index 0 (not a carrier)
@@ -538,7 +538,7 @@ class TestSpawnManagerCustomCarriers:
 
         # Next spawn is index 1 (should be a carrier)
         manager.enemy_tanks = []
-        manager.spawn_enemy(mock_player_tank, mock_game_map)
+        manager.spawn_enemy([mock_player_tank], mock_game_map)
         carrier_tanks = [t for t in manager.enemy_tanks if t.is_carrier]
         assert len(carrier_tanks) == 1
 
@@ -553,6 +553,6 @@ class TestSpawnManagerCustomCarriers:
             game_map=mock_game_map,
             enemy_composition=_DEFAULT_COMPOSITION,
             spawn_interval=5.0,
-            player_tank=mock_player_tank,
+            player_tanks=[mock_player_tank],
         )
         assert manager._powerup_carrier_indices == POWERUP_CARRIER_INDICES


### PR DESCRIPTION
## Summary

- Extract player-related logic from `GameManager` into new `PlayerManager` class (player creation, input routing, movement, ice sliding, shooting, bullets, score, state preservation, death handling, game-over detection)
- Extract gameplay input from `InputHandler` into new `PlayerInput` class (per-player keyboard or joystick input with merged OR logic)
- Update all consumers to accept player lists: `CollisionManager`, `CollisionResponseHandler`, `SpawnManager`, `Renderer`
- `InputHandler` now handles only menu/system input
- Deduplicate `_is_on_ice` into `Map.is_tile_slidable()`

## Motivation

Prepares the codebase for 2-player co-op (#82). `GameManager` had player logic deeply interleaved with the game loop — creating the tank, processing input, movement, ice sliding, shooting, bullet management, score, respawning, and game-over detection. Extracting this into `PlayerManager` with a list-based interface means adding a second player only requires `PlayerManager` creating two tanks instead of one.

## Test plan

- [ ] 811 tests pass (`uv run pytest`)
- [ ] Lint clean (`uv run ruff check src/ tests/`)
- [ ] Smoke test: play through level 1 — movement, shooting, brick destruction, ice sliding, power-ups, enemy kills, score, death/respawn, game over all work identically to before