### PR TITLE
Tier 3 small cleanups: grid_to_pixels, dead branch, pending-spawn rect cache

### DIFF
--- a/src/managers/collision_response_handler.py
+++ b/src/managers/collision_response_handler.py
@@ -254,8 +254,6 @@ class CollisionResponseHandler:
     ) -> bool:
         if not bullet_a.active or not bullet_b.active:
             return False
-        if bullet_a == bullet_b:
-            return False
         logger.debug("Bullet hit bullet. Both deactivated.")
         bullet_a.active = False
         bullet_b.active = False

--- a/src/managers/player_manager.py
+++ b/src/managers/player_manager.py
@@ -67,9 +67,10 @@ class PlayerManager:
         map_height_px = game_map.height * game_map.tile_size
 
         def make_player(spawn: tuple[int, int], pid: int) -> PlayerTank:
+            x, y = game_map.grid_to_pixels(spawn[0], spawn[1])
             return PlayerTank(
-                spawn[0] * game_map.tile_size,
-                spawn[1] * game_map.tile_size,
+                x,
+                y,
                 game_map.tile_size,
                 self._texture_manager,
                 map_width_px=map_width_px,

--- a/src/managers/power_up_manager.py
+++ b/src/managers/power_up_manager.py
@@ -195,7 +195,6 @@ class PowerUpManager:
         """Find a random walkable tile position not occupied by any tank."""
         walkable = []
         grid = self._game_map.tiles
-        tile_size = self._game_map.tile_size  # sub-tile size (16px)
 
         # Iterate in steps of 2 sub-tiles (= 1 TILE_SIZE = 32px)
         for row in range(0, len(grid), 2):
@@ -214,9 +213,7 @@ class PowerUpManager:
                     if not all_empty:
                         break
                 if all_empty:
-                    px = col * tile_size
-                    py = row * tile_size
-                    walkable.append((px, py))
+                    walkable.append(self._game_map.grid_to_pixels(col, row))
 
         if not walkable:
             return None

--- a/src/managers/spawn_manager.py
+++ b/src/managers/spawn_manager.py
@@ -29,6 +29,7 @@ class _PendingSpawn:
     y: int
     tank_type: TankType
     effect: Effect
+    rect: pygame.Rect
     is_carrier: bool = False
 
 
@@ -127,10 +128,7 @@ class SpawnManager:
             if rect.colliderect(enemy.rect):
                 return True
         for pending in self._pending_spawns:
-            pending_rect = pygame.Rect(
-                pending.x, pending.y, self.tile_size, self.tile_size
-            )
-            if rect.colliderect(pending_rect):
+            if rect.colliderect(pending.rect):
                 return True
         return False
 
@@ -171,7 +169,12 @@ class SpawnManager:
             effect = self._effect_manager.spawn(EffectType.SPAWN, center_x, center_y)
             self._pending_spawns.append(
                 _PendingSpawn(
-                    x=x, y=y, tank_type=tank_type, effect=effect, is_carrier=is_carrier
+                    x=x,
+                    y=y,
+                    tank_type=tank_type,
+                    effect=effect,
+                    rect=pygame.Rect(x, y, self.tile_size, self.tile_size),
+                    is_carrier=is_carrier,
                 )
             )
             logger.debug(

--- a/tests/unit/managers/test_player_manager.py
+++ b/tests/unit/managers/test_player_manager.py
@@ -46,6 +46,10 @@ def mock_game_map():
     game_map.width = 26
     game_map.height = 26
     game_map.tile_size = TILE_SIZE
+    game_map.grid_to_pixels.side_effect = lambda gx, gy: (
+        gx * TILE_SIZE,
+        gy * TILE_SIZE,
+    )
     # Default: no ice tile under any tank
     game_map.get_tile_at.return_value = None
     return game_map

--- a/tests/unit/managers/test_power_up_manager.py
+++ b/tests/unit/managers/test_power_up_manager.py
@@ -20,6 +20,7 @@ class TestPowerUpManager:
         game_map.width = 32
         game_map.height = 32
         game_map.tile_size = 16
+        game_map.grid_to_pixels.side_effect = lambda gx, gy: (gx * 16, gy * 16)
         # All tiles are EMPTY (None mimics "no blocking tile")
         game_map.tiles = [[None for _ in range(32)] for _ in range(32)]
         return game_map


### PR DESCRIPTION
Addresses three of the four items in #161. The fourth — dropping \`GameManager.player_tank\` / \`GameManager.score\` / \`PlayerManager.add_bullet\` — turned out to touch 50+ integration-test call sites and was not a good fit for this bundle; deferred for a separate decision.

## Summary
1. **\`Map.grid_to_pixels\`** — \`PlayerManager.create_players\` and \`PowerUpManager._find_spawn_position\` now call the existing helper instead of inlining \`grid * tile_size\`.
2. **Dead branch** — removed the unreachable \`if bullet_a == bullet_b: return False\` in \`CollisionResponseHandler._handle_bullet_vs_bullet\`. \`CollisionManager\` dedupes pairs via \`_seen_pairs\` before queuing, and \`_check_bullet_vs_bullet\` only iterates \`player_bullets × enemy_bullets\` (disjoint lists).
3. **\`_PendingSpawn\` rect cache** — stash the rect on the dataclass at construction instead of allocating a fresh \`pygame.Rect\` per pending-spawn per \`_is_spawn_blocked\` call.

## Test changes
Mock \`Map\` fixtures in \`test_player_manager\` and \`test_power_up_manager\` now configure \`grid_to_pixels.side_effect\` so the call returns a real tuple instead of a MagicMock.

## Test plan
- [x] \`pytest\` — 877 passed
- [x] \`ruff check\` / \`ruff format --check\` clean for touched files