### PR TITLE
Collapse SoundManager play_* wrappers into play(name)

### DIFF
--- a/src/managers/collision_response_handler.py
+++ b/src/managers/collision_response_handler.py
@@ -60,21 +60,9 @@ class CollisionResponseHandler:
             (EnemyTank, Tile): self._handle_tank_vs_tile,
         }
 
-    def _play_explosion(self) -> None:
+    def _play(self, name: str) -> None:
         if self._sound_manager is not None:
-            self._sound_manager.play_explosion()
-
-    def _play_brick_hit(self) -> None:
-        if self._sound_manager is not None:
-            self._sound_manager.play_brick_hit()
-
-    def _play_bullet_hit_bullet(self) -> None:
-        if self._sound_manager is not None:
-            self._sound_manager.play_bullet_hit_bullet()
-
-    def _play_powerup(self) -> None:
-        if self._sound_manager is not None:
-            self._sound_manager.play_powerup()
+            self._sound_manager.play(name)
 
     def process_collisions(self, events: List[Tuple[Any, Any]]) -> List[EnemyTank]:
         """Process collision events and return list of enemies to remove."""
@@ -171,7 +159,7 @@ class CollisionResponseHandler:
                 float(enemy.rect.centerx),
                 float(enemy.rect.centery),
             )
-            self._play_explosion()
+            self._play("explosion")
         return True
 
     def _handle_bullet_vs_player(
@@ -206,7 +194,7 @@ class CollisionResponseHandler:
                     float(player.rect.centerx),
                     float(player.rect.centery),
                 )
-                self._play_explosion()
+                self._play("explosion")
                 if self._on_player_death is not None:
                     if self._on_player_death(player):
                         self._set_game_state(GameState.GAME_OVER)
@@ -235,9 +223,9 @@ class CollisionResponseHandler:
             float(bullet.rect.centery),
         )
         if tile.type == TileType.BASE:
-            self._play_explosion()
+            self._play("explosion")
         else:
-            self._play_brick_hit()
+            self._play("brick_hit")
 
         if tile.type == TileType.STEEL:
             if bullet.power_bullet:
@@ -264,7 +252,7 @@ class CollisionResponseHandler:
         logger.debug("Bullet hit bullet. Both deactivated.")
         bullet_a.active = False
         bullet_b.active = False
