### PR TITLE
Extract MenuController from GameManager

### DIFF
--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -40,6 +40,7 @@ from src.managers.collision_response_handler import CollisionResponseHandler
 from src.managers.effect_manager import EffectManager
 from src.managers.texture_manager import TextureManager
 from src.managers.input_handler import InputHandler
+from src.managers.menu_controller import MenuController, MenuItem
 from src.managers.player_input import CTRL_START_BUTTON
 from src.managers.spawn_manager import SpawnManager
 from src.managers.renderer import Renderer
@@ -79,13 +80,12 @@ class GameManager:
         )
 
         self.state: GameState = GameState.TITLE_SCREEN
-        self._title_selection: int = 0
-        self._pause_selection: int = 0
-        self._options_selection: int = 0
         self._options_from_pause: bool = False
         self._state_timer: float = 0.0
         self._two_player_mode: bool = False
         self._post_curtain_state: GameState = GameState.RUNNING
+
+        self._title_menu, self._pause_menu, self._options_menu = self._build_menus()
 
         # Renderer for title screen (recreated with map dims in _load_stage)
         self.renderer: Renderer = Renderer(
@@ -95,6 +95,49 @@ class GameManager:
             LOGICAL_WIDTH,
             LOGICAL_HEIGHT,
         )
+
+    def _build_menus(self) -> tuple[MenuController, MenuController, MenuController]:
+        # Late-bound so tests can swap sound_manager after construction.
+        def play_select() -> None:
+            self.sound_manager.play_menu_select()
+
+        title = MenuController(
+            items=[
+                MenuItem("1 Player", on_confirm=lambda: self._start_game(False)),
+                MenuItem("2 Players", on_confirm=lambda: self._start_game(True)),
+                MenuItem("Options", on_confirm=lambda: self._open_options(False)),
+                MenuItem("Quit", on_confirm=self._quit_game),
+            ],
+            on_select=play_select,
+        )
+        pause = MenuController(
+            items=[
+                MenuItem("Resume", on_confirm=self._resume_game),
+                MenuItem("Options", on_confirm=lambda: self._open_options(True)),
+                MenuItem("Title", on_confirm=self._return_to_title),
+                MenuItem("Quit", on_confirm=self._quit_game),
+            ],
+            on_select=play_select,
+            on_back=self._resume_game,
+        )
+        options = MenuController(
+            items=[
+                MenuItem(
+                    "Difficulty",
+                    on_left=lambda: self._cycle_difficulty(-1),
+                    on_right=lambda: self._cycle_difficulty(1),
+                ),
+                MenuItem(
+                    "Volume",
+                    on_left=lambda: self._adjust_volume(-VOLUME_ADJUSTMENT_STEP),
+                    on_right=lambda: self._adjust_volume(VOLUME_ADJUSTMENT_STEP),
+                ),
+                MenuItem("Back", on_confirm=self._exit_options),
+            ],
+            on_select=play_select,
+            on_back=self._exit_options,
+        )
+        return title, pause, options
 
     @property
     def player_tank(self) -> Optional[PlayerTank]:
@@ -242,17 +285,22 @@ class GameManager:
 
     def _process_menu_actions(self) -> None:
         """Poll and route menu actions from InputHandler."""
+        menu = self._active_menu()
         for action in self.input_handler.consume_menu_actions():
-            if self.state == GameState.TITLE_SCREEN:
-                self._handle_title_input(action)
-            elif self.state == GameState.PAUSED:
-                self._handle_pause_input(action)
-            elif self.state == GameState.OPTIONS_MENU:
-                self._handle_options_input(action)
+            if menu is not None:
+                menu.handle_action(action)
             elif action == MenuAction.CONFIRM and self.state == GameState.GAME_COMPLETE:
                 logger.info("Returning to title screen.")
