### PR TITLE
Inline _is_on_ice, delete redundant wrappers

### DIFF
--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -436,7 +436,9 @@ class GameManager:
                     )
                     closest_pos = (closest.x, closest.y)
                 enemy.update(dt, player_position=closest_pos)
-                enemy.on_ice = self._is_on_ice(enemy)
+                enemy.on_ice = self.map.is_tile_slidable(
+                    enemy.x, enemy.y, enemy.width, enemy.height
+                )
                 if enemy.consume_shoot():
                     self._try_shoot(enemy)
 
@@ -534,10 +536,6 @@ class GameManager:
             self.state = GameState.GAME_COMPLETE
             return
         self.state = state
-
-    def _is_on_ice(self, tank) -> bool:
-        """Check if the tank's center is over an ice tile."""
-        return self.map.is_tile_slidable(tank.x, tank.y, tank.width, tank.height)
 
     def _apply_power_up(
         self, power_up_type: PowerUpType, player: Optional[PlayerTank] = None

--- a/src/managers/player_manager.py
+++ b/src/managers/player_manager.py
@@ -147,7 +147,9 @@ class PlayerManager:
             has_valid_input = (dx != 0 or dy != 0) and not (dx != 0 and dy != 0)
 
             # Ice slide: trigger BEFORE move() so start_slide() captures old direction
-            player.on_ice = self._is_on_ice(player, game_map)
+            player.on_ice = game_map.is_tile_slidable(
+                player.x, player.y, player.width, player.height
+            )
             if player.on_ice and not player.is_sliding:
                 if not has_valid_input or (dx, dy) != player.direction.delta:
                     if player.start_slide():
@@ -289,8 +291,3 @@ class PlayerManager:
         self._bullets.clear()
         self._scores = {}
         self._preserved_state = {}
-
-    @staticmethod
-    def _is_on_ice(tank: PlayerTank, game_map: "Map") -> bool:
-        """Return True if the tank's centre is over a slidable (ice) tile."""
-        return game_map.is_tile_slidable(tank.x, tank.y, tank.width, tank.height)

--- a/tests/unit/managers/test_player_manager.py
+++ b/tests/unit/managers/test_player_manager.py
@@ -455,40 +455,6 @@ class TestPlayerManagerScore:
 
 
 # ---------------------------------------------------------------------------
-# TestPlayerManagerIsOnIce
-# ---------------------------------------------------------------------------
-
-
-class TestPlayerManagerIsOnIce:
-    def test_not_on_ice_delegates_to_map(self, player_manager, mock_game_map):
-        """Returns False when map.is_tile_slidable returns False."""
-        mock_game_map.is_tile_slidable.return_value = False
-
-        player = MagicMock(spec=PlayerTank)
-        player.x = 0
-        player.y = 0
-        player.width = TILE_SIZE
-        player.height = TILE_SIZE
-
-        assert player_manager._is_on_ice(player, mock_game_map) is False
-        mock_game_map.is_tile_slidable.assert_called_once_with(
-            player.x, player.y, player.width, player.height
-        )
-
-    def test_on_ice_delegates_to_map(self, player_manager, mock_game_map):
-        """Returns True when map.is_tile_slidable returns True."""
-        mock_game_map.is_tile_slidable.return_value = True
-
-        player = MagicMock(spec=PlayerTank)
-        player.x = 0
-        player.y = 0
-        player.width = TILE_SIZE
-        player.height = TILE_SIZE
-
-        assert player_manager._is_on_ice(player, mock_game_map) is True
-
-
-# ---------------------------------------------------------------------------
 # TestPlayerManagerStatePreservation
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #148.

## Summary
- `GameManager._is_on_ice` and `PlayerManager._is_on_ice` were each one-line wrappers forwarding to `Map.is_tile_slidable`.
- Both have been deleted and their two call sites now invoke `Map.is_tile_slidable` directly.
- The two unit tests that asserted the wrapper delegation have been removed — ice-slide behaviour remains covered end-to-end by `tests/integration/test_ice_slide.py`.

## Test plan
- [x] `pytest` — 881 passed
- [x] `ruff check` / `ruff format --check` clean for modified files