### PR TITLE
Move power-up effect dispatch into PowerUpManager

### DIFF
--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -19,9 +19,6 @@ from src.utils.constants import (
     LOGICAL_HEIGHT,
     PowerUpType,
     SPAWN_INVINCIBILITY_DURATION,
-    HELMET_INVINCIBILITY_DURATION,
-    CLOCK_FREEZE_DURATION,
-    EffectType,
     CURTAIN_CLOSE_DURATION,
     CURTAIN_OPEN_DURATION,
     CURTAIN_STAGE_DISPLAY,
@@ -245,7 +242,6 @@ class GameManager:
         )
 
         self.bullets: List[Bullet] = []
-        self.freeze_timer: float = 0.0
 
         # Restore player progress
         self.player_manager.restore_state()
@@ -424,9 +420,7 @@ class GameManager:
 
         active_players = self.player_manager.get_active_players()
 
-        if self.freeze_timer > 0:
-            self.freeze_timer -= dt
-        else:
+        if not self.spawn_manager.enemies_frozen:
             for enemy in self.spawn_manager.enemy_tanks:
                 closest_pos = None
                 if active_players:
@@ -542,12 +536,7 @@ class GameManager:
     def _apply_power_up(
         self, power_up_type: PowerUpType, player: Optional[PlayerTank] = None
     ) -> None:
-        """Dispatch power-up effect by type.
-
-        Args:
-            power_up_type: The type of power-up to apply.
-            player: The player tank that collected the power-up.
-        """
+        """Resolve the recipient and forward to PowerUpManager.apply."""
         if self.state != GameState.RUNNING:
             return
         if player is None:
@@ -555,58 +544,9 @@ class GameManager:
             player = active[0] if active else None
         if player is None:
             return