-                self.state = GameState.TITLE_SCREEN
-                self._title_selection = 0
+                self._return_to_title()
+
+    def _active_menu(self) -> Optional[MenuController]:
+        if self.state == GameState.TITLE_SCREEN:
+            return self._title_menu
+        if self.state == GameState.PAUSED:
+            return self._pause_menu
+        if self.state == GameState.OPTIONS_MENU:
+            return self._options_menu
+        return None
 
     def _handle_escape(self) -> None:
         """Handle ESC key based on current state.
@@ -263,7 +311,7 @@ class GameManager:
         if self.state == GameState.RUNNING:
             logger.info("Game paused.")
             self.sound_manager.stop_loops()
-            self._pause_selection = 0
+            self._pause_menu.reset()
             self.state = GameState.PAUSED
             # Drop any menu actions queued while RUNNING (e.g. a held UP key
             # that emitted a KEYDOWN before START was pressed), otherwise they
@@ -292,86 +340,40 @@ class GameManager:
         else:
             self.state = GameState.TITLE_SCREEN
 
-    def _handle_title_input(self, action: MenuAction) -> None:
-        """Handle menu action on the title screen."""
-        if action in (MenuAction.UP, MenuAction.DOWN):
-            step = -1 if action == MenuAction.UP else 1
-            self._title_selection = (self._title_selection + step) % 4
-            self.sound_manager.play_menu_select()
-        elif action == MenuAction.CONFIRM:
-            if self._title_selection in (0, 1):
-                self._two_player_mode = self._title_selection == 1
-                labels = {0: "1 Player", 1: "2 Players"}
-                logger.info(f"{labels[self._title_selection]} selected, starting game.")
-                self._new_game()
-                self.state = GameState.STAGE_CURTAIN_CLOSE
-                self._state_timer = 0.0
-                self.sound_manager.play_stage_start()
-            elif self._title_selection == 2:
-                self._options_from_pause = False
-                self._options_selection = 0
-                self.state = GameState.OPTIONS_MENU
-            elif self._title_selection == 3:
-                self._quit_game()
+    def _start_game(self, two_player: bool) -> None:
+        self._two_player_mode = two_player
+        logger.info(
+            f"{'2 Players' if two_player else '1 Player'} selected, starting game."
+        )
+        self._new_game()
+        self.state = GameState.STAGE_CURTAIN_CLOSE
+        self._state_timer = 0.0
+        self.sound_manager.play_stage_start()
 
-    def _handle_pause_input(self, action: MenuAction) -> None:
-        """Handle menu action on the pause menu."""
-        if action in (MenuAction.UP, MenuAction.DOWN):
-            if action == MenuAction.UP:
-                self._pause_selection = (self._pause_selection - 1) % 4
-            else:
-                self._pause_selection = (self._pause_selection + 1) % 4
-            self.sound_manager.play_menu_select()
-        elif action == MenuAction.BACK:
-            self._resume_game()
-        elif action == MenuAction.CONFIRM:
-            if self._pause_selection == 0:
-                self._resume_game()
-            elif self._pause_selection == 1:
-                self._options_from_pause = True
-                self._options_selection = 0
-                self.state = GameState.OPTIONS_MENU
-            elif self._pause_selection == 2:
-                self.sound_manager.stop_loops()
-                self._title_selection = 0
-                self.state = GameState.TITLE_SCREEN
-            elif self._pause_selection == 3:
-                self._quit_game()
+    def _open_options(self, from_pause: bool) -> None:
+        self._options_from_pause = from_pause
+        self._options_menu.reset()
+        self.state = GameState.OPTIONS_MENU
 
-    def _handle_options_input(self, action: MenuAction) -> None:
-        """Handle menu action on the options menu."""
-        if action in (MenuAction.UP, MenuAction.DOWN):
-            if action == MenuAction.UP:
-                self._options_selection = (self._options_selection - 1) % 3
-            else:
-                self._options_selection = (self._options_selection + 1) % 3
-            self.sound_manager.play_menu_select()
-        elif action in (MenuAction.LEFT, MenuAction.RIGHT):
-            if self._options_selection == 0:
-                difficulties = list(Difficulty)
-                idx = difficulties.index(self.settings_manager.difficulty)
-                step = -1 if action == MenuAction.LEFT else 1
-                self.settings_manager.difficulty = difficulties[
-                    (idx + step) % len(difficulties)
-                ]
-                self.sound_manager.play_menu_select()
-            elif self._options_selection == 1:
-                if action == MenuAction.LEFT:
-                    delta = -VOLUME_ADJUSTMENT_STEP
-                else:
-                    delta = VOLUME_ADJUSTMENT_STEP
-                self.settings_manager.master_volume = max(
-                    0.0, min(1.0, self.settings_manager.master_volume + delta)
-                )
-                self.sound_manager.set_master_volume(
-                    self.settings_manager.master_volume
-                )
-                self.sound_manager.play_menu_select()
-        elif action == MenuAction.BACK:
-            self._exit_options()
-        elif action == MenuAction.CONFIRM:
-            if self._options_selection == 2:
-                self._exit_options()
+    def _return_to_title(self) -> None:
+        self.sound_manager.stop_loops()
+        self._title_menu.reset()
+        self.state = GameState.TITLE_SCREEN
+
+    def _cycle_difficulty(self, step: int) -> None:
+        difficulties = list(Difficulty)
+        idx = difficulties.index(self.settings_manager.difficulty)
+        self.settings_manager.difficulty = difficulties[
+            (idx + step) % len(difficulties)
+        ]
+        self.sound_manager.play_menu_select()
+
+    def _adjust_volume(self, delta: float) -> None:
+        self.settings_manager.master_volume = max(
+            0.0, min(1.0, self.settings_manager.master_volume + delta)
+        )
+        self.sound_manager.set_master_volume(self.settings_manager.master_volume)
+        self.sound_manager.play_menu_select()
 
     def update(self) -> None:
         """Update game state."""
@@ -407,7 +409,7 @@ class GameManager:
                 self.state = self._post_curtain_state
                 self._post_curtain_state = GameState.RUNNING
                 if self.state == GameState.TITLE_SCREEN:
-                    self._title_selection = 0
+                    self._title_menu.reset()
             return
 
         if self.state == GameState.GAME_OVER_ANIMATION:
@@ -664,7 +666,7 @@ class GameManager:
     def render(self) -> None:
         """Render the game state."""
         if self.state == GameState.TITLE_SCREEN:
-            self.renderer.render_title_screen(self._title_selection)
+            self.renderer.render_title_screen(self._title_menu.selection)
             return
 
         if self.state in (
@@ -683,12 +685,12 @@ class GameManager:
             self.renderer.render_options_menu(
                 self.settings_manager.master_volume,
                 self.settings_manager.difficulty,
-                self._options_selection,
+                self._options_menu.selection,
             )
             return
 
         if self.state == GameState.PAUSED:
-            self.renderer.render_pause_menu(self._pause_selection)
+            self.renderer.render_pause_menu(self._pause_menu.selection)
             return
 
         if self.state == GameState.EXIT:

--- a/src/managers/menu_controller.py
+++ b/src/managers/menu_controller.py
@@ -1,0 +1,56 @@
+"""Declarative menu navigation: items + callbacks, no per-screen handler boilerplate."""
+
+from dataclasses import dataclass
+from typing import Callable, List, Optional
+
+from src.utils.constants import MenuAction
+
+
+@dataclass(frozen=True)
+class MenuItem:
+    label: str
+    on_confirm: Optional[Callable[[], None]] = None
+    on_left: Optional[Callable[[], None]] = None
+    on_right: Optional[Callable[[], None]] = None
+
+
+class MenuController:
+    """UP/DOWN cycles the cursor; CONFIRM/LEFT/RIGHT dispatch to the active item."""
+
+    def __init__(
+        self,
+        items: List[MenuItem],
+        on_select: Optional[Callable[[], None]] = None,
+        on_back: Optional[Callable[[], None]] = None,
+    ) -> None:
+        if not items:
+            raise ValueError("MenuController requires at least one MenuItem")
+        self._items = items
+        self._on_select = on_select
+        self._on_back = on_back
+        self.selection: int = 0
+
+    def reset(self) -> None:
+        self.selection = 0
+
+    def handle_action(self, action: MenuAction) -> None:
+        if action in (MenuAction.UP, MenuAction.DOWN):
+            step = -1 if action == MenuAction.UP else 1
+            self.selection = (self.selection + step) % len(self._items)
+            if self._on_select is not None:
+                self._on_select()
+        elif action == MenuAction.CONFIRM:
+            cb = self._items[self.selection].on_confirm
+            if cb is not None:
+                cb()
+        elif action == MenuAction.LEFT:
+            cb = self._items[self.selection].on_left
+            if cb is not None:
+                cb()
+        elif action == MenuAction.RIGHT:
+            cb = self._items[self.selection].on_right
+            if cb is not None:
+                cb()
+        elif action == MenuAction.BACK:
+            if self._on_back is not None:
+                self._on_back()

--- a/tests/integration/test_controller.py
+++ b/tests/integration/test_controller.py
@@ -86,7 +86,7 @@ class TestControllerMenuNavigation:
     def test_ctrl_dpad_navigates_title_screen(self) -> None:
         """Controller D-pad navigates title screen menu items."""
         gm = GameManager()
-        initial_selection = gm._title_selection
+        initial_selection = gm._title_menu.selection
 
         pygame.event.post(
             pygame.event.Event(
@@ -97,12 +97,12 @@ class TestControllerMenuNavigation:
         )
         gm.handle_events()
 
-        assert gm._title_selection != initial_selection
+        assert gm._title_menu.selection != initial_selection
 
     def test_ctrl_a_confirms_title_selection(self) -> None:
         """Controller A button confirms the selected title screen option."""
         gm = GameManager()
-        gm._title_selection = 0  # 1 Player
+        gm._title_menu.selection = 0  # 1 Player
 
         pygame.event.post(
             pygame.event.Event(

--- a/tests/unit/managers/test_game_manager.py
+++ b/tests/unit/managers/test_game_manager.py
@@ -70,31 +70,31 @@ class TestGameManager:
     def test_initialization_starts_at_title_screen(self, game_manager_at_title):
         """Test that GameManager starts at the title screen."""
         assert game_manager_at_title.state == GameState.TITLE_SCREEN
-        assert game_manager_at_title._title_selection == 0
+        assert game_manager_at_title._title_menu.selection == 0
 
     def test_title_screen_cursor_moves(self, game_manager_at_title, key_down_event):
         """Test up/down keys cycle through selectable items (0, 1, 2, 3, 4)."""
         gm = game_manager_at_title
-        assert gm._title_selection == 0
+        assert gm._title_menu.selection == 0
         pygame.event.post(key_down_event(pygame.K_DOWN))
         gm.handle_events()
-        assert gm._title_selection == 1
+        assert gm._title_menu.selection == 1
         pygame.event.post(key_down_event(pygame.K_DOWN))
         gm.handle_events()
-        assert gm._title_selection == 2
+        assert gm._title_menu.selection == 2
         pygame.event.post(key_down_event(pygame.K_DOWN))
         gm.handle_events()
-        assert gm._title_selection == 3
+        assert gm._title_menu.selection == 3
         pygame.event.post(key_down_event(pygame.K_UP))
         gm.handle_events()
-        assert gm._title_selection == 2
+        assert gm._title_menu.selection == 2
 
     def test_title_screen_enter_starts_game(
         self, game_manager_at_title, key_down_event
     ):
         """Test Enter on '1 PLAYER' begins the curtain-close transition."""
         gm = game_manager_at_title
-        gm._title_selection = 0
+        gm._title_menu.selection = 0
         pygame.event.post(key_down_event(pygame.K_RETURN))
         gm.handle_events()
         assert gm.state == GameState.STAGE_CURTAIN_CLOSE
@@ -104,7 +104,7 @@ class TestGameManager:
     ):
         """Test Enter on '2 PLAYERS' (index 1) starts the game in two-player mode."""
         gm = game_manager_at_title
-        gm._title_selection = 1
+        gm._title_menu.selection = 1
         pygame.event.post(key_down_event(pygame.K_RETURN))
         gm.handle_events()
         assert gm.state == GameState.STAGE_CURTAIN_CLOSE
@@ -122,7 +122,7 @@ class TestGameManager:
         self, game_manager_at_title, key_down_event
     ):
         """Test that R key acts as CONFIRM on title screen."""
-        game_manager_at_title._title_selection = 0
+        game_manager_at_title._title_menu.selection = 0
         pygame.event.post(key_down_event(pygame.K_r))
         game_manager_at_title.handle_events()
         assert game_manager_at_title.state == GameState.STAGE_CURTAIN_CLOSE
@@ -191,66 +191,66 @@ class TestGameManager:
         def test_title_input_down(self, game_manager_at_title):
             """MenuAction.DOWN navigates title screen down."""
             gm = game_manager_at_title
-            gm._title_selection = 2
-            gm._handle_title_input(MenuAction.DOWN)
-            assert gm._title_selection == 3
+            gm._title_menu.selection = 2
+            gm._title_menu.handle_action(MenuAction.DOWN)
+            assert gm._title_menu.selection == 3
 
         def test_title_input_confirm(self, game_manager_at_title):
             """MenuAction.CONFIRM starts the game."""
             gm = game_manager_at_title
-            gm._title_selection = 0
-            gm._handle_title_input(MenuAction.CONFIRM)
+            gm._title_menu.selection = 0
+            gm._title_menu.handle_action(MenuAction.CONFIRM)
             assert gm.state == GameState.STAGE_CURTAIN_CLOSE
 
         def test_pause_input_down(self, game_manager):
             """MenuAction.DOWN navigates pause menu."""
             game_manager.state = GameState.PAUSED
-            game_manager._pause_selection = 0
-            game_manager._handle_pause_input(MenuAction.DOWN)
-            assert game_manager._pause_selection == 1
+            game_manager._pause_menu.selection = 0
+            game_manager._pause_menu.handle_action(MenuAction.DOWN)
+            assert game_manager._pause_menu.selection == 1
 
         def test_pause_input_confirm_resume(self, game_manager):
             """MenuAction.CONFIRM on Resume resumes game."""
             game_manager.state = GameState.PAUSED
-            game_manager._pause_selection = 0
-            game_manager._handle_pause_input(MenuAction.CONFIRM)
+            game_manager._pause_menu.selection = 0
+            game_manager._pause_menu.handle_action(MenuAction.CONFIRM)
             assert game_manager.state == GameState.RUNNING
 
         def test_options_input_right_volume(self, game_manager):
             """MenuAction.RIGHT on volume row increases volume."""
             game_manager.state = GameState.OPTIONS_MENU
-            game_manager._options_selection = 1  # volume is now index 1
+            game_manager._options_menu.selection = 1  # volume is now index 1
             game_manager.settings_manager.master_volume = 0.5
             initial_vol = game_manager.settings_manager.master_volume
-            game_manager._handle_options_input(MenuAction.RIGHT)
+            game_manager._options_menu.handle_action(MenuAction.RIGHT)
             assert game_manager.settings_manager.master_volume > initial_vol
 
         def test_options_difficulty_cycles_forward(self, game_manager):
             """MenuAction.RIGHT cycles difficulty forward with wrap-around."""
             game_manager.state = GameState.OPTIONS_MENU
-            game_manager._options_selection = 0
+            game_manager._options_menu.selection = 0
             game_manager.settings_manager.difficulty = Difficulty.EASY
-            game_manager._handle_options_input(MenuAction.RIGHT)
+            game_manager._options_menu.handle_action(MenuAction.RIGHT)
             assert game_manager.settings_manager.difficulty == Difficulty.NORMAL
-            game_manager._handle_options_input(MenuAction.RIGHT)
+            game_manager._options_menu.handle_action(MenuAction.RIGHT)
             assert game_manager.settings_manager.difficulty == Difficulty.EASY
 
         def test_options_difficulty_cycles_backward(self, game_manager):
             """MenuAction.LEFT cycles difficulty backward with wrap-around."""
             game_manager.state = GameState.OPTIONS_MENU
-            game_manager._options_selection = 0
+            game_manager._options_menu.selection = 0
             game_manager.settings_manager.difficulty = Difficulty.NORMAL
-            game_manager._handle_options_input(MenuAction.LEFT)
+            game_manager._options_menu.handle_action(MenuAction.LEFT)
             assert game_manager.settings_manager.difficulty == Difficulty.EASY
-            game_manager._handle_options_input(MenuAction.LEFT)
+            game_manager._options_menu.handle_action(MenuAction.LEFT)
             assert game_manager.settings_manager.difficulty == Difficulty.NORMAL
 
         def test_options_input_confirm_back(self, game_manager):
             """MenuAction.CONFIRM on Back returns to previous screen."""
             game_manager.state = GameState.OPTIONS_MENU
-            game_manager._options_selection = 2  # back is now index 2
+            game_manager._options_menu.selection = 2  # back is now index 2
             game_manager._options_from_pause = False
-            game_manager._handle_options_input(MenuAction.CONFIRM)
+            game_manager._options_menu.handle_action(MenuAction.CONFIRM)
             assert game_manager.state == GameState.TITLE_SCREEN
 
         def test_game_complete_confirm(self, game_manager):
@@ -356,7 +356,7 @@ class TestGameManagerSoundWiring:
     def test_handle_title_input_plays_menu_select(self, game_manager_at_title):
         gm = game_manager_at_title
         gm.sound_manager = MagicMock()
-        gm._handle_title_input(MenuAction.DOWN)
+        gm._title_menu.handle_action(MenuAction.DOWN)
         gm.sound_manager.play_menu_select.assert_called()
 
 
@@ -452,7 +452,7 @@ class TestStageProgression:
         with patch("pygame.event.get", return_value=[event]):
             game_manager.handle_events()
         assert game_manager.state == GameState.TITLE_SCREEN
-        assert game_manager._title_selection == 0
+        assert game_manager._title_menu.selection == 0
 
 
 class TestPauseAndOptionsStateMachine:
@@ -516,7 +516,7 @@ class TestPauseAndOptionsStateMachine:
         pygame.event.post(key_down_event(pygame.K_ESCAPE))
         game_manager.handle_events()
         assert game_manager.state == GameState.PAUSED
-        assert game_manager._pause_selection == 0
+        assert game_manager._pause_menu.selection == 0
 
     def test_esc_during_paused_resumes(self, game_manager, key_down_event):
         """ESC during PAUSED transitions back to RUNNING."""
@@ -596,17 +596,17 @@ class TestPauseAndOptionsStateMachine:
     ):
         """Enter on OPTIONS (index 2) on title screen goes to OPTIONS_MENU."""
         gm = game_manager_at_title
-        gm._title_selection = 2
+        gm._title_menu.selection = 2
         pygame.event.post(key_down_event(pygame.K_RETURN))
         gm.handle_events()
         assert gm.state == GameState.OPTIONS_MENU
         assert gm._options_from_pause is False
-        assert gm._options_selection == 0
+        assert gm._options_menu.selection == 0
 
     def test_title_quit_exits(self, game_manager_at_title, key_down_event):
         """Enter on QUIT (index 3) on title screen exits the game."""
         gm = game_manager_at_title
-        gm._title_selection = 3
+        gm._title_menu.selection = 3
         gm.sound_manager = MagicMock()
         pygame.event.post(key_down_event(pygame.K_RETURN))
         gm.handle_events()
@@ -618,7 +618,7 @@ class TestPauseAndOptionsStateMachine:
         """Enter on RESUME (0) in pause menu returns to RUNNING."""
         gm = game_manager
         gm.state = GameState.PAUSED
-        gm._pause_selection = 0
+        gm._pause_menu.selection = 0
         pygame.event.post(key_down_event(pygame.K_RETURN))
         gm.handle_events()
         assert gm.state == GameState.RUNNING
@@ -627,31 +627,31 @@ class TestPauseAndOptionsStateMachine:
         """Enter on OPTIONS (1) in pause menu goes to OPTIONS_MENU."""
         gm = game_manager
         gm.state = GameState.PAUSED
-        gm._pause_selection = 1
+        gm._pause_menu.selection = 1
         gm.sound_manager = MagicMock()
         pygame.event.post(key_down_event(pygame.K_RETURN))
         gm.handle_events()
         assert gm.state == GameState.OPTIONS_MENU
         assert gm._options_from_pause is True
-        assert gm._options_selection == 0
+        assert gm._options_menu.selection == 0
 
     def test_pause_title_screen(self, game_manager, key_down_event):
         """Enter on TITLE SCREEN (2) in pause menu returns to title."""
         gm = game_manager
         gm.state = GameState.PAUSED
-        gm._pause_selection = 2
+        gm._pause_menu.selection = 2
         gm.sound_manager = MagicMock()
         pygame.event.post(key_down_event(pygame.K_RETURN))
         gm.handle_events()
         assert gm.state == GameState.TITLE_SCREEN
-        assert gm._title_selection == 0
+        assert gm._title_menu.selection == 0
         gm.sound_manager.stop_loops.assert_called_once()
 
     def test_pause_quit(self, game_manager, key_down_event):
         """Enter on QUIT (3) in pause menu exits the game."""
         gm = game_manager
         gm.state = GameState.PAUSED
-        gm._pause_selection = 3
+        gm._pause_menu.selection = 3
         gm.sound_manager = MagicMock()
         pygame.event.post(key_down_event(pygame.K_RETURN))
         gm.handle_events()
@@ -661,8 +661,8 @@ class TestPauseAndOptionsStateMachine:
         """BACK action in pause menu resumes the game regardless of selection."""
         gm = game_manager
         gm.state = GameState.PAUSED
-        gm._pause_selection = 2  # not on RESUME
-        gm._handle_pause_input(MenuAction.BACK)
+        gm._pause_menu.selection = 2  # not on RESUME
+        gm._pause_menu.handle_action(MenuAction.BACK)
         assert gm.state == GameState.RUNNING
 
     def test_options_back_exits(self, game_manager):
@@ -670,7 +670,7 @@ class TestPauseAndOptionsStateMachine:
         gm = game_manager
         gm.state = GameState.OPTIONS_MENU
         gm._options_from_pause = True
-        gm._handle_options_input(MenuAction.BACK)
+        gm._options_menu.handle_action(MenuAction.BACK)
         assert gm.state == GameState.PAUSED
 
     def test_options_back_from_title_returns_to_title(self, game_manager):
@@ -678,7 +678,7 @@ class TestPauseAndOptionsStateMachine:
         gm = game_manager
         gm.state = GameState.OPTIONS_MENU
         gm._options_from_pause = False
-        gm._handle_options_input(MenuAction.BACK)
+        gm._options_menu.handle_action(MenuAction.BACK)
         assert gm.state == GameState.TITLE_SCREEN
 
     def test_held_direction_before_pause_does_not_move_selector(
@@ -699,7 +699,7 @@ class TestPauseAndOptionsStateMachine:
         pygame.event.post(key_down_event(pygame.K_ESCAPE))
         gm.handle_events()
         assert gm.state == GameState.PAUSED
-        assert gm._pause_selection == 0
+        assert gm._pause_menu.selection == 0
 
     def test_resume_clears_pending_shoot(self, game_manager):
         """Resuming from pause clears buffered shoot input on all players.
@@ -710,8 +710,8 @@ class TestPauseAndOptionsStateMachine:
         """
         gm = game_manager
         gm.state = GameState.PAUSED
-        gm._pause_selection = 0
-        gm._handle_pause_input(MenuAction.CONFIRM)
+        gm._pause_menu.selection = 0
+        gm._pause_menu.handle_action(MenuAction.CONFIRM)
         assert gm.state == GameState.RUNNING
         gm.player_manager.clear_pending_shoot.assert_called_once()
 
@@ -719,34 +719,34 @@ class TestPauseAndOptionsStateMachine:
         """UP/DOWN navigation wraps through 4 pause items."""
         gm = game_manager
         gm.state = GameState.PAUSED
-        gm._pause_selection = 0
+        gm._pause_menu.selection = 0
         gm.sound_manager = MagicMock()
         # Down from 0 -> 1
         pygame.event.post(key_down_event(pygame.K_DOWN))
         gm.handle_events()
-        assert gm._pause_selection == 1
+        assert gm._pause_menu.selection == 1
         # Down from 1 -> 2
         pygame.event.post(key_down_event(pygame.K_DOWN))
         gm.handle_events()
-        assert gm._pause_selection == 2
+        assert gm._pause_menu.selection == 2
         # Down from 2 -> 3
         pygame.event.post(key_down_event(pygame.K_DOWN))
         gm.handle_events()
-        assert gm._pause_selection == 3
+        assert gm._pause_menu.selection == 3
         # Down from 3 -> 0 (wrap)
         pygame.event.post(key_down_event(pygame.K_DOWN))
         gm.handle_events()
-        assert gm._pause_selection == 0
+        assert gm._pause_menu.selection == 0
         # Up from 0 -> 3 (wrap)
         pygame.event.post(key_down_event(pygame.K_UP))
         gm.handle_events()
-        assert gm._pause_selection == 3
+        assert gm._pause_menu.selection == 3
 
     def test_pause_plays_menu_select_on_navigation(self, game_manager, key_down_event):
         """Navigating pause menu plays menu_select sound."""
         gm = game_manager
         gm.state = GameState.PAUSED
-        gm._pause_selection = 0
+        gm._pause_menu.selection = 0
         gm.sound_manager = MagicMock()
         pygame.event.post(key_down_event(pygame.K_DOWN))
         gm.handle_events()
@@ -758,7 +758,7 @@ class TestPauseAndOptionsStateMachine:
         """LEFT on VOLUME (1) in options decreases master volume."""
         gm = game_manager
         gm.state = GameState.OPTIONS_MENU
-        gm._options_selection = 1
+        gm._options_menu.selection = 1
         gm.settings_manager = MagicMock()
         gm.settings_manager.master_volume = 0.5
         gm.sound_manager = MagicMock()
@@ -773,7 +773,7 @@ class TestPauseAndOptionsStateMachine:
         """RIGHT on VOLUME (1) in options increases master volume."""
         gm = game_manager
         gm.state = GameState.OPTIONS_MENU
-        gm._options_selection = 1
+        gm._options_menu.selection = 1
         gm.settings_manager = MagicMock()
         gm.settings_manager.master_volume = 0.5
         gm.sound_manager = MagicMock()
@@ -788,7 +788,7 @@ class TestPauseAndOptionsStateMachine:
         """Volume does not go below 0.0."""
         gm = game_manager
         gm.state = GameState.OPTIONS_MENU
-        gm._options_selection = 1
+        gm._options_menu.selection = 1
         gm.settings_manager = MagicMock()
         gm.settings_manager.master_volume = 0.0
         gm.sound_manager = MagicMock()
@@ -800,7 +800,7 @@ class TestPauseAndOptionsStateMachine:
         """Volume does not go above 1.0."""
         gm = game_manager
         gm.state = GameState.OPTIONS_MENU
-        gm._options_selection = 1
+        gm._options_menu.selection = 1
         gm.settings_manager = MagicMock()
         gm.settings_manager.master_volume = 1.0
         gm.sound_manager = MagicMock()
@@ -814,7 +814,7 @@ class TestPauseAndOptionsStateMachine:
         """Enter on BACK (2) in options saves and returns to origin."""
         gm = game_manager
         gm.state = GameState.OPTIONS_MENU
-        gm._options_selection = 2
+        gm._options_menu.selection = 2
         gm._options_from_pause = False
         gm.settings_manager = MagicMock()
         pygame.event.post(key_down_event(pygame.K_RETURN))
@@ -828,7 +828,7 @@ class TestPauseAndOptionsStateMachine:
         """Enter on BACK (2) in options from pause saves and returns to PAUSED."""
         gm = game_manager
         gm.state = GameState.OPTIONS_MENU
-        gm._options_selection = 2
+        gm._options_menu.selection = 2
         gm._options_from_pause = True
         gm.settings_manager = MagicMock()
         pygame.event.post(key_down_event(pygame.K_RETURN))
@@ -840,17 +840,17 @@ class TestPauseAndOptionsStateMachine:
         """UP/DOWN navigation wraps between 3 options items."""
         gm = game_manager
         gm.state = GameState.OPTIONS_MENU
-        gm._options_selection = 0
+        gm._options_menu.selection = 0
         gm.sound_manager = MagicMock()
         pygame.event.post(key_down_event(pygame.K_DOWN))
         gm.handle_events()
-        assert gm._options_selection == 1
+        assert gm._options_menu.selection == 1
         pygame.event.post(key_down_event(pygame.K_DOWN))
         gm.handle_events()
-        assert gm._options_selection == 2
+        assert gm._options_menu.selection == 2
         pygame.event.post(key_down_event(pygame.K_DOWN))
         gm.handle_events()
-        assert gm._options_selection == 0
+        assert gm._options_menu.selection == 0
 
     # --- Update early return for PAUSED/OPTIONS_MENU ---
 
@@ -878,7 +878,7 @@ class TestPauseAndOptionsStateMachine:
         gm.state = GameState.PAUSED
         gm.renderer = MagicMock()
         gm.render()
-        gm.renderer.render_pause_menu.assert_called_once_with(gm._pause_selection)
+        gm.renderer.render_pause_menu.assert_called_once_with(gm._pause_menu.selection)
 
     def test_render_options_calls_render_options_menu(self, game_manager):
         """OPTIONS_MENU state renders options menu."""
@@ -890,13 +890,13 @@ class TestPauseAndOptionsStateMachine:
         gm.settings_manager.difficulty = Difficulty.NORMAL
         gm.render()
         gm.renderer.render_options_menu.assert_called_once_with(
-            0.7, Difficulty.NORMAL, gm._options_selection
+            0.7, Difficulty.NORMAL, gm._options_menu.selection
         )
 
     def test_render_title_uses_title_selection(self, game_manager_at_title):
         """TITLE_SCREEN renders with _title_selection."""
         gm = game_manager_at_title
         gm.renderer = MagicMock()
-        gm._title_selection = 2
+        gm._title_menu.selection = 2
         gm.render()
         gm.renderer.render_title_screen.assert_called_once_with(2)

--- a/tests/unit/managers/test_game_manager_curtain.py
+++ b/tests/unit/managers/test_game_manager_curtain.py
@@ -123,7 +123,7 @@ class TestCurtainTransitions:
 
     def test_title_start_triggers_curtain(self, game):
         game.state = GameState.TITLE_SCREEN
-        game._title_selection = 0
+        game._title_menu.selection = 0
         event = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_RETURN)
         pygame.event.post(event)
         game.handle_events()
@@ -199,5 +199,5 @@ class TestGameOverAnimation:
         for _ in range(int(total * FPS) + 2):
             game.update()
         assert game.state == GameState.TITLE_SCREEN
-        assert game._title_selection == 0
+        assert game._title_menu.selection == 0
         assert game._post_curtain_state == GameState.RUNNING

--- a/tests/unit/managers/test_menu_controller.py
+++ b/tests/unit/managers/test_menu_controller.py
@@ -1,0 +1,77 @@
+import pytest
+from unittest.mock import MagicMock
+
+from src.managers.menu_controller import MenuController, MenuItem
+from src.utils.constants import MenuAction
+
+
+class TestMenuController:
+    def test_requires_at_least_one_item(self):
+        with pytest.raises(ValueError):
+            MenuController(items=[])
+
+    def test_initial_selection_is_zero(self):
+        mc = MenuController(items=[MenuItem("a"), MenuItem("b")])
+        assert mc.selection == 0
+
+    def test_down_advances_selection(self):
+        mc = MenuController(items=[MenuItem("a"), MenuItem("b"), MenuItem("c")])
+        mc.handle_action(MenuAction.DOWN)
+        assert mc.selection == 1
+
+    def test_up_wraps_to_last(self):
+        mc = MenuController(items=[MenuItem("a"), MenuItem("b"), MenuItem("c")])
+        mc.handle_action(MenuAction.UP)
+        assert mc.selection == 2
+
+    def test_down_wraps_to_first(self):
+        mc = MenuController(items=[MenuItem("a"), MenuItem("b")])
+        mc.handle_action(MenuAction.DOWN)
+        mc.handle_action(MenuAction.DOWN)
+        assert mc.selection == 0
+
+    def test_navigation_invokes_on_select(self):
+        on_select = MagicMock()
+        mc = MenuController(items=[MenuItem("a"), MenuItem("b")], on_select=on_select)
+        mc.handle_action(MenuAction.DOWN)
+        on_select.assert_called_once()
+
+    def test_confirm_invokes_active_items_callback(self):
+        cb_a, cb_b = MagicMock(), MagicMock()
+        mc = MenuController(
+            items=[MenuItem("a", on_confirm=cb_a), MenuItem("b", on_confirm=cb_b)]
+        )
+        mc.handle_action(MenuAction.CONFIRM)
+        cb_a.assert_called_once()
+        cb_b.assert_not_called()
+
+    def test_confirm_without_callback_is_noop(self):
+        mc = MenuController(items=[MenuItem("a")])
+        mc.handle_action(MenuAction.CONFIRM)  # must not raise
+
+    def test_left_and_right_dispatch_to_active_item(self):
+        on_left, on_right = MagicMock(), MagicMock()
+        mc = MenuController(
+            items=[MenuItem("only", on_left=on_left, on_right=on_right)]
+        )
+        mc.handle_action(MenuAction.LEFT)
+        mc.handle_action(MenuAction.RIGHT)
+        on_left.assert_called_once()
+        on_right.assert_called_once()
+
+    def test_back_invokes_on_back(self):
+        on_back = MagicMock()
+        mc = MenuController(items=[MenuItem("a")], on_back=on_back)
+        mc.handle_action(MenuAction.BACK)
+        on_back.assert_called_once()
+
+    def test_back_without_callback_is_noop(self):
+        mc = MenuController(items=[MenuItem("a")])
+        mc.handle_action(MenuAction.BACK)
+
+    def test_reset_clears_selection(self):
+        mc = MenuController(items=[MenuItem("a"), MenuItem("b"), MenuItem("c")])
+        mc.handle_action(MenuAction.DOWN)
+        mc.handle_action(MenuAction.DOWN)
+        mc.reset()
+        assert mc.selection == 0


### PR DESCRIPTION
## Summary
- New `MenuController` (`src/managers/menu_controller.py`) owns navigation + dispatch for one menu. Driven by a list of `MenuItem(label, on_confirm=, on_left=, on_right=)` plus optional `on_select`/`on_back` hooks. `handle_action(MenuAction)` does UP/DOWN cursor wrap and dispatches CONFIRM/LEFT/RIGHT to the active item.
- GameManager builds three controllers (title / pause / options) once in `__init__` and routes through whichever menu is active. The three `_handle_*_input` methods (~90 lines of duplicated `(selection ± 1) % N` + magic-index `==`/`in (...)` ladders) are gone.
- Action callbacks live in six tiny private helpers (`_start_game`, `_open_options`, `_return_to_title`, `_cycle_difficulty`, `_adjust_volume`) — each is now a single concept rather than a branch inside a switch.
- Renderer call sites updated to read `menu.selection` from the controllers.

Closes #143.

## Test plan
- [x] `pytest` (881 passed; +12 new MenuController unit tests, existing tests updated to drive the new API)
- [x] `ruff check` and `ruff format` pass on touched files