### PR TITLE
Move cycle_difficulty and adjust_volume onto SettingsManager

### DIFF
--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -8,7 +8,6 @@ from src.core.tile import Tile
 from src.core.bullet import Bullet
 from src.states.game_state import GameState
 from src.utils.constants import (
-    Difficulty,
     VOLUME_ADJUSTMENT_STEP,
     WINDOW_TITLE,
     FPS,
@@ -349,17 +348,11 @@ class GameManager:
         self.state = GameState.TITLE_SCREEN
 
     def _cycle_difficulty(self, step: int) -> None:
-        difficulties = list(Difficulty)
-        idx = difficulties.index(self.settings_manager.difficulty)
-        self.settings_manager.difficulty = difficulties[
-            (idx + step) % len(difficulties)
-        ]
+        self.settings_manager.cycle_difficulty(step)
         self.sound_manager.play("menu_select")
 
     def _adjust_volume(self, delta: float) -> None:
-        self.settings_manager.master_volume = max(
-            0.0, min(1.0, self.settings_manager.master_volume + delta)
-        )
+        self.settings_manager.adjust_volume(delta)
         self.sound_manager.set_master_volume(self.settings_manager.master_volume)
         self.sound_manager.play("menu_select")
 

--- a/src/managers/settings_manager.py
+++ b/src/managers/settings_manager.py
@@ -34,6 +34,16 @@ class SettingsManager:
                 f"Could not load settings from {self._path}; using defaults."
             )
 
