### PR TITLE
Extract update_and_prune helper for four managers

### DIFF
--- a/src/managers/effect_manager.py
+++ b/src/managers/effect_manager.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Tuple
 from loguru import logger
 from src.core.effect import Effect
 from src.managers.texture_manager import TextureManager
+from src.utils.collections import update_and_prune
 from src.utils.constants import (
     ATLAS_BG_COLOR,
     EffectType,
@@ -105,13 +106,7 @@ class EffectManager:
         Args:
             dt: Time elapsed since last update in seconds.
         """
-        any_expired = False
-        for effect in self.effects:
-            effect.update(dt)
-            if not effect.active:
-                any_expired = True
-        if any_expired:
-            self.effects = [e for e in self.effects if e.active]
+        self.effects = update_and_prune(self.effects, dt)
 
     def draw(self, surface: pygame.Surface) -> None:
         """Draw all active effects.

--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -41,6 +41,7 @@ from src.managers.power_up_manager import PowerUpManager
 from src.managers.player_manager import PlayerManager
 from src.managers.sound_manager import SoundManager
 from src.managers.settings_manager import SettingsManager
+from src.utils.collections import update_and_prune
 from src.utils.paths import resource_path
 
 
@@ -443,10 +444,7 @@ class GameManager:
         self.sound_manager.update_engine(any_moving)
 
         # Update enemy bullets (player bullets managed by PlayerManager)
-        for bullet in self.bullets:
-            bullet.update(dt)
-        # Remove inactive bullets
-        self.bullets = [b for b in self.bullets if b.active]
+        self.bullets = update_and_prune(self.bullets, dt)
 
         self.spawn_manager.update(dt, active_players, self.map)
         self.power_up_manager.update(dt)

--- a/src/managers/player_manager.py
+++ b/src/managers/player_manager.py
@@ -15,6 +15,7 @@ from src.managers.player_input import (
     KeyboardInput,
     PlayerInput,
 )
+from src.utils.collections import update_and_prune
 
 if TYPE_CHECKING:
     from src.core.map import Map
@@ -158,11 +159,7 @@ class PlayerManager:
             if has_valid_input and not player.is_sliding:
                 player.move(dx, dy, dt)
 
-        for bullet in self._bullets:
-            if bullet.active:
-                bullet.update(dt)
-
-        self._bullets = [b for b in self._bullets if b.active]
+        self._bullets = update_and_prune(self._bullets, dt)
 
     def try_shoot(self) -> None:
         """Check shoot input for each player and fire a bullet if possible.

--- a/src/managers/power_up_manager.py
+++ b/src/managers/power_up_manager.py
@@ -13,6 +13,7 @@ from src.core.player_tank import PlayerTank
 from src.core.power_up import PowerUp
 from src.core.map import Map
 from src.managers.texture_manager import TextureManager
+from src.utils.collections import update_and_prune
 from src.utils.constants import (
     CLOCK_FREEZE_DURATION,
     EffectType,
@@ -79,14 +80,7 @@ class PowerUpManager:
 
     def update(self, dt: float) -> None:
         """Update all active power-ups; remove any that have timed out."""
-        any_expired = False
-        for pu in self.active_power_ups:
-            pu.update(dt)
-            if not pu.active:
-                any_expired = True
-        if any_expired:
-            self.active_power_ups = [pu for pu in self.active_power_ups if pu.active]
-
+        self.active_power_ups = update_and_prune(self.active_power_ups, dt)
         self._tick_shovel(dt)
 
     def apply(

--- a/src/utils/collections.py
+++ b/src/utils/collections.py
@@ -1,0 +1,21 @@
+"""Shared collection helpers."""
+
+from __future__ import annotations
+
+from typing import Protocol, TypeVar
+
+
+class _Updatable(Protocol):
+    active: bool
+
+    def update(self, dt: float) -> None: ...
+
+
+T = TypeVar("T", bound=_Updatable)
+
+
+def update_and_prune(items: list[T], dt: float) -> list[T]:
+    """Call ``update(dt)`` on each item and return those still ``active``."""
+    for item in items:
+        item.update(dt)
+    return [i for i in items if i.active]


### PR DESCRIPTION
Closes #155.

## Summary
- New \`src/utils/collections.update_and_prune(items, dt)\` replaces the same \"tick each item, drop inactive\" loop written four times across \`EffectManager\`, \`PowerUpManager\`, \`PlayerManager\`, and \`GameManager\`.
- \`PlayerManager\` previously wrapped \`bullet.update(dt)\` in an outer \`if bullet.active\` check. That guard was redundant — \`Bullet.update\` already short-circuits on inactive bullets (\`src/core/bullet.py:63-64\`). Removing it unifies the four call sites.
- Two of the four copies had an \`any_expired\` short-circuit optimization and two didn't; helper is unconditional and uniform.

Net: ~16 lines of duplication removed; four managers call a single well-named helper.

## Test plan
- [x] \`pytest\` — 874 passed
- [x] \`ruff check\` / \`ruff format --check\` clean