-        self._play_bullet_hit_bullet()
+        self._play("bullet_hit_bullet")
         return True
 
     def _handle_player_vs_powerup(
@@ -277,10 +265,8 @@ class CollisionResponseHandler:
             return False
         power_up_type = self._power_up_manager.collect_power_up(power_up)
         if power_up_type is not None:
-            self._add_score(
-                POWERUP_COLLECT_POINTS, player_id=player.player_id
-            )
-            self._play_powerup()
+            self._add_score(POWERUP_COLLECT_POINTS, player_id=player.player_id)
+            self._play("powerup")
             logger.info(f"Player collected power-up: {power_up_type.value}")
             self._collected_power_up_type = power_up_type
             self._collected_power_up_player = player

--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -95,7 +95,7 @@ class GameManager:
     def _build_menus(self) -> tuple[MenuController, MenuController, MenuController]:
         # Late-bound so tests can swap sound_manager after construction.
         def play_select() -> None:
-            self.sound_manager.play_menu_select()
+            self.sound_manager.play("menu_select")
 
         title = MenuController(
             items=[
@@ -340,7 +340,7 @@ class GameManager:
         self._new_game()
         self.state = GameState.STAGE_CURTAIN_CLOSE
         self._state_timer = 0.0
-        self.sound_manager.play_stage_start()
+        self.sound_manager.play("stage_start")
 
     def _open_options(self, from_pause: bool) -> None:
         self._options_from_pause = from_pause
@@ -358,14 +358,14 @@ class GameManager:
         self.settings_manager.difficulty = difficulties[
             (idx + step) % len(difficulties)
         ]
-        self.sound_manager.play_menu_select()
+        self.sound_manager.play("menu_select")
 
     def _adjust_volume(self, delta: float) -> None:
         self.settings_manager.master_volume = max(
             0.0, min(1.0, self.settings_manager.master_volume + delta)
         )
         self.sound_manager.set_master_volume(self.settings_manager.master_volume)
-        self.sound_manager.play_menu_select()
+        self.sound_manager.play("menu_select")
 
     def update(self) -> None:
         """Update game state."""
@@ -384,7 +384,7 @@ class GameManager:
                     self._load_stage()
                     self.state = GameState.STAGE_CURTAIN_CLOSE
                     self._state_timer = 0.0
-                    self.sound_manager.play_stage_start()
+                    self.sound_manager.play("stage_start")
             return
 
         if self.state == GameState.STAGE_CURTAIN_CLOSE:
@@ -510,7 +510,7 @@ class GameManager:
             bullet = tank.shoot()
             if bullet is not None:
                 self.bullets.append(bullet)
-                self.sound_manager.play_shoot()
+                self.sound_manager.play("shoot")
 
     def _set_game_state(self, state: GameState) -> None:
         """Set the game state with sound management."""
@@ -523,12 +523,12 @@ class GameManager:
         if state == GameState.GAME_OVER:
             self.state = GameState.GAME_OVER_ANIMATION
             self._state_timer = 0.0
-            self.sound_manager.play_game_over()
+            self.sound_manager.play("game_over")
             return
         if state == GameState.VICTORY:
             self.state = GameState.VICTORY
             self._state_timer = 0.0
-            self.sound_manager.play_victory()
+            self.sound_manager.play("victory")
             return
         if state == GameState.GAME_COMPLETE:
             self.state = GameState.GAME_COMPLETE

--- a/src/managers/player_manager.py
+++ b/src/managers/player_manager.py
@@ -151,7 +151,7 @@ class PlayerManager:
             if player.on_ice and not player.is_sliding:
                 if not has_valid_input or (dx, dy) != player.direction.delta:
                     if player.start_slide():
-                        self._sound_manager.play_ice_slide()
+                        self._sound_manager.play("ice_slide")
 
             if has_valid_input and not player.is_sliding:
                 player.move(dx, dy, dt)
@@ -179,7 +179,7 @@ class PlayerManager:
                     bullet: Optional[Bullet] = player.shoot()
                     if bullet is not None:
                         self._bullets.append(bullet)
-                        self._sound_manager.play_shoot()
+                        self._sound_manager.play("shoot")
 
     def get_all_bullets(self) -> list[Bullet]:
         """Return all player bullets (pruned to active-only by update()).

--- a/src/managers/sound_manager.py
+++ b/src/managers/sound_manager.py
@@ -60,43 +60,13 @@ class SoundManager:
         for channel in self._looping_channels.values():
             channel.set_volume(self._master_volume)
 
-    def _play(self, name: str) -> None:
+    def play(self, name: str) -> None:
         """Play a named sound if enabled and loaded."""
         if not self._enabled:
             return
         sound = self._sounds.get(name)
         if sound is not None:
             sound.play()
-
-    def play_shoot(self) -> None:
-        self._play("shoot")
-
-    def play_brick_hit(self) -> None:
-        self._play("brick_hit")
-
-    def play_explosion(self) -> None:
-        self._play("explosion")
-
-    def play_powerup(self) -> None:
-        self._play("powerup")
-
-    def play_game_over(self) -> None:
-        self._play("game_over")
-
-    def play_bullet_hit_bullet(self) -> None:
-        self._play("bullet_hit_bullet")
-
-    def play_stage_start(self) -> None:
-        self._play("stage_start")
-
-    def play_victory(self) -> None:
-        self._play("victory")
-
-    def play_menu_select(self) -> None:
-        self._play("menu_select")
-
-    def play_ice_slide(self) -> None:
-        self._play("ice_slide")
 
     def update_engine(self, any_moving: bool) -> None:
         """Start or stop engine loop based on whether any tank is moving."""

--- a/tests/unit/managers/test_game_manager.py
+++ b/tests/unit/managers/test_game_manager.py
@@ -337,14 +337,14 @@ class TestGameManagerSoundWiring:
         gm = gm_with_mock_sound
         gm._set_game_state(GameState.VICTORY)
         gm.sound_manager.stop_loops.assert_called_once()
-        gm.sound_manager.play_victory.assert_called_once()
+        gm.sound_manager.play.assert_called_once_with("victory")
         assert gm.state == GameState.VICTORY
 
     def test_set_game_state_game_over_stops_loops(self, gm_with_mock_sound):
         gm = gm_with_mock_sound
         gm._set_game_state(GameState.GAME_OVER)
         gm.sound_manager.stop_loops.assert_called_once()
-        gm.sound_manager.play_game_over.assert_called_once()
+        gm.sound_manager.play.assert_called_once_with("game_over")
         assert gm.state == GameState.GAME_OVER_ANIMATION
 
     def test_quit_game_stops_loops(self, gm_with_mock_sound):
@@ -357,7 +357,7 @@ class TestGameManagerSoundWiring:
         gm = game_manager_at_title
         gm.sound_manager = MagicMock()
         gm._title_menu.handle_action(MenuAction.DOWN)
-        gm.sound_manager.play_menu_select.assert_called()
+        gm.sound_manager.play.assert_any_call("menu_select")
 
 
 class TestStageProgression:
@@ -750,7 +750,7 @@ class TestPauseAndOptionsStateMachine:
         gm.sound_manager = MagicMock()
         pygame.event.post(key_down_event(pygame.K_DOWN))
         gm.handle_events()
-        gm.sound_manager.play_menu_select.assert_called()
+        gm.sound_manager.play.assert_any_call("menu_select")
 
     # --- Options menu ---
 

--- a/tests/unit/managers/test_player_manager.py
+++ b/tests/unit/managers/test_player_manager.py
@@ -288,7 +288,7 @@ class TestPlayerManagerUpdate:
         self.pm.update(0.016, self.game_map)
 
         player.start_slide.assert_called_once()
-        self.pm._sound_manager.play_ice_slide.assert_called_once()
+        self.pm._sound_manager.play.assert_called_once_with("ice_slide")
 
     def test_bullets_updated_during_update(self):
         """Active bullets have update(dt) called."""
@@ -343,7 +343,7 @@ class TestPlayerManagerShooting:
 
         player.shoot.assert_called_once()
         assert bullet in self.pm._bullets
-        self.pm._sound_manager.play_shoot.assert_called_once()
+        self.pm._sound_manager.play.assert_called_once_with("shoot")
 
     def test_try_shoot_no_bullet_without_input(self, mock_sound_manager):
         """try_shoot() does nothing when shoot was not pressed."""
@@ -357,7 +357,7 @@ class TestPlayerManagerShooting:
         self.pm.try_shoot()
 
         player.shoot.assert_not_called()
-        self.pm._sound_manager.play_shoot.assert_not_called()
+        self.pm._sound_manager.play.assert_not_called()
 
     def test_try_shoot_respects_max_bullets(self):
         """No new bullet is created when max_bullets are already active."""

--- a/tests/unit/managers/test_sound_manager.py
+++ b/tests/unit/managers/test_sound_manager.py
@@ -1,4 +1,3 @@
-import pytest
 from unittest.mock import patch, MagicMock
 from src.managers.sound_manager import SoundManager
 
@@ -17,24 +16,26 @@ class TestSoundManager:
             sm = SoundManager()
             assert sm._enabled is False
 
-    def test_play_methods_noop_when_disabled(self):
+    def test_play_noop_when_disabled(self):
         with patch("src.managers.sound_manager.pygame") as mock_pg:
             mock_pg.error = type("error", (Exception,), {})
             mock_pg.mixer.init.side_effect = mock_pg.error("no audio")
             sm = SoundManager()
-            sm.play_shoot()
-            sm.play_brick_hit()
-            sm.play_explosion()
-            sm.play_powerup()
-            sm.play_game_over()
+            sm.play("shoot")  # should not raise
 
-    def test_play_shoot_calls_sound_play(self):
+    def test_play_calls_sound_play(self):
         with patch("src.managers.sound_manager.pygame") as mock_pg:
             mock_sound = MagicMock()
             mock_pg.mixer.Sound.return_value = mock_sound
             sm = SoundManager()
-            sm.play_shoot()
+            sm.play("shoot")
             mock_sound.play.assert_called()
+
+    def test_play_unknown_name_is_noop(self):
+        with patch("src.managers.sound_manager.pygame") as mock_pg:
+            mock_pg.mixer.Sound.return_value = MagicMock()
+            sm = SoundManager()
+            sm.play("nonexistent")  # should not raise
 
 
 class TestLoopManagement:
@@ -114,43 +115,6 @@ class TestLoopManagement:
             channel_a.fadeout.assert_called_once_with(50)
             channel_b.fadeout.assert_called_once_with(50)
             assert len(sm._looping_channels) == 0
-
-
-class TestNewPlayMethods:
-    @pytest.mark.parametrize(
-        "method",
-        [
-            "play_bullet_hit_bullet",
-            "play_stage_start",
-            "play_victory",
-            "play_menu_select",
-            "play_ice_slide",
-        ],
-    )
-    def test_oneshot_methods_call_sound_play(self, method):
-        with patch("src.managers.sound_manager.pygame") as mock_pg:
-            mock_sound = MagicMock()
-            mock_pg.mixer.Sound.return_value = mock_sound
-            sm = SoundManager()
-            getattr(sm, method)()
-            mock_sound.play.assert_called()
-
-    @pytest.mark.parametrize(
-        "method",
-        [
-            "play_bullet_hit_bullet",
-            "play_stage_start",
-            "play_victory",
-            "play_menu_select",
-            "play_ice_slide",
-        ],
-    )
-    def test_oneshot_methods_noop_when_disabled(self, method):
-        with patch("src.managers.sound_manager.pygame") as mock_pg:
-            mock_pg.error = type("error", (Exception,), {})
-            mock_pg.mixer.init.side_effect = mock_pg.error("no audio")
-            sm = SoundManager()
-            getattr(sm, method)()  # should not raise
 
 
 class TestUpdateEngine:


### PR DESCRIPTION
Closes #147.

## Summary
- Ten per-sound wrappers on `SoundManager` (`play_shoot`, `play_brick_hit`, …) collapsed into a single public `play(name: str)` — formerly the private `_play`.
- Four null-guarded `_play_*` helpers on `CollisionResponseHandler` collapsed into one `_play(name)` that keeps the optional-`sound_manager` None-check.
- All call sites updated in `game_manager`, `player_manager`, and `collision_response_handler`.
- Tests updated: two parametrized \"new play methods\" classes collapsed; assertions switched to \`play.assert_any_call(\"<name>\")\`.

Net ~80 lines removed across managers and tests.

## Test plan
- [x] \`pytest\` — 874 passed
- [x] \`ruff check\` / \`ruff format\` clean