### PR TITLE
Renderer takes menu labels from caller instead of hardcoding

### DIFF
--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -126,7 +126,7 @@ class GameManager:
             items=[
                 MenuItem("Resume", on_confirm=self._resume_game),
                 MenuItem("Options", on_confirm=lambda: self._open_options(True)),
-                MenuItem("Title", on_confirm=self._return_to_title),
+                MenuItem("Title Screen", on_confirm=self._return_to_title),
                 MenuItem("Quit", on_confirm=self._quit_game),
             ],
             on_select=play_select,
@@ -551,7 +551,9 @@ class GameManager:
     def render(self) -> None:
         """Render the game state."""
         if self.state == GameState.TITLE_SCREEN:
-            self.renderer.render_title_screen(self._title_menu.selection)
+            self.renderer.render_title_screen(
+                self._title_menu.labels, self._title_menu.selection
+            )
             return
 
         if self.state in (
@@ -575,7 +577,9 @@ class GameManager:
             return
 
         if self.state == GameState.PAUSED:
-            self.renderer.render_pause_menu(self._pause_menu.selection)
+            self.renderer.render_pause_menu(
+                self._pause_menu.labels, self._pause_menu.selection
+            )
             return
 
         if self.state == GameState.EXIT:

--- a/src/managers/menu_controller.py
+++ b/src/managers/menu_controller.py
@@ -30,6 +30,11 @@ class MenuController:
         self._on_back = on_back
         self.selection: int = 0
 
+    @property
+    def labels(self) -> List[str]:
+        """Return the ordered labels of this menu's items."""
+        return [item.label for item in self._items]
+
     def reset(self) -> None:
         self.selection = 0
 

--- a/src/managers/renderer.py
+++ b/src/managers/renderer.py
@@ -181,9 +181,7 @@ class Renderer:
         else:
             lives = player_tanks[0].lives if player_tanks else 0
             total_score = sum(scores.values())
-            self._draw_hud_slot(
-                "lives", f"Lives: {lives}", None, WHITE, "left"
-            )
+            self._draw_hud_slot("lives", f"Lives: {lives}", None, WHITE, "left")
             self._draw_hud_slot(
                 "score", f"Score: {total_score:>6}", None, WHITE, "right"
             )
@@ -204,9 +202,7 @@ class Renderer:
         if cached is None or cached[0] != label or cached[1] != score_text:
             label_surf = self.small_font.render(label, True, color)
             score_surf = (
-                self.small_font.render(score_text, True, WHITE)
-                if score_text
-                else None
+                self.small_font.render(score_text, True, WHITE) if score_text else None
             )
             self._cached_hud[slot] = (label, score_text, label_surf, score_surf)
         else:
@@ -218,14 +214,10 @@ class Renderer:
             if score_surf:
                 self.game_surface.blit(score_surf, (10, 24))
         else:
-            label_rect = label_surf.get_rect(
-                topright=(self.logical_width - 10, 10)
-            )
+            label_rect = label_surf.get_rect(topright=(self.logical_width - 10, 10))
             self.game_surface.blit(label_surf, label_rect)
             if score_surf:
-                score_rect = score_surf.get_rect(
-                    topright=(self.logical_width - 10, 24)
-                )
+                score_rect = score_surf.get_rect(topright=(self.logical_width - 10, 24))
                 self.game_surface.blit(score_surf, score_rect)
 
     def _draw_game_over_rising(self, progress: float) -> None:
@@ -311,23 +303,19 @@ class Renderer:
         self.game_surface.blit(cursor_text, cursor_rect)
         return rects
 
-    def render_title_screen(self, menu_selection: int) -> None:
-        """Render the title screen with menu options.
-
-        Args:
-            menu_selection: Currently selected menu item (0-3).
-        """
+    def render_title_screen(self, labels: Sequence[str], menu_selection: int) -> None:
+        """Render the title screen with menu options."""
         self.game_surface.fill(BLACK)
 
         self._draw_centered_text("BATTLE CITY", self.font, WHITE, self._center_y - 80)
 
-        options = ["1 PLAYER", "2 PLAYERS", "OPTIONS", "QUIT"]
-        colors = [WHITE, WHITE, WHITE, WHITE]
-        self._draw_menu(options, menu_selection, self._center_y, colors=colors)
+        self._draw_menu(
+            [label.upper() for label in labels], menu_selection, self._center_y
+        )
 
         self._present_surface()
 
-    def render_pause_menu(self, menu_selection: int) -> None:
+    def render_pause_menu(self, labels: Sequence[str], menu_selection: int) -> None:
         """Render pause menu overlay on top of frozen game frame.
 
         Does NOT clear the game surface — draws on top of the
@@ -337,8 +325,9 @@ class Renderer:
 
         self._draw_centered_text("PAUSED", self.font, WHITE, self._center_y - 60)
 
-        options = ["RESUME", "OPTIONS", "TITLE SCREEN", "QUIT"]
-        self._draw_menu(options, menu_selection, self._center_y)
+        self._draw_menu(
+            [label.upper() for label in labels], menu_selection, self._center_y
+        )
 
         self._present_surface()
 

--- a/tests/unit/managers/test_game_manager.py
+++ b/tests/unit/managers/test_game_manager.py
@@ -849,7 +849,9 @@ class TestPauseAndOptionsStateMachine:
         gm.state = GameState.PAUSED
         gm.renderer = MagicMock()
         gm.render()
-        gm.renderer.render_pause_menu.assert_called_once_with(gm._pause_menu.selection)
+        gm.renderer.render_pause_menu.assert_called_once_with(
+            gm._pause_menu.labels, gm._pause_menu.selection
+        )
 
     def test_render_options_calls_render_options_menu(self, game_manager):
         """OPTIONS_MENU state renders options menu."""
@@ -870,4 +872,6 @@ class TestPauseAndOptionsStateMachine:
         gm.renderer = MagicMock()
         gm._title_menu.selection = 2
         gm.render()
-        gm.renderer.render_title_screen.assert_called_once_with(2)
+        gm.renderer.render_title_screen.assert_called_once_with(
+            gm._title_menu.labels, 2
+        )

--- a/tests/unit/managers/test_renderer.py
+++ b/tests/unit/managers/test_renderer.py
@@ -226,13 +226,15 @@ class TestRenderCurtain:
 class TestRenderPauseMenu:
     """Tests for render_pause_menu."""
 
+    PAUSE_LABELS = ["Resume", "Options", "Title Screen", "Quit"]
+
     def test_overlay_is_blitted(self, renderer):
         """Pause menu blits the pre-created overlay onto the game surface."""
         with (
             patch("pygame.transform.scale"),
             patch("pygame.display.flip"),
         ):
-            renderer.render_pause_menu(0)
+            renderer.render_pause_menu(self.PAUSE_LABELS, 0)
 
         # The cached overlay should be blitted onto the game surface
         blit_calls = renderer.game_surface.blit.call_args_list
@@ -247,7 +249,7 @@ class TestRenderPauseMenu:
             patch("pygame.transform.scale"),
             patch("pygame.display.flip"),
         ):
-            renderer.render_pause_menu(0)
+            renderer.render_pause_menu(self.PAUSE_LABELS, 0)
 
         render_calls = [call.args[0] for call in renderer.font.render.call_args_list]
         assert "PAUSED" in render_calls
@@ -259,7 +261,7 @@ class TestRenderPauseMenu:
             patch("pygame.transform.scale"),
             patch("pygame.display.flip"),
         ):
-            renderer.render_pause_menu(0)
+            renderer.render_pause_menu(self.PAUSE_LABELS, 0)
 
         render_calls = [
             call.args[0] for call in renderer.small_font.render.call_args_list
@@ -276,7 +278,7 @@ class TestRenderPauseMenu:
             patch("pygame.transform.scale"),
             patch("pygame.display.flip"),
         ):
-            renderer.render_pause_menu(0)
+            renderer.render_pause_menu(self.PAUSE_LABELS, 0)
 
         render_calls = [
             call.args[0] for call in renderer.small_font.render.call_args_list
@@ -391,12 +393,14 @@ class TestRenderTitleScreenUpdated:
     """Tests for updated title screen with OPTIONS and QUIT."""
 
     def test_menu_items_rendered(self, renderer):
-        """Title screen renders 1 PLAYER, 2 PLAYERS, OPTIONS, QUIT."""
+        """Title screen uppercases and renders the given labels."""
         with (
             patch("pygame.transform.scale"),
             patch("pygame.display.flip"),
         ):
-            renderer.render_title_screen(0)
+            renderer.render_title_screen(
+                ["1 Player", "2 Players", "Options", "Quit"], 0
+            )
 
         render_calls = [
             call.args[0] for call in renderer.small_font.render.call_args_list


### PR DESCRIPTION
Closes #162.

## Summary
- \`MenuController\` gains a \`labels\` property returning item labels in order.
- \`render_title_screen\` and \`render_pause_menu\` now take \`(labels: Sequence[str], menu_selection: int)\`. They uppercase each label at render time to preserve the NES-style look.
- \`GameManager\` passes \`menu.labels\` and \`menu.selection\`.
- Renamed the pause-menu \`MenuItem(\"Title\", ...)\` to \`MenuItem(\"Title Screen\", ...)\` so the visible menu text matches what the renderer previously hardcoded (\`\"TITLE SCREEN\"\`). The renderer no longer gets a say in the labels.
- Dropped the dead \`colors=[WHITE]*4\` uniform that was passed alongside the old hardcoded options list.

## Test plan
- [x] \`pytest\` — 877 passed
- [x] \`ruff check\` / \`ruff format\` clean