### PR TITLE
Fix pause menu input bugs and adopt Xbox A/B menu convention

### DIFF
--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -302,11 +302,24 @@ class GameManager:
             self.sound_manager.stop_loops()
             self._pause_selection = 0
             self.state = GameState.PAUSED
+            # Drop any menu actions queued while RUNNING (e.g. a held UP key
+            # that emitted a KEYDOWN before START was pressed), otherwise they
+            # would jump the pause selector on the first frame.
+            self.input_handler.reset()
         elif self.state == GameState.PAUSED:
-            logger.info("Game resumed.")
-            self.state = GameState.RUNNING
+            self._resume_game()
         elif self.state == GameState.OPTIONS_MENU:
             self._exit_options()
+
+    def _resume_game(self) -> None:
+        """Transition from PAUSED back to RUNNING.
+
+        Clears any buffered shoot input so the button press that confirmed
+        the menu (e.g. controller A) does not leak into gameplay as a bullet.
+        """
+        logger.info("Game resumed.")
+        self.state = GameState.RUNNING
+        self.player_manager.clear_pending_shoot()
 
     def _exit_options(self) -> None:
         """Save settings and return to the screen that opened options."""
@@ -355,22 +368,20 @@ class GameManager:
             else:
                 self._pause_selection = (self._pause_selection + 1) % 4
             self.sound_manager.play_menu_select()
+        elif action == MenuAction.BACK:
+            self._resume_game()
         elif action == MenuAction.CONFIRM:
             if self._pause_selection == 0:
-                # RESUME
-                self.state = GameState.RUNNING
+                self._resume_game()
             elif self._pause_selection == 1:
-                # OPTIONS
                 self._options_from_pause = True
                 self._options_selection = 0
                 self.state = GameState.OPTIONS_MENU
             elif self._pause_selection == 2:
-                # TITLE SCREEN
                 self.sound_manager.stop_loops()
                 self._title_selection = 0
                 self.state = GameState.TITLE_SCREEN
             elif self._pause_selection == 3:
-                # QUIT
                 self._quit_game()
 
     def _handle_options_input(self, action: MenuAction) -> None:
@@ -400,6 +411,8 @@ class GameManager:
                     self.settings_manager.master_volume
                 )
                 self.sound_manager.play_menu_select()
+        elif action == MenuAction.BACK:
+            self._exit_options()
         elif action == MenuAction.CONFIRM:
             if self._options_selection == 2:
                 self._exit_options()