+    def cycle_difficulty(self, step: int) -> None:
+        """Advance the difficulty by ``step`` positions, wrapping around."""
+        difficulties = list(Difficulty)
+        idx = difficulties.index(self.difficulty)
+        self.difficulty = difficulties[(idx + step) % len(difficulties)]
+
+    def adjust_volume(self, delta: float) -> None:
+        """Add ``delta`` to master volume, clamped to [0.0, 1.0]."""
+        self.master_volume = max(0.0, min(1.0, self.master_volume + delta))
+
     def save(self) -> None:
         """Save current settings to file."""
         data = {

--- a/tests/unit/managers/test_game_manager.py
+++ b/tests/unit/managers/test_game_manager.py
@@ -9,6 +9,7 @@ from src.utils.constants import (
     MAX_STAGE,
     MenuAction,
     VICTORY_PAUSE_DURATION,
+    VOLUME_ADJUSTMENT_STEP,
 )
 
 
@@ -217,33 +218,27 @@ class TestGameManager:
             assert game_manager.state == GameState.RUNNING
 
         def test_options_input_right_volume(self, game_manager):
-            """MenuAction.RIGHT on volume row increases volume."""
+            """MenuAction.RIGHT on volume row delegates to settings_manager."""
             game_manager.state = GameState.OPTIONS_MENU
             game_manager._options_menu.selection = 1  # volume is now index 1
-            game_manager.settings_manager.master_volume = 0.5
-            initial_vol = game_manager.settings_manager.master_volume
             game_manager._options_menu.handle_action(MenuAction.RIGHT)
-            assert game_manager.settings_manager.master_volume > initial_vol
+            game_manager.settings_manager.adjust_volume.assert_called_once_with(
+                VOLUME_ADJUSTMENT_STEP
+            )
 
         def test_options_difficulty_cycles_forward(self, game_manager):
-            """MenuAction.RIGHT cycles difficulty forward with wrap-around."""
+            """MenuAction.RIGHT on difficulty row delegates with step=+1."""
             game_manager.state = GameState.OPTIONS_MENU
             game_manager._options_menu.selection = 0
-            game_manager.settings_manager.difficulty = Difficulty.EASY
             game_manager._options_menu.handle_action(MenuAction.RIGHT)
-            assert game_manager.settings_manager.difficulty == Difficulty.NORMAL
-            game_manager._options_menu.handle_action(MenuAction.RIGHT)
-            assert game_manager.settings_manager.difficulty == Difficulty.EASY
+            game_manager.settings_manager.cycle_difficulty.assert_called_once_with(1)
 
         def test_options_difficulty_cycles_backward(self, game_manager):
-            """MenuAction.LEFT cycles difficulty backward with wrap-around."""
+            """MenuAction.LEFT on difficulty row delegates with step=-1."""
             game_manager.state = GameState.OPTIONS_MENU
             game_manager._options_menu.selection = 0
-            game_manager.settings_manager.difficulty = Difficulty.NORMAL
             game_manager._options_menu.handle_action(MenuAction.LEFT)
-            assert game_manager.settings_manager.difficulty == Difficulty.EASY
-            game_manager._options_menu.handle_action(MenuAction.LEFT)
-            assert game_manager.settings_manager.difficulty == Difficulty.NORMAL
+            game_manager.settings_manager.cycle_difficulty.assert_called_once_with(-1)
 
         def test_options_input_confirm_back(self, game_manager):
             """MenuAction.CONFIRM on Back returns to previous screen."""
@@ -755,58 +750,34 @@ class TestPauseAndOptionsStateMachine:
     # --- Options menu ---
 
     def test_options_volume_left_decreases(self, game_manager, key_down_event):
-        """LEFT on VOLUME (1) in options decreases master volume."""
+        """LEFT on VOLUME (1) delegates to settings_manager.adjust_volume."""
         gm = game_manager
         gm.state = GameState.OPTIONS_MENU
         gm._options_menu.selection = 1
         gm.settings_manager = MagicMock()
-        gm.settings_manager.master_volume = 0.5
+        gm.settings_manager.master_volume = 0.4  # value adjust_volume would land on
         gm.sound_manager = MagicMock()
         pygame.event.post(key_down_event(pygame.K_LEFT))
         gm.handle_events()
-        assert gm.settings_manager.master_volume == pytest.approx(0.4, abs=0.01)
-        gm.sound_manager.set_master_volume.assert_called_once_with(
-            pytest.approx(0.4, abs=0.01)
+        gm.settings_manager.adjust_volume.assert_called_once_with(
+            -VOLUME_ADJUSTMENT_STEP
         )
+        gm.sound_manager.set_master_volume.assert_called_once_with(0.4)
 
     def test_options_volume_right_increases(self, game_manager, key_down_event):
-        """RIGHT on VOLUME (1) in options increases master volume."""
+        """RIGHT on VOLUME (1) delegates to settings_manager.adjust_volume."""
         gm = game_manager
         gm.state = GameState.OPTIONS_MENU
         gm._options_menu.selection = 1
         gm.settings_manager = MagicMock()
-        gm.settings_manager.master_volume = 0.5
+        gm.settings_manager.master_volume = 0.6  # value adjust_volume would land on
         gm.sound_manager = MagicMock()
         pygame.event.post(key_down_event(pygame.K_RIGHT))
         gm.handle_events()
-        assert gm.settings_manager.master_volume == pytest.approx(0.6, abs=0.01)
-        gm.sound_manager.set_master_volume.assert_called_once_with(
-            pytest.approx(0.6, abs=0.01)
+        gm.settings_manager.adjust_volume.assert_called_once_with(
+            VOLUME_ADJUSTMENT_STEP
         )
-
-    def test_options_volume_clamps_at_zero(self, game_manager, key_down_event):
-        """Volume does not go below 0.0."""
-        gm = game_manager
-        gm.state = GameState.OPTIONS_MENU
-        gm._options_menu.selection = 1
-        gm.settings_manager = MagicMock()
-        gm.settings_manager.master_volume = 0.0
-        gm.sound_manager = MagicMock()
-        pygame.event.post(key_down_event(pygame.K_LEFT))
-        gm.handle_events()
-        assert gm.settings_manager.master_volume == 0.0
-
-    def test_options_volume_clamps_at_one(self, game_manager, key_down_event):
-        """Volume does not go above 1.0."""
-        gm = game_manager
-        gm.state = GameState.OPTIONS_MENU
-        gm._options_menu.selection = 1
-        gm.settings_manager = MagicMock()
-        gm.settings_manager.master_volume = 1.0
-        gm.sound_manager = MagicMock()
-        pygame.event.post(key_down_event(pygame.K_RIGHT))
-        gm.handle_events()
-        assert gm.settings_manager.master_volume == 1.0
+        gm.sound_manager.set_master_volume.assert_called_once_with(0.6)
 
     def test_options_back_saves_and_returns_to_title(
         self, game_manager, key_down_event

--- a/tests/unit/managers/test_settings_manager.py
+++ b/tests/unit/managers/test_settings_manager.py
@@ -1,5 +1,6 @@
 import json
 from src.managers.settings_manager import SettingsManager
+from src.utils.constants import Difficulty
 
 
 class TestSettingsManager:
@@ -51,3 +52,35 @@ class TestSettingsManager:
             json.dump({}, f)
         sm = SettingsManager(path=path)
         assert sm.master_volume == 1.0
+
+    def test_adjust_volume_applies_delta(self, tmp_path):
+        sm = SettingsManager(path=str(tmp_path / "settings.json"))
+        sm.master_volume = 0.5
+        sm.adjust_volume(0.1)
+        assert sm.master_volume == 0.6
+
+    def test_adjust_volume_clamps_at_zero(self, tmp_path):
+        sm = SettingsManager(path=str(tmp_path / "settings.json"))
+        sm.master_volume = 0.0
+        sm.adjust_volume(-0.1)
+        assert sm.master_volume == 0.0
+
+    def test_adjust_volume_clamps_at_one(self, tmp_path):
+        sm = SettingsManager(path=str(tmp_path / "settings.json"))
+        sm.master_volume = 1.0
+        sm.adjust_volume(0.1)
+        assert sm.master_volume == 1.0
+
+    def test_cycle_difficulty_forward_wraps(self, tmp_path):
+        sm = SettingsManager(path=str(tmp_path / "settings.json"))
+        difficulties = list(Difficulty)
+        sm.difficulty = difficulties[-1]
+        sm.cycle_difficulty(1)
+        assert sm.difficulty == difficulties[0]
+
+    def test_cycle_difficulty_backward_wraps(self, tmp_path):
+        sm = SettingsManager(path=str(tmp_path / "settings.json"))
+        difficulties = list(Difficulty)
+        sm.difficulty = difficulties[0]
+        sm.cycle_difficulty(-1)
+        assert sm.difficulty == difficulties[-1]


### PR DESCRIPTION
Closes #157.

## Summary
- Added \`SettingsManager.cycle_difficulty(step)\` and \`SettingsManager.adjust_volume(delta)\` — the wrap-around and clamp-to-[0,1] logic moved from \`GameManager\` to the class that owns the state.
- \`GameManager._cycle_difficulty\` and \`_adjust_volume\` are now thin wrappers that delegate and emit the menu-tick sound (volume also pushes the new value to \`SoundManager\`).
- Dropped the now-unused \`Difficulty\` import from \`game_manager.py\`.
- Moved the volume clamp / difficulty wrap unit tests out of \`test_game_manager.py\` into \`test_settings_manager.py\`, where they fit the actual code under test.
- Rewrote the five \`test_game_manager\` tests that previously relied on real math running against a mocked \`settings_manager\` — they now assert delegation (\`adjust_volume.assert_called_once_with(...)\`) instead of end state.

Not moving \`_build_menus\` itself — the menu wiring is a natural fit for \`GameManager\` and a \`MenuFactory\` abstraction would be ceremony for little win.

## Test plan
- [x] \`pytest\` — 877 passed
- [x] \`ruff check\` / \`ruff format --check\` clean