-        handlers = {
-            PowerUpType.HELMET: self._apply_helmet,
-            PowerUpType.EXTRA_LIFE: self._apply_extra_life,
-            PowerUpType.BOMB: self._apply_bomb,
-            PowerUpType.CLOCK: self._apply_clock,
-            PowerUpType.SHOVEL: self._apply_shovel,
-            PowerUpType.STAR: self._apply_star,
-        }
-        handler = handlers.get(power_up_type)
-        if handler:
-            handler(player)
-        else:
-            logger.warning(f"Unhandled power-up type: {power_up_type}")
-
-    def _apply_helmet(self, player: PlayerTank) -> None:
-        """Grant temporary invincibility to the player."""
-        player.activate_invincibility(HELMET_INVINCIBILITY_DURATION)
-        logger.info(
-            f"Helmet power-up applied: player invincible "
-            f"for {HELMET_INVINCIBILITY_DURATION}s"
+        self.power_up_manager.apply(
+            power_up_type, player, self.spawn_manager, self.effect_manager
         )
-
-    def _apply_extra_life(self, player: PlayerTank) -> None:
-        """Award the player one extra life."""
-        player.lives += 1
-        logger.info(f"Extra Life power-up applied: lives now {player.lives}")
-
-    def _apply_bomb(self, player: PlayerTank) -> None:
-        """Destroy all active enemies on the map without awarding points."""
-        for enemy in list(self.spawn_manager.enemy_tanks):
-            self.effect_manager.spawn(
-                EffectType.LARGE_EXPLOSION,
-                float(enemy.rect.centerx),
-                float(enemy.rect.centery),
-            )
-            self.spawn_manager.remove_enemy(enemy)
-        logger.info("Bomb power-up applied: all enemies destroyed")
-
-    def _apply_clock(self, player: PlayerTank) -> None:
-        """Freeze all enemies for the clock duration."""
-        self.freeze_timer = CLOCK_FREEZE_DURATION
-        logger.info(
-            f"Clock power-up applied: enemies frozen for {CLOCK_FREEZE_DURATION}s"
-        )
-
-    def _apply_shovel(self, player: PlayerTank) -> None:
-        self.power_up_manager.apply_shovel()
-
-    def _apply_star(self, player: PlayerTank) -> None:
-        """Apply star upgrade to the player tank."""
-        player.apply_star()
-        logger.info(f"Star power-up applied: player at tier {player.star_level}")
 
     def render(self) -> None:
         """Render the game state."""

--- a/src/managers/power_up_manager.py
+++ b/src/managers/power_up_manager.py
@@ -106,34 +106,32 @@ class PowerUpManager:
         """
         if power_up_type == PowerUpType.HELMET:
             player.activate_invincibility(HELMET_INVINCIBILITY_DURATION)
-            logger.info(
-                f"Helmet power-up applied: player invincible "
-                f"for {HELMET_INVINCIBILITY_DURATION}s"
-            )
         elif power_up_type == PowerUpType.EXTRA_LIFE:
             player.lives += 1
-            logger.info(f"Extra Life power-up applied: lives now {player.lives}")
         elif power_up_type == PowerUpType.BOMB:
-            for enemy in list(spawn_manager.enemy_tanks):
-                effect_manager.spawn(
-                    EffectType.LARGE_EXPLOSION,
-                    float(enemy.rect.centerx),
-                    float(enemy.rect.centery),
-                )
-                spawn_manager.remove_enemy(enemy)
-            logger.info("Bomb power-up applied: all enemies destroyed")
+            self._detonate_bomb(spawn_manager, effect_manager)
         elif power_up_type == PowerUpType.CLOCK:
             spawn_manager.freeze(CLOCK_FREEZE_DURATION)
-            logger.info(
-                f"Clock power-up applied: enemies frozen for {CLOCK_FREEZE_DURATION}s"
-            )
         elif power_up_type == PowerUpType.SHOVEL:
             self.apply_shovel()
         elif power_up_type == PowerUpType.STAR:
             player.apply_star()
-            logger.info(f"Star power-up applied: player at tier {player.star_level}")
         else:
             logger.warning(f"Unhandled power-up type: {power_up_type}")
+            return
+        logger.info(f"Power-up applied: {power_up_type.value}")
+
+    @staticmethod
+    def _detonate_bomb(
+        spawn_manager: "SpawnManager", effect_manager: "EffectManager"
+    ) -> None:
+        for enemy in list(spawn_manager.enemy_tanks):
+            effect_manager.spawn(
+                EffectType.LARGE_EXPLOSION,
+                float(enemy.rect.centerx),
+                float(enemy.rect.centery),
+            )
+            spawn_manager.remove_enemy(enemy)
 
     def apply_shovel(self) -> None:
         """Fortify base walls with steel, restoring destroyed bricks first."""

--- a/src/managers/power_up_manager.py
+++ b/src/managers/power_up_manager.py
@@ -104,21 +104,22 @@ class PowerUpManager:
             spawn_manager: Used by BOMB and CLOCK to affect enemies.
             effect_manager: Used by BOMB to spawn explosion effects.
         """
-        if power_up_type == PowerUpType.HELMET:
-            player.activate_invincibility(HELMET_INVINCIBILITY_DURATION)
-        elif power_up_type == PowerUpType.EXTRA_LIFE:
-            player.lives += 1
-        elif power_up_type == PowerUpType.BOMB:
-            self._detonate_bomb(spawn_manager, effect_manager)
-        elif power_up_type == PowerUpType.CLOCK:
-            spawn_manager.freeze(CLOCK_FREEZE_DURATION)
-        elif power_up_type == PowerUpType.SHOVEL:
-            self.apply_shovel()
-        elif power_up_type == PowerUpType.STAR:
-            player.apply_star()
-        else:
-            logger.warning(f"Unhandled power-up type: {power_up_type}")
-            return
+        match power_up_type:
+            case PowerUpType.HELMET:
+                player.activate_invincibility(HELMET_INVINCIBILITY_DURATION)
+            case PowerUpType.EXTRA_LIFE:
+                player.lives += 1
+            case PowerUpType.BOMB:
+                self._detonate_bomb(spawn_manager, effect_manager)
+            case PowerUpType.CLOCK:
+                spawn_manager.freeze(CLOCK_FREEZE_DURATION)
+            case PowerUpType.SHOVEL:
+                self.apply_shovel()
+            case PowerUpType.STAR:
+                player.apply_star()
+            case _:
+                logger.warning(f"Unhandled power-up type: {power_up_type}")
+                return
         logger.info(f"Power-up applied: {power_up_type.value}")
 
     @staticmethod

--- a/src/managers/power_up_manager.py
+++ b/src/managers/power_up_manager.py
@@ -1,7 +1,9 @@
 """Manages power-up spawning, lifecycle, and collection."""
 
+from __future__ import annotations
+
 import random
-from typing import List, Optional, Tuple
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import pygame
 from loguru import logger
@@ -12,6 +14,9 @@ from src.core.power_up import PowerUp
 from src.core.map import Map
 from src.managers.texture_manager import TextureManager
 from src.utils.constants import (
+    CLOCK_FREEZE_DURATION,
+    EffectType,
+    HELMET_INVINCIBILITY_DURATION,
     PowerUpType,
     SHOVEL_DURATION,
     SHOVEL_FLASH_CYCLE,
@@ -20,6 +25,10 @@ from src.utils.constants import (
     TILE_SIZE,
 )
 from src.core.tile import BrickVariant, Tile, TileType
+
+if TYPE_CHECKING:
+    from src.managers.effect_manager import EffectManager
+    from src.managers.spawn_manager import SpawnManager
 
 
 class PowerUpManager:
@@ -79,6 +88,52 @@ class PowerUpManager:
             self.active_power_ups = [pu for pu in self.active_power_ups if pu.active]
 
         self._tick_shovel(dt)
+
+    def apply(
+        self,
+        power_up_type: PowerUpType,
+        player: PlayerTank,
+        spawn_manager: "SpawnManager",
+        effect_manager: "EffectManager",
+    ) -> None:
+        """Dispatch a power-up effect.
+
+        Args:
+            power_up_type: The collected power-up type.
+            player: The collecting player (recipient for player-targeted effects).
+            spawn_manager: Used by BOMB and CLOCK to affect enemies.
+            effect_manager: Used by BOMB to spawn explosion effects.
+        """
+        if power_up_type == PowerUpType.HELMET:
+            player.activate_invincibility(HELMET_INVINCIBILITY_DURATION)
+            logger.info(
+                f"Helmet power-up applied: player invincible "
+                f"for {HELMET_INVINCIBILITY_DURATION}s"
+            )
+        elif power_up_type == PowerUpType.EXTRA_LIFE:
+            player.lives += 1
+            logger.info(f"Extra Life power-up applied: lives now {player.lives}")
+        elif power_up_type == PowerUpType.BOMB:
+            for enemy in list(spawn_manager.enemy_tanks):
+                effect_manager.spawn(
+                    EffectType.LARGE_EXPLOSION,
+                    float(enemy.rect.centerx),
+                    float(enemy.rect.centery),
+                )
+                spawn_manager.remove_enemy(enemy)
+            logger.info("Bomb power-up applied: all enemies destroyed")
+        elif power_up_type == PowerUpType.CLOCK:
+            spawn_manager.freeze(CLOCK_FREEZE_DURATION)
+            logger.info(
+                f"Clock power-up applied: enemies frozen for {CLOCK_FREEZE_DURATION}s"
+            )
+        elif power_up_type == PowerUpType.SHOVEL:
+            self.apply_shovel()
+        elif power_up_type == PowerUpType.STAR:
+            player.apply_star()
+            logger.info(f"Star power-up applied: player at tier {player.star_level}")
+        else:
+            logger.warning(f"Unhandled power-up type: {power_up_type}")
 
     def apply_shovel(self) -> None:
         """Fortify base walls with steel, restoring destroyed bricks first."""

--- a/src/managers/spawn_manager.py
+++ b/src/managers/spawn_manager.py
@@ -71,6 +71,7 @@ class SpawnManager:
         self.enemy_tanks: List[EnemyTank] = []
         self.total_enemy_spawns: int = 0
         self.spawn_timer: float = 0.0
+        self._freeze_timer: float = 0.0
         self._effect_manager = effect_manager
         self._powerup_carrier_indices: tuple[int, ...] = (
             powerup_carrier_indices
@@ -204,6 +205,15 @@ class SpawnManager:
             f"{' [CARRIER]' if is_carrier else ''}"
         )
 
+    def freeze(self, duration: float) -> None:
+        """Freeze enemy AI updates for the given duration (clock power-up)."""
+        self._freeze_timer = duration
+
+    @property
+    def enemies_frozen(self) -> bool:
+        """Whether enemy AI updates are currently suppressed."""
+        return self._freeze_timer > 0
+
     def update(self, dt: float, player_tanks: List[PlayerTank], game_map: Map) -> None:
         """Update spawn timer and attempt to spawn enemies.
 
@@ -215,6 +225,9 @@ class SpawnManager:
             player_tanks: List of player tanks (for collision checking).
             game_map: The game map (for collision checking).
         """
+        if self._freeze_timer > 0:
+            self._freeze_timer -= dt
+
         # Materialize tanks whose spawn animation is done
         still_pending = []
         for pending in self._pending_spawns:

--- a/tests/integration/test_power_up_effects.py
+++ b/tests/integration/test_power_up_effects.py
@@ -6,7 +6,6 @@ Uses real objects (no mocks) with SDL_VIDEODRIVER=dummy for headless execution.
 import pytest
 from src.utils.constants import (
     BULLET_SPEED,
-    CLOCK_FREEZE_DURATION,
     HELMET_INVINCIBILITY_DURATION,
     STAR_BULLET_SPEED_MULTIPLIER,
     PowerUpType,
@@ -64,7 +63,7 @@ class TestRemainingPowerUpEffects:
 
     def test_clock_effect(self, game):
         game._apply_power_up(PowerUpType.CLOCK)
-        assert game.freeze_timer == CLOCK_FREEZE_DURATION
+        assert game.spawn_manager.enemies_frozen is True
 
     def test_shovel_effect(self, game):
         game._apply_power_up(PowerUpType.SHOVEL)

--- a/tests/unit/managers/test_game_manager_powerups.py
+++ b/tests/unit/managers/test_game_manager_powerups.py
@@ -2,6 +2,7 @@ import pytest
 import pygame
 from unittest.mock import MagicMock
 from src.managers.game_manager import GameManager
+from src.managers.power_up_manager import PowerUpManager
 from src.utils.constants import (
     PowerUpType,
     HELMET_INVINCIBILITY_DURATION,
@@ -13,126 +14,156 @@ from src.utils.constants import (
 from src.states.game_state import GameState
 
 
-class TestPowerUpEffects:
-    @pytest.fixture
-    def game(self):
-        gm = MagicMock(spec=GameManager)
-        gm._apply_power_up = GameManager._apply_power_up.__get__(gm)
-        gm._apply_helmet = GameManager._apply_helmet.__get__(gm)
-        gm._apply_extra_life = GameManager._apply_extra_life.__get__(gm)
-        gm._apply_bomb = GameManager._apply_bomb.__get__(gm)
-        gm.state = GameState.RUNNING
-        mock_player = MagicMock()
-        mock_player.lives = 3
-        mock_player.is_invincible = False
-        gm._test_player = mock_player
-        gm.player_manager = MagicMock()
-        gm.player_manager.get_active_players.return_value = [mock_player]
-        gm.spawn_manager = MagicMock()
-        gm.spawn_manager.enemy_tanks = []
-        gm.effect_manager = MagicMock()
-        gm.power_up_manager = MagicMock()
-        return gm
+class TestPowerUpManagerApply:
+    """Power-up effect dispatch lives on PowerUpManager.apply()."""
 
-    def test_helmet_grants_invincibility(self, game):
-        game._apply_power_up(PowerUpType.HELMET)
-        game._test_player.activate_invincibility.assert_called_once_with(
+    @pytest.fixture
+    def player(self):
+        p = MagicMock()
+        p.lives = 3
+        p.is_invincible = False
+        return p
+
+    @pytest.fixture
+    def spawn_manager(self):
+        sm = MagicMock()
+        sm.enemy_tanks = []
+        return sm
+
+    @pytest.fixture
+    def effect_manager(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def manager(self):
+        # apply() does not read any PowerUpManager state except apply_shovel(),
+        # which is tested separately; a plain MagicMock-backed method is fine.
+        m = MagicMock(spec=PowerUpManager)
+        m.apply = PowerUpManager.apply.__get__(m)
+        m.apply_shovel = MagicMock()
+        return m
+
+    def test_helmet_grants_invincibility(
+        self, manager, player, spawn_manager, effect_manager
+    ):
+        manager.apply(PowerUpType.HELMET, player, spawn_manager, effect_manager)
+        player.activate_invincibility.assert_called_once_with(
             HELMET_INVINCIBILITY_DURATION
         )
 
-    def test_extra_life_increments_lives(self, game):
-        game._apply_power_up(PowerUpType.EXTRA_LIFE)
-        assert game._test_player.lives == 4
+    def test_extra_life_increments_lives(
+        self, manager, player, spawn_manager, effect_manager
+    ):
+        manager.apply(PowerUpType.EXTRA_LIFE, player, spawn_manager, effect_manager)
+        assert player.lives == 4
 
-    def test_bomb_destroys_all_enemies(self, game):
+    def test_bomb_destroys_all_enemies(
+        self, manager, player, spawn_manager, effect_manager
+    ):
         enemies = []
         for tt in [TankType.BASIC, TankType.FAST, TankType.POWER]:
             e = MagicMock()
             e.tank_type = tt
             e.rect = pygame.Rect(100, 100, TILE_SIZE, TILE_SIZE)
             enemies.append(e)
-        game.spawn_manager.enemy_tanks = list(enemies)
-        game._apply_power_up(PowerUpType.BOMB)
-        assert game.spawn_manager.remove_enemy.call_count == 3
+        spawn_manager.enemy_tanks = list(enemies)
+        manager.apply(PowerUpType.BOMB, player, spawn_manager, effect_manager)
+        assert spawn_manager.remove_enemy.call_count == 3
 
-    def test_bomb_spawns_explosions(self, game):
+    def test_bomb_spawns_explosions(
+        self, manager, player, spawn_manager, effect_manager
+    ):
         enemy = MagicMock()
         enemy.tank_type = TankType.BASIC
         enemy.rect = pygame.Rect(100, 100, TILE_SIZE, TILE_SIZE)
-        game.spawn_manager.enemy_tanks = [enemy]
-        game._apply_power_up(PowerUpType.BOMB)
-        game.effect_manager.spawn.assert_called_once_with(
+        spawn_manager.enemy_tanks = [enemy]
+        manager.apply(PowerUpType.BOMB, player, spawn_manager, effect_manager)
+        effect_manager.spawn.assert_called_once_with(
             EffectType.LARGE_EXPLOSION,
             float(enemy.rect.centerx),
             float(enemy.rect.centery),
         )
 
-    def test_bomb_does_not_trigger_carrier_powerup(self, game):
+    def test_bomb_does_not_trigger_carrier_powerup(
+        self, manager, player, spawn_manager, effect_manager
+    ):
         carrier = MagicMock()
         carrier.tank_type = TankType.BASIC
         carrier.is_carrier = True
         carrier.rect = pygame.Rect(100, 100, TILE_SIZE, TILE_SIZE)
-        game.spawn_manager.enemy_tanks = [carrier]
-        game._apply_power_up(PowerUpType.BOMB)
-        game.spawn_manager.remove_enemy.assert_called_once_with(carrier)
-        game.power_up_manager.spawn_power_up.assert_not_called()
+        spawn_manager.enemy_tanks = [carrier]
+        manager.apply(PowerUpType.BOMB, player, spawn_manager, effect_manager)
+        spawn_manager.remove_enemy.assert_called_once_with(carrier)
+        # The bomb path goes through spawn_manager.remove_enemy directly,
+        # bypassing the carrier-drops-powerup behaviour (which lives in
+        # GameManager's collision-response path, not in apply()).
 
-    def test_power_up_not_applied_on_game_over(self, game):
-        game.state = GameState.GAME_OVER
-        game._apply_power_up(PowerUpType.EXTRA_LIFE)
-        assert game._test_player.lives == 3
+    def test_clock_freezes_enemies(
+        self, manager, player, spawn_manager, effect_manager
+    ):
+        manager.apply(PowerUpType.CLOCK, player, spawn_manager, effect_manager)
+        spawn_manager.freeze.assert_called_once_with(CLOCK_FREEZE_DURATION)
 
-    def test_unknown_power_up_type_is_noop(self, game):
-        game._apply_power_up(PowerUpType.STAR)
-        assert game._test_player.lives == 3
+    def test_shovel_delegates_to_apply_shovel(
+        self, manager, player, spawn_manager, effect_manager
+    ):
+        manager.apply(PowerUpType.SHOVEL, player, spawn_manager, effect_manager)
+        manager.apply_shovel.assert_called_once_with()
 
-    def test_helmet_overrides_respawn_invincibility(self, game):
-        game._test_player.is_invincible = True
-        game._apply_power_up(PowerUpType.HELMET)
-        game._test_player.activate_invincibility.assert_called_once_with(
+    def test_star_applies_to_player(
+        self, manager, player, spawn_manager, effect_manager
+    ):
+        manager.apply(PowerUpType.STAR, player, spawn_manager, effect_manager)
+        player.apply_star.assert_called_once_with()
+
+    def test_helmet_overrides_respawn_invincibility(
+        self, manager, player, spawn_manager, effect_manager
+    ):
+        player.is_invincible = True
+        manager.apply(PowerUpType.HELMET, player, spawn_manager, effect_manager)
+        player.activate_invincibility.assert_called_once_with(
             HELMET_INVINCIBILITY_DURATION
         )
 
 
-class TestClockEffect:
+class TestGameManagerApplyPowerUpDelegation:
+    """GameManager._apply_power_up resolves the recipient and delegates."""
+
     @pytest.fixture
     def game(self):
         gm = MagicMock(spec=GameManager)
         gm._apply_power_up = GameManager._apply_power_up.__get__(gm)
-        gm._apply_clock = GameManager._apply_clock.__get__(gm)
         gm.state = GameState.RUNNING
-        gm.freeze_timer = 0.0
         mock_player = MagicMock()
         mock_player.lives = 3
+        gm._test_player = mock_player
         gm.player_manager = MagicMock()
         gm.player_manager.get_active_players.return_value = [mock_player]
-        return gm
-
-    def test_clock_sets_freeze_timer(self, game):
-        game._apply_power_up(PowerUpType.CLOCK)
-        assert game.freeze_timer == CLOCK_FREEZE_DURATION
-
-    def test_clock_recollection_resets_timer(self, game):
-        game.freeze_timer = 3.0
-        game._apply_power_up(PowerUpType.CLOCK)
-        assert game.freeze_timer == CLOCK_FREEZE_DURATION
-
-
-class TestShovelDelegation:
-    """Shovel state machine lives in PowerUpManager; GameManager just delegates."""
-
-    @pytest.fixture
-    def game(self):
-        gm = MagicMock(spec=GameManager)
-        gm._apply_power_up = GameManager._apply_power_up.__get__(gm)
-        gm._apply_shovel = GameManager._apply_shovel.__get__(gm)
-        gm.state = GameState.RUNNING
-        mock_player = MagicMock()
-        gm.player_manager = MagicMock()
-        gm.player_manager.get_active_players.return_value = [mock_player]
+        gm.spawn_manager = MagicMock()
+        gm.effect_manager = MagicMock()
         gm.power_up_manager = MagicMock()
         return gm
 
-    def test_apply_shovel_delegates_to_power_up_manager(self, game):
-        game._apply_power_up(PowerUpType.SHOVEL)
-        game.power_up_manager.apply_shovel.assert_called_once_with()
+    def test_delegates_to_power_up_manager(self, game):
+        game._apply_power_up(PowerUpType.EXTRA_LIFE)
+        game.power_up_manager.apply.assert_called_once_with(
+            PowerUpType.EXTRA_LIFE,
+            game._test_player,
+            game.spawn_manager,
+            game.effect_manager,
+        )
+
+    def test_skipped_when_not_running(self, game):
+        game.state = GameState.GAME_OVER
+        game._apply_power_up(PowerUpType.EXTRA_LIFE)
+        game.power_up_manager.apply.assert_not_called()
+
+    def test_falls_back_to_first_active_player(self, game):
+        game._apply_power_up(PowerUpType.HELMET)
+        args = game.power_up_manager.apply.call_args.args
+        assert args[1] is game._test_player
+
+    def test_noop_when_no_active_players(self, game):
+        game.player_manager.get_active_players.return_value = []
+        game._apply_power_up(PowerUpType.HELMET)
+        game.power_up_manager.apply.assert_not_called()

--- a/tests/unit/managers/test_game_manager_powerups.py
+++ b/tests/unit/managers/test_game_manager_powerups.py
@@ -40,6 +40,7 @@ class TestPowerUpManagerApply:
         # which is tested separately; a plain MagicMock-backed method is fine.
         m = MagicMock(spec=PowerUpManager)
         m.apply = PowerUpManager.apply.__get__(m)
+        m._detonate_bomb = PowerUpManager._detonate_bomb
         m.apply_shovel = MagicMock()
         return m
 


### PR DESCRIPTION
Closes #150.

## Summary
- `PowerUpManager.apply(type, player, spawn_manager, effect_manager)` now owns the `PowerUpType` → effect dispatch.
- `SpawnManager` owns the enemy-freeze state: `freeze(duration)` method + `enemies_frozen` property. Timer ticks inside `SpawnManager.update`.
- `GameManager._apply_power_up` collapses to a thin wrapper that enforces \"ignore when not RUNNING\" and resolves the default recipient, then delegates.
- Deleted six per-type `_apply_*` handlers from `GameManager`.
- Dropped `HELMET_INVINCIBILITY_DURATION`, `CLOCK_FREEZE_DURATION`, `EffectType` imports from `game_manager.py` (now only used by `power_up_manager.py`).
- Rewrote `test_game_manager_powerups.py` to target `PowerUpManager.apply` for the effect semantics and a small class for the `GameManager` delegation.
- Integration `test_clock_effect` now asserts `spawn_manager.enemies_frozen` rather than `freeze_timer`.

Net ~60 lines off `GameManager`.

## Test plan
- [x] \`pytest\` — 885 passed
- [x] \`ruff check\` clean; touched files pass \`ruff format --check\`