--- a/src/managers/input_handler.py
+++ b/src/managers/input_handler.py
@@ -5,10 +5,8 @@ from src.utils.constants import Direction, MenuAction
 from src.managers.player_input import (
     AXIS_DEADZONE,
     CTRL_DPAD_BUTTONS,
-    CTRL_SHOOT_BUTTONS,
     JOY_AXIS_X,
     JOY_AXIS_Y,
-    JOY_SHOOT_BUTTONS,
 )
 
 _DIRECTION_TO_MENU_ACTION: dict[Direction, MenuAction] = {
@@ -108,8 +106,10 @@ class InputHandler:
             if event.button in CTRL_DPAD_BUTTONS:
                 direction = CTRL_DPAD_BUTTONS[event.button]
                 self._menu_actions.append(_DIRECTION_TO_MENU_ACTION[direction])
-            elif event.button in CTRL_SHOOT_BUTTONS:
+            elif event.button == pygame.CONTROLLER_BUTTON_A:
                 self._menu_actions.append(MenuAction.CONFIRM)
+            elif event.button == pygame.CONTROLLER_BUTTON_B:
+                self._menu_actions.append(MenuAction.BACK)
 
         # --- Axis motion (shared: CONTROLLER_AXIS_LEFTX == 0, LEFTY == 1) ---
         elif event.type in (
@@ -140,8 +140,10 @@ class InputHandler:
             if hat_dir is not None:
                 self._menu_actions.append(_DIRECTION_TO_MENU_ACTION[hat_dir])
         elif event.type == pygame.JOYBUTTONDOWN:
-            if event.button in JOY_SHOOT_BUTTONS:
+            if event.button == 0:
                 self._menu_actions.append(MenuAction.CONFIRM)
+            elif event.button == 1:
+                self._menu_actions.append(MenuAction.BACK)
 
     def reset(self) -> None:
         """Reset all input state. Called between stages."""

--- a/src/managers/player_input.py
+++ b/src/managers/player_input.py
@@ -124,6 +124,10 @@ class PlayerInput:
             return True
         return False
 
+    def clear_pending_shoot(self) -> None:
+        """Clear any pending shoot input without consuming it as a shot."""
+        self._shoot_pressed = False
+
     # ------------------------------------------------------------------
     # Private helpers
     # ------------------------------------------------------------------

--- a/src/managers/player_manager.py
+++ b/src/managers/player_manager.py
@@ -129,6 +129,15 @@ class PlayerManager:
         for pi in self._player_inputs:
             pi.handle_event(event)
 
+    def clear_pending_shoot(self) -> None:
+        """Clear any buffered shoot input on all players.
+
+        Used when exiting a menu so the button press that confirmed the menu
+        (e.g. controller A) does not leak into gameplay as a fired bullet.
+        """
+        for pi in self._player_inputs:
+            pi.clear_pending_shoot()
+
     # ------------------------------------------------------------------
     # Per-frame update
     # ------------------------------------------------------------------

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -83,6 +83,7 @@ class MenuAction(Enum):
     LEFT = auto()
     RIGHT = auto()
     CONFIRM = auto()
+    BACK = auto()
 
 
 class EffectType(Enum):

--- a/tests/unit/managers/test_game_manager.py
+++ b/tests/unit/managers/test_game_manager.py
@@ -677,6 +677,64 @@ class TestPauseAndOptionsStateMachine:
         gm.handle_events()
         assert gm.state == GameState.EXIT
 
+    def test_pause_back_resumes(self, game_manager):
+        """BACK action in pause menu resumes the game regardless of selection."""
+        gm = game_manager
+        gm.state = GameState.PAUSED
+        gm._pause_selection = 2  # not on RESUME
+        gm._handle_pause_input(MenuAction.BACK)
+        assert gm.state == GameState.RUNNING
+
+    def test_options_back_exits(self, game_manager):
+        """BACK action in options menu exits options (like ESC)."""
+        gm = game_manager
+        gm.state = GameState.OPTIONS_MENU
+        gm._options_from_pause = True
+        gm._handle_options_input(MenuAction.BACK)
+        assert gm.state == GameState.PAUSED
+
+    def test_options_back_from_title_returns_to_title(self, game_manager):
+        """BACK in options opened from title returns to the title screen."""
+        gm = game_manager
+        gm.state = GameState.OPTIONS_MENU
+        gm._options_from_pause = False
+        gm._handle_options_input(MenuAction.BACK)
+        assert gm.state == GameState.TITLE_SCREEN
+
+    def test_held_direction_before_pause_does_not_move_selector(
+        self, game_manager, key_down_event
+    ):
+        """A KEYDOWN queued while RUNNING must not jump the pause selector.
+
+        Regression: previously, an UP KEYDOWN fired before pressing ESC would
+        queue MenuAction.UP in InputHandler; on transition to PAUSED the stale
+        action was consumed and moved the selector from 0 (Resume) to 3 (Quit).
+        """
+        gm = game_manager
+        gm.state = GameState.RUNNING
+        gm.sound_manager = MagicMock()
+        # Both events land in the same handle_events batch: UP queues a menu
+        # action, ESC pauses and should drain it before _process_menu_actions.
+        pygame.event.post(key_down_event(pygame.K_UP))
+        pygame.event.post(key_down_event(pygame.K_ESCAPE))
+        gm.handle_events()
+        assert gm.state == GameState.PAUSED
+        assert gm._pause_selection == 0
+
+    def test_resume_clears_pending_shoot(self, game_manager):
+        """Resuming from pause clears buffered shoot input on all players.
+
+        Regression: pressing controller A to select Resume used to also fire a
+        bullet on the first RUNNING frame because the press was captured as
+        both a menu CONFIRM and a shoot.
+        """
+        gm = game_manager
+        gm.state = GameState.PAUSED
+        gm._pause_selection = 0
+        gm._handle_pause_input(MenuAction.CONFIRM)
+        assert gm.state == GameState.RUNNING
+        gm.player_manager.clear_pending_shoot.assert_called_once()
+
     def test_pause_navigation_up_down(self, game_manager, key_down_event):
         """UP/DOWN navigation wraps through 4 pause items."""
         gm = game_manager

--- a/tests/unit/managers/test_input_handler.py
+++ b/tests/unit/managers/test_input_handler.py
@@ -196,10 +196,10 @@ class TestMenuActionsController:
         handler.handle_event(ctrl_button_down_event(pygame.CONTROLLER_BUTTON_A))
         assert MenuAction.CONFIRM in handler.consume_menu_actions()
 
-    def test_b_button_produces_confirm(self, handler, ctrl_button_down_event) -> None:
-        """Controller B button produces MenuAction.CONFIRM."""
+    def test_b_button_produces_back(self, handler, ctrl_button_down_event) -> None:
+        """Controller B button produces MenuAction.BACK (Xbox convention)."""
         handler.handle_event(ctrl_button_down_event(pygame.CONTROLLER_BUTTON_B))
-        assert MenuAction.CONFIRM in handler.consume_menu_actions()
+        assert MenuAction.BACK in handler.consume_menu_actions()
 
     def test_joy_hat_up_produces_menu_up(self, handler, joy_hat_event) -> None:
         """Raw joystick hat UP produces MenuAction.UP."""
@@ -228,12 +228,12 @@ class TestMenuActionsController:
         handler.handle_event(joy_button_down_event(button=0))
         assert MenuAction.CONFIRM in handler.consume_menu_actions()
 
-    def test_joy_button_1_produces_confirm(
+    def test_joy_button_1_produces_back(
         self, handler, joy_button_down_event
     ) -> None:
-        """Raw joystick button 1 produces MenuAction.CONFIRM."""
+        """Raw joystick button 1 produces MenuAction.BACK (Xbox convention)."""
         handler.handle_event(joy_button_down_event(button=1))
-        assert MenuAction.CONFIRM in handler.consume_menu_actions()
+        assert MenuAction.BACK in handler.consume_menu_actions()
 
 
 class TestMenuActionsAxisEdgeDetection:


### PR DESCRIPTION
## Summary

- **Xbox A/B convention in menus:** controller B (and raw joystick button 1) now emit `MenuAction.BACK`; A / button 0 remains `CONFIRM`. Pause BACK resumes the game; options BACK exits (same as ESC). Gameplay shooting still accepts both A and B.
- **Fix: held UP + START jumped pause selector to Quit.** A `KEYDOWN` for UP before pause queued a `MenuAction.UP` in `InputHandler`; on transition to PAUSED the stale action was consumed and moved the selector from Resume (0) to Quit (3). The `RUNNING -> PAUSED` transition now calls `InputHandler.reset()` to drain the queue.
- **Fix: pressing A to select Resume also fired a bullet.** The controller A press was both menu `CONFIRM` and a buffered shoot; on the first RUNNING frame `try_shoot()` consumed the flag. New `PlayerManager.clear_pending_shoot()` is called at every `PAUSED -> RUNNING` transition (ESC, pause CONFIRM on Resume, pause BACK).
- **Refactor:** extracted `_resume_game()` helper so the three resume paths share one implementation.

## Test plan

- [x] `uv run pytest` — all 859 tests pass
- [x] New regression tests:
  - `test_held_direction_before_pause_does_not_move_selector` — K_UP + K_ESCAPE in one event batch; selector stays at 0
  - `test_resume_clears_pending_shoot` — CONFIRM on Resume invokes `clear_pending_shoot()`
  - `test_options_back_from_title_returns_to_title` — options opened from title, BACK returns to title
  - `test_pause_back_resumes` — pause BACK resumes regardless of selection
  - `test_options_back_exits` — options BACK exits to previous screen
- [ ] Manual: hold UP, press START — pause selector on Resume (not Quit)
- [ ] Manual: in pause menu, press A on Resume — tank does not fire
- [ ] Manual: in pause menu, press B — game resumes
- [ ] Manual: in options menu (from title or pause), press B — returns to previous screen