### PR TITLE
Move shovel-flash state machine from GameManager to PowerUpManager

### DIFF
--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 from loguru import logger
 from src.core.map import Map
 from src.core.player_tank import PlayerTank
-from src.core.tile import BrickVariant, Tile, TileType
+from src.core.tile import Tile
 from src.core.bullet import Bullet
 from src.states.game_state import GameState
 from src.utils.constants import (
@@ -21,10 +21,6 @@ from src.utils.constants import (
     SPAWN_INVINCIBILITY_DURATION,
     HELMET_INVINCIBILITY_DURATION,
     CLOCK_FREEZE_DURATION,
-    SHOVEL_DURATION,
-    SHOVEL_WARNING_DURATION,
-    SHOVEL_FLASH_CYCLE,
-    SHOVEL_FLASH_INTERVAL,
     EffectType,
     CURTAIN_CLOSE_DURATION,
     CURTAIN_OPEN_DURATION,
@@ -207,10 +203,6 @@ class GameManager:
 
         self.bullets: List[Bullet] = []
         self.freeze_timer: float = 0.0
-        self.shovel_timer: float = 0.0
-        self._shovel_original_tiles: List[tuple] = []
-        self._shovel_flash_timer: float = 0.0
-        self._shovel_flash_showing_steel: bool = True
 
         # Restore player progress
         self.player_manager.restore_state()
@@ -460,7 +452,6 @@ class GameManager:
 
         self.spawn_manager.update(dt, active_players, self.map)
         self.power_up_manager.update(dt)
-        self._tick_shovel(dt)
 
         # --- Prepare data for Collision Manager ---
         # Built AFTER updates so newly fired bullets are included
@@ -608,53 +599,7 @@ class GameManager:
         )
 
     def _apply_shovel(self, player: PlayerTank) -> None:
-        """Fortify base walls with steel, restoring destroyed bricks first."""
-        if not self._shovel_original_tiles:
-            tiles = self.map.get_base_surrounding_tiles(include_empty=True)
-            # Restore destroyed and damaged tiles to full BRICK before fortifying
-            for tile in tiles:
-                damaged = (
-                    tile.type == TileType.EMPTY
-                    or tile.brick_variant != BrickVariant.FULL
-                )
-                if damaged:
-                    self.map.set_tile_type(tile, TileType.BRICK)
-                    tile.brick_variant = BrickVariant.FULL
-                    tile.reset_rect()
-            # Save original types AFTER restoration (so BRICK, not EMPTY)
-            self._shovel_original_tiles = [(t, t.type) for t in tiles]
-            for tile in tiles:
-                self.map.set_tile_type(tile, TileType.STEEL)
-            logger.info(
-                f"Shovel power-up applied: base fortified for {SHOVEL_DURATION}s"
-            )
-        self.shovel_timer = SHOVEL_DURATION
-        self._shovel_flash_timer = 0.0
-        self._shovel_flash_showing_steel = True
-
-    def _tick_shovel(self, dt: float) -> None:
-        """Update shovel timer and flash logic."""
-        if self.shovel_timer <= 0:
-            return
-        self.shovel_timer -= dt
-        if self.shovel_timer <= 0:
-            for tile, orig_type in self._shovel_original_tiles:
-                if tile.type != TileType.EMPTY:
-                    self.map.set_tile_type(tile, orig_type)
-            self._shovel_original_tiles = []
-            logger.info("Shovel expired: base walls reverted")
-            return
-        if self.shovel_timer <= SHOVEL_WARNING_DURATION:
-            self._shovel_flash_timer += dt
-            should_show_steel = (
-                self._shovel_flash_timer % SHOVEL_FLASH_CYCLE < SHOVEL_FLASH_INTERVAL
-            )
-            if should_show_steel != self._shovel_flash_showing_steel:
-                self._shovel_flash_showing_steel = should_show_steel
-                for tile, orig_type in self._shovel_original_tiles:
-                    if tile.type != TileType.EMPTY:
-                        target = TileType.STEEL if should_show_steel else orig_type
-                        self.map.set_tile_type(tile, target)
+        self.power_up_manager.apply_shovel()
 
     def _apply_star(self, player: PlayerTank) -> None:
         """Apply star upgrade to the player tank."""

--- a/src/managers/power_up_manager.py
+++ b/src/managers/power_up_manager.py
@@ -1,7 +1,7 @@
 """Manages power-up spawning, lifecycle, and collection."""
 
 import random
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import pygame
 from loguru import logger
@@ -11,8 +11,15 @@ from src.core.player_tank import PlayerTank
 from src.core.power_up import PowerUp
 from src.core.map import Map
 from src.managers.texture_manager import TextureManager
-from src.utils.constants import PowerUpType, TILE_SIZE
-from src.core.tile import TileType
+from src.utils.constants import (
+    PowerUpType,
+    SHOVEL_DURATION,
+    SHOVEL_FLASH_CYCLE,
+    SHOVEL_FLASH_INTERVAL,
+    SHOVEL_WARNING_DURATION,
+    TILE_SIZE,
+)
+from src.core.tile import BrickVariant, Tile, TileType
 
 
 class PowerUpManager:
@@ -26,6 +33,10 @@ class PowerUpManager:
         self._texture_manager = texture_manager
         self._game_map = game_map
         self.active_power_ups: List[PowerUp] = []
+        self.shovel_timer: float = 0.0
+        self._shovel_original_tiles: List[Tuple[Tile, TileType]] = []
+        self._shovel_flash_timer: float = 0.0
+        self._shovel_flash_showing_steel: bool = True
 
     def spawn_power_up(
         self,
@@ -66,6 +77,55 @@ class PowerUpManager:
                 any_expired = True
         if any_expired:
             self.active_power_ups = [pu for pu in self.active_power_ups if pu.active]
+
+        self._tick_shovel(dt)
+
+    def apply_shovel(self) -> None:
+        """Fortify base walls with steel, restoring destroyed bricks first."""
+        if not self._shovel_original_tiles:
+            tiles = self._game_map.get_base_surrounding_tiles(include_empty=True)
+            for tile in tiles:
+                damaged = (
+                    tile.type == TileType.EMPTY
+                    or tile.brick_variant != BrickVariant.FULL
+                )
+                if damaged:
+                    self._game_map.set_tile_type(tile, TileType.BRICK)
+                    tile.brick_variant = BrickVariant.FULL
+                    tile.reset_rect()
+            # Save originals AFTER restoration so reverted tiles are BRICK, not EMPTY.
+            self._shovel_original_tiles = [(t, t.type) for t in tiles]
+            for tile in tiles:
+                self._game_map.set_tile_type(tile, TileType.STEEL)
+            logger.info(
+                f"Shovel power-up applied: base fortified for {SHOVEL_DURATION}s"
+            )
+        self.shovel_timer = SHOVEL_DURATION
+        self._shovel_flash_timer = 0.0
+        self._shovel_flash_showing_steel = True
+
+    def _tick_shovel(self, dt: float) -> None:
+        if self.shovel_timer <= 0:
+            return
+        self.shovel_timer -= dt
+        if self.shovel_timer <= 0:
+            for tile, orig_type in self._shovel_original_tiles:
+                if tile.type != TileType.EMPTY:
+                    self._game_map.set_tile_type(tile, orig_type)
+            self._shovel_original_tiles = []
+            logger.info("Shovel expired: base walls reverted")
+            return
+        if self.shovel_timer <= SHOVEL_WARNING_DURATION:
+            self._shovel_flash_timer += dt
+            should_show_steel = (
+                self._shovel_flash_timer % SHOVEL_FLASH_CYCLE < SHOVEL_FLASH_INTERVAL
+            )
+            if should_show_steel != self._shovel_flash_showing_steel:
+                self._shovel_flash_showing_steel = should_show_steel
+                for tile, orig_type in self._shovel_original_tiles:
+                    if tile.type != TileType.EMPTY:
+                        target = TileType.STEEL if should_show_steel else orig_type
+                        self._game_map.set_tile_type(tile, target)
 
     def get_power_ups(self) -> List[PowerUp]:
         """Return the list of active power-ups for collision checking and rendering."""

--- a/tests/integration/test_power_up_effects.py
+++ b/tests/integration/test_power_up_effects.py
@@ -68,7 +68,7 @@ class TestRemainingPowerUpEffects:
 
     def test_shovel_effect(self, game):
         game._apply_power_up(PowerUpType.SHOVEL)
-        assert game.shovel_timer > 0
+        assert game.power_up_manager.shovel_timer > 0
         tiles = game.map.get_base_surrounding_tiles()
         steel_tiles = [t for t in tiles if t.type == TileType.STEEL]
         assert len(steel_tiles) > 0

--- a/tests/unit/managers/test_game_manager_powerups.py
+++ b/tests/unit/managers/test_game_manager_powerups.py
@@ -1,21 +1,16 @@
 import pytest
 import pygame
 from unittest.mock import MagicMock
-from src.core.tile import BrickVariant
 from src.managers.game_manager import GameManager
 from src.utils.constants import (
     PowerUpType,
     HELMET_INVINCIBILITY_DURATION,
     CLOCK_FREEZE_DURATION,
-    SHOVEL_DURATION,
-    SHOVEL_WARNING_DURATION,
-    SHOVEL_FLASH_INTERVAL,
     TankType,
     EffectType,
     TILE_SIZE,
 )
 from src.states.game_state import GameState
-from src.core.tile import TileType
 
 
 class TestPowerUpEffects:
@@ -123,75 +118,21 @@ class TestClockEffect:
         assert game.freeze_timer == CLOCK_FREEZE_DURATION
 
 
-class TestShovelEffect:
+class TestShovelDelegation:
+    """Shovel state machine lives in PowerUpManager; GameManager just delegates."""
+
     @pytest.fixture
     def game(self):
         gm = MagicMock(spec=GameManager)
         gm._apply_power_up = GameManager._apply_power_up.__get__(gm)
         gm._apply_shovel = GameManager._apply_shovel.__get__(gm)
-        gm._tick_shovel = GameManager._tick_shovel.__get__(gm)
         gm.state = GameState.RUNNING
-        gm.freeze_timer = 0.0
-        gm.shovel_timer = 0.0
-        gm._shovel_original_tiles = []
-        gm._shovel_flash_timer = 0.0
-        gm._shovel_flash_showing_steel = True
         mock_player = MagicMock()
-        mock_player.lives = 3
         gm.player_manager = MagicMock()
         gm.player_manager.get_active_players.return_value = [mock_player]
-        mock_tiles = []
-        for _ in range(4):
-            t = MagicMock()
-            t.type = TileType.BRICK
-            t.brick_variant = BrickVariant.FULL
-            mock_tiles.append(t)
-        gm.map = MagicMock()
-        gm.map.get_base_surrounding_tiles.return_value = mock_tiles
-        gm.map.set_tile_type = MagicMock()
+        gm.power_up_manager = MagicMock()
         return gm
 
-    def test_shovel_fortifies_base(self, game):
+    def test_apply_shovel_delegates_to_power_up_manager(self, game):
         game._apply_power_up(PowerUpType.SHOVEL)
-        assert game.shovel_timer == SHOVEL_DURATION
-        calls = game.map.set_tile_type.call_args_list
-        for call in calls:
-            assert call.args[1] == TileType.STEEL
-
-    def test_shovel_stores_originals(self, game):
-        game._apply_power_up(PowerUpType.SHOVEL)
-        assert len(game._shovel_original_tiles) == 4
-        for tile, orig_type in game._shovel_original_tiles:
-            assert orig_type == TileType.BRICK
-
-    def test_shovel_reverts_after_duration(self, game):
-        game._apply_power_up(PowerUpType.SHOVEL)
-        game.map.set_tile_type.reset_mock()
-        game._tick_shovel(SHOVEL_DURATION + 0.1)
-        assert game.shovel_timer <= 0
-        calls = game.map.set_tile_type.call_args_list
-        for call in calls:
-            assert call.args[1] == TileType.BRICK
-
-    def test_shovel_recollection_resets_timer(self, game):
-        game._apply_power_up(PowerUpType.SHOVEL)
-        original_tiles = game._shovel_original_tiles
-        game.shovel_timer = 5.0
-        game.map.set_tile_type.reset_mock()
-        mock_player = game.player_manager.get_active_players()[0]
-        game._apply_shovel(mock_player)
-        assert game.shovel_timer == SHOVEL_DURATION
-        assert game._shovel_original_tiles is original_tiles
-        game.map.set_tile_type.assert_not_called()
-
-    def test_shovel_flashes_during_warning(self, game):
-        game._apply_power_up(PowerUpType.SHOVEL)
-        game.map.set_tile_type.reset_mock()
-        # Advance into warning phase
-        game._tick_shovel(SHOVEL_DURATION - SHOVEL_WARNING_DURATION + 0.5)
-        # Advance past one flash interval to trigger toggle
-        game._tick_shovel(SHOVEL_FLASH_INTERVAL + 0.01)
-        # Verify toggle happened: tiles set to original type (BRICK)
-        assert game._shovel_flash_showing_steel is False
-        last_call = game.map.set_tile_type.call_args_list[-1]
-        assert last_call.args[1] == TileType.BRICK
+        game.power_up_manager.apply_shovel.assert_called_once_with()

--- a/tests/unit/managers/test_power_up_manager.py
+++ b/tests/unit/managers/test_power_up_manager.py
@@ -2,8 +2,15 @@ import pytest
 import pygame
 from unittest.mock import MagicMock
 from src.managers.power_up_manager import PowerUpManager
-from src.core.tile import TileType
-from src.utils.constants import PowerUpType, TILE_SIZE, POWERUP_TIMEOUT
+from src.core.tile import BrickVariant, TileType
+from src.utils.constants import (
+    POWERUP_TIMEOUT,
+    PowerUpType,
+    SHOVEL_DURATION,
+    SHOVEL_FLASH_INTERVAL,
+    SHOVEL_WARNING_DURATION,
+    TILE_SIZE,
+)
 
 
 class TestPowerUpManager:
@@ -121,3 +128,59 @@ class TestPowerUpManager:
         player.rect = pygame.Rect(0, 0, TILE_SIZE, TILE_SIZE)
         manager.spawn_power_up(player, [])
         assert len(manager.active_power_ups) == 0
+
+
+class TestShovelEffect:
+    @pytest.fixture
+    def manager(self, mock_texture_manager):
+        game_map = MagicMock()
+        mock_tiles = []
+        for _ in range(4):
+            t = MagicMock()
+            t.type = TileType.BRICK
+            t.brick_variant = BrickVariant.FULL
+            mock_tiles.append(t)
+        game_map.get_base_surrounding_tiles.return_value = mock_tiles
+        return PowerUpManager(mock_texture_manager, game_map)
+
+    def test_initial_shovel_state(self, manager):
+        assert manager.shovel_timer == 0.0
+
+    def test_shovel_fortifies_base(self, manager):
+        manager.apply_shovel()
+        assert manager.shovel_timer == SHOVEL_DURATION
+        for call in manager._game_map.set_tile_type.call_args_list:
+            assert call.args[1] == TileType.STEEL
+
+    def test_shovel_stores_originals(self, manager):
+        manager.apply_shovel()
+        assert len(manager._shovel_original_tiles) == 4
+        for _, orig_type in manager._shovel_original_tiles:
+            assert orig_type == TileType.BRICK
+
+    def test_shovel_reverts_after_duration(self, manager):
+        manager.apply_shovel()
+        manager._game_map.set_tile_type.reset_mock()
+        manager.update(SHOVEL_DURATION + 0.1)
+        assert manager.shovel_timer <= 0
+        for call in manager._game_map.set_tile_type.call_args_list:
+            assert call.args[1] == TileType.BRICK
+
+    def test_shovel_recollection_resets_timer(self, manager):
+        manager.apply_shovel()
+        original_tiles = manager._shovel_original_tiles
+        manager.shovel_timer = 5.0
+        manager._game_map.set_tile_type.reset_mock()
+        manager.apply_shovel()
+        assert manager.shovel_timer == SHOVEL_DURATION
+        assert manager._shovel_original_tiles is original_tiles
+        manager._game_map.set_tile_type.assert_not_called()
+
+    def test_shovel_flashes_during_warning(self, manager):
+        manager.apply_shovel()
+        manager._game_map.set_tile_type.reset_mock()
+        manager.update(SHOVEL_DURATION - SHOVEL_WARNING_DURATION + 0.5)
+        manager.update(SHOVEL_FLASH_INTERVAL + 0.01)
+        assert manager._shovel_flash_showing_steel is False
+        last_call = manager._game_map.set_tile_type.call_args_list[-1]
+        assert last_call.args[1] == TileType.BRICK


### PR DESCRIPTION
## Summary
- PowerUpManager now owns `shovel_timer`, the original-tile snapshot, and the flash state. `apply_shovel()` + a private `_tick_shovel(dt)` run inside the existing `update(dt)`.
- GameManager's `_apply_shovel` becomes a one-line delegate. The `_tick_shovel(dt)` call drops out of `GameManager.update`. Four `_shovel_*` fields, `shovel_timer`, four SHOVEL constant imports, and `BrickVariant` / `TileType` imports are removed from GameManager.
- Shovel test class moves from `test_game_manager_powerups.py` into `test_power_up_manager.py` and exercises PowerUpManager directly without GameManager mock scaffolding. A small delegation smoke test stays behind on the GameManager side.
- Integration test updated to read `game.power_up_manager.shovel_timer`.

Closes #144.

## Test plan
- [x] `pytest` (871 passed, +2 from new shovel tests)
- [x] `ruff check` and `ruff format` pass on touched files