### PR TITLE
Drop test-only public surface on GameManager and PlayerManager

### DIFF
--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -151,21 +151,6 @@ class GameManager:
         )
         return title, pause, options
 
-    @property
-    def player_tank(self) -> Optional[PlayerTank]:
-        """Convenience property returning the first active player tank.
-
-        Used by integration tests that need a single player reference.
-        Returns None if no active players exist.
-        """
-        active = self.player_manager.get_active_players()
-        return active[0] if active else None
-
-    @property
-    def score(self) -> int:
-        """Convenience property delegating to player_manager.score."""
-        return self.player_manager.score
-
     def _reset_game(self) -> None:
         """Start a new game and immediately enter RUNNING state (used by tests)."""
         self._new_game()

--- a/src/managers/player_manager.py
+++ b/src/managers/player_manager.py
@@ -189,17 +189,6 @@ class PlayerManager:
         """
         return list(self._bullets)
 
-    def add_bullet(self, bullet: Bullet) -> None:
-        """Add a bullet to the player bullet list.
-
-        Useful for tests that need to inject bullets outside the normal
-        input → try_shoot flow.
-
-        Args:
-            bullet: The bullet to add.
-        """
-        self._bullets.append(bullet)
-
     def get_active_players(self) -> list[PlayerTank]:
         """Return players that are still alive (health > 0).
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -24,6 +24,15 @@ def game_manager_fixture():
     return manager
 
 
+def first_player(game):
+    """Return the first active player tank, assuming one exists.
+
+    Most integration tests are single-player and just want \"the\" player;
+    this centralises the get_active_players()[0] lookup.
+    """
+    return game.player_manager.get_active_players()[0]
+
+
 def flush_pending_spawns(game, max_ticks=120):
     """Tick effect updates until all pending spawn animations finish.
 

--- a/tests/integration/test_collision_integration.py
+++ b/tests/integration/test_collision_integration.py
@@ -4,6 +4,7 @@ from src.utils.constants import Direction, FPS, TILE_SIZE, SUB_TILE_SIZE, TankTy
 from src.states.game_state import GameState
 from src.core.tile import BrickVariant, Tile, TileDefaults, TileType
 from src.core.enemy_tank import EnemyTank
+from tests.integration.conftest import first_player
 
 # Tests related to collision interactions between different game objects
 
@@ -25,7 +26,7 @@ def test_player_bullet_vs_tile(
 ):
     """Test player bullet interaction with various tile types."""
     game_manager = game_manager_fixture
-    player_tank = game_manager.player_tank
+    player_tank = first_player(game_manager)
     game_map = game_manager.map
 
     # Define target tile location (sub-tile grid coords)
@@ -81,7 +82,7 @@ def test_player_bullet_vs_tile(
     player_tank.direction = Direction.UP
     bullet_obj = player_tank.shoot()
     assert bullet_obj is not None, "Bullet failed to spawn."
-    game_manager.player_manager.add_bullet(bullet_obj)
+    game_manager.player_manager._bullets.append(bullet_obj)
     bullet = bullet_obj
 
     # Simulate game time until bullet should have hit (or passed)
@@ -132,7 +133,7 @@ def test_player_bullet_destroys_enemy_tank(game_manager_fixture, mocker):
     """Test player bullet hitting and destroying a basic enemy tank."""
     mocker.patch("src.core.enemy_tank.random.uniform", return_value=0.0)
     game_manager = game_manager_fixture
-    player_tank = game_manager.player_tank
+    player_tank = first_player(game_manager)
 
     # --- Spawn Enemy Tank --- #
     enemy_type = TankType.BASIC
@@ -182,7 +183,7 @@ def test_player_bullet_destroys_enemy_tank(game_manager_fixture, mocker):
     player_tank.direction = Direction.UP
     bullet_obj = player_tank.shoot()
     assert bullet_obj is not None, "Bullet failed to spawn."
-    game_manager.player_manager.add_bullet(bullet_obj)
+    game_manager.player_manager._bullets.append(bullet_obj)
     bullet = bullet_obj
 
     # Simulate game time until bullet should have hit
@@ -260,7 +261,7 @@ def test_enemy_bullet_hits_player_tank(
     """Test enemy bullet hitting the player tank under different conditions."""
     mocker.patch("src.core.enemy_tank.random.uniform", return_value=0.0)
     game_manager = game_manager_fixture
-    player_tank = game_manager.player_tank
+    player_tank = first_player(game_manager)
     initial_spawn_pos = player_tank.initial_position
 
     # --- Configure Player State ---
@@ -538,7 +539,7 @@ def test_player_tank_vs_enemy_tank_no_overlap(game_manager_fixture, mocker):
     """Test that a player tank driving into an enemy tank does not overlap."""
     mocker.patch("src.core.enemy_tank.random.uniform", return_value=0.0)
     game_manager = game_manager_fixture
-    player_tank = game_manager.player_tank
+    player_tank = first_player(game_manager)
 
     # --- Spawn an enemy tank directly above the player --- #
     enemy_type = TankType.BASIC

--- a/tests/integration/test_controller.py
+++ b/tests/integration/test_controller.py
@@ -4,6 +4,7 @@ import pygame
 from src.managers.game_manager import GameManager
 from src.managers.player_input import AXIS_MAX
 from src.states.game_state import GameState
+from tests.integration.conftest import first_player
 
 
 def _send_event(gm, event):
@@ -20,7 +21,7 @@ class TestControllerGameplay:
         gm = GameManager()
         gm._reset_game()
         gm.state = GameState.RUNNING
-        initial_y = gm.player_tank.y
+        initial_y = first_player(gm).y
 
         event = pygame.event.Event(
             pygame.CONTROLLERBUTTONDOWN,
@@ -30,14 +31,14 @@ class TestControllerGameplay:
         _send_event(gm, event)
         gm.update()
 
-        assert gm.player_tank.y < initial_y
+        assert first_player(gm).y < initial_y
 
     def test_ctrl_stick_moves_player(self) -> None:
         """Controller left stick UP moves the player tank up."""
         gm = GameManager()
         gm._reset_game()
         gm.state = GameState.RUNNING
-        initial_y = gm.player_tank.y
+        initial_y = first_player(gm).y
 
         event = pygame.event.Event(
             pygame.CONTROLLERAXISMOTION,
@@ -48,7 +49,7 @@ class TestControllerGameplay:
         _send_event(gm, event)
         gm.update()
 
-        assert gm.player_tank.y < initial_y
+        assert first_player(gm).y < initial_y
 
     def test_ctrl_a_button_fires_bullet(self) -> None:
         """Controller A button fires a bullet."""
@@ -71,13 +72,13 @@ class TestControllerGameplay:
         gm = GameManager()
         gm._reset_game()
         gm.state = GameState.RUNNING
-        initial_y = gm.player_tank.y
+        initial_y = first_player(gm).y
 
         key_event = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_UP)
         _send_event(gm, key_event)
         gm.update()
 
-        assert gm.player_tank.y < initial_y
+        assert first_player(gm).y < initial_y
 
 
 class TestControllerMenuNavigation:

--- a/tests/integration/test_effect_integration.py
+++ b/tests/integration/test_effect_integration.py
@@ -6,6 +6,7 @@ plays through frames over multiple updates, and is cleaned up.
 
 from src.core.tile import TileType
 from src.utils.constants import EffectType, FPS
+from tests.integration.conftest import first_player
 
 
 class TestEffectLifecycle:
@@ -27,7 +28,7 @@ class TestEffectLifecycle:
         target = steel_tiles[0]
 
         # Position player near the target and shoot toward it
-        player = gm.player_tank
+        player = first_player(gm)
         player.x = float(target.rect.centerx)
         player.y = float(target.rect.bottom + 10)
         player.rect.topleft = (round(player.x), round(player.y))

--- a/tests/integration/test_enemy_integration.py
+++ b/tests/integration/test_enemy_integration.py
@@ -11,6 +11,7 @@ from src.utils.constants import (
 )
 from src.core.tile import Tile, TileType
 from src.core.enemy_tank import EnemyTank
+from tests.integration.conftest import first_player
 import random
 
 
@@ -145,7 +146,7 @@ def test_enemy_spawning_rules(game_manager_fixture):
     # Attempt to spawn one more enemy beyond the limit
     logger.info("Attempting to spawn beyond max limit...")
     spawn_success = game_manager.spawn_manager.spawn_enemy(
-        game_manager.player_tank, game_manager.map
+        first_player(game_manager), game_manager.map
     )
 
     # Assert counts did NOT change and spawn failed
@@ -164,7 +165,7 @@ def test_enemy_spawning_rules(game_manager_fixture):
 def test_enemy_spawn_blocked(game_manager_fixture):
     """Test that enemies do not spawn on a blocked spawn point."""
     game_manager = game_manager_fixture
-    player_tank = game_manager.player_tank
+    player_tank = first_player(game_manager)
 
     spawn_points_grid = game_manager.spawn_manager.spawn_points
     spawn_points_pixels = [

--- a/tests/integration/test_gamestate_integration.py
+++ b/tests/integration/test_gamestate_integration.py
@@ -13,6 +13,7 @@ from src.utils.constants import (
 from src.states.game_state import GameState
 from src.core.bullet import Bullet
 from src.core.tile import Tile, TileType
+from tests.integration.conftest import first_player
 from src.core.enemy_tank import EnemyTank
 
 # Tests related to game state transitions and initial state verification
@@ -29,9 +30,9 @@ def test_initial_game_state(game_manager_fixture):
 
     # 2. Verify initial player lives
     expected_initial_lives = 3  # Assuming PlayerTank defaults to 3
-    assert game_manager.player_tank.lives == expected_initial_lives, (
+    assert first_player(game_manager).lives == expected_initial_lives, (
         f"Expected initial player lives {expected_initial_lives}, "
-        f"got {game_manager.player_tank.lives}"
+        f"got {first_player(game_manager).lives}"
     )
 
     # 3. Verify initial number of enemies (may be pending spawn animation)
@@ -74,7 +75,7 @@ def test_player_game_over_on_zero_lives():
     # Use a fresh instance as we are mocking methods
     game_manager = GameManager()
     game_manager._reset_game()
-    player_tank = game_manager.player_tank
+    player_tank = first_player(game_manager)
     # collision_manager variable removed as it wasn't used
 
     # Ensure the player starts with at least 1 life for the test
@@ -134,7 +135,7 @@ def test_player_game_over_on_zero_lives():
 def test_player_bullet_hits_base(game_manager_fixture):
     """Test that a player bullet hitting the base destroys it and causes game over."""
     game_manager = game_manager_fixture
-    player_tank = game_manager.player_tank
+    player_tank = first_player(game_manager)
     game_map = game_manager.map
 
     # Find the base tile
@@ -174,7 +175,7 @@ def test_player_bullet_hits_base(game_manager_fixture):
     player_tank.direction = Direction.DOWN  # Aim down towards base
     bullet = player_tank.shoot()
     assert bullet is not None, "Player bullet failed to spawn."
-    game_manager.player_manager.add_bullet(bullet)
+    game_manager.player_manager._bullets.append(bullet)
     assert bullet.active, "Player bullet spawned inactive."
 
     # Assert initial game state is RUNNING
@@ -279,8 +280,8 @@ def test_enemy_bullet_destroys_base_game_over(game_manager_fixture):
     enemy_tank.direction = Direction.DOWN  # Aim at base
     game_manager.spawn_manager.enemy_tanks = [enemy_tank]  # Replace default enemies
     # Move player out of the bullet path
-    game_manager.player_tank.set_position(0, 0)
-    game_manager.player_tank.rect.topleft = (0, 0)
+    first_player(game_manager).set_position(0, 0)
+    first_player(game_manager).rect.topleft = (0, 0)
     logger.debug(
         f"Manually added {enemy_type} enemy at ({enemy_x_grid}, {enemy_y_grid}) "
         f"aiming {enemy_tank.direction}"
@@ -379,7 +380,7 @@ def test_victory_condition(game_manager_fixture):
 def test_score_accumulates_on_enemy_kill(game_manager_fixture):
     """Test that score increases when the player destroys an enemy."""
     gm = game_manager_fixture
-    assert gm.score == 0
+    assert gm.player_manager.score == 0
 
     # Wait for initial spawn animation to complete
     for _ in range(60):
@@ -392,7 +393,7 @@ def test_score_accumulates_on_enemy_kill(game_manager_fixture):
     expected_points = ENEMY_POINTS.get(tank_type, 0)
 
     # Position player near the enemy and shoot at it
-    player = gm.player_tank
+    player = first_player(gm)
     player.x = float(enemy.x)
     player.y = float(enemy.y + TILE_SIZE + 10)
     player.rect.topleft = (round(player.x), round(player.y))
@@ -401,7 +402,7 @@ def test_score_accumulates_on_enemy_kill(game_manager_fixture):
     # Fire a bullet via PlayerManager
     bullet = player.shoot()
     assert bullet is not None
-    gm.player_manager.add_bullet(bullet)
+    gm.player_manager._bullets.append(bullet)
 
     # Clear other enemies to avoid interference
     gm.spawn_manager.enemy_tanks = [enemy]
@@ -418,7 +419,7 @@ def test_score_accumulates_on_enemy_kill(game_manager_fixture):
         if enemy not in gm.spawn_manager.enemy_tanks:
             break
 
-    assert gm.score == expected_points, (
+    assert gm.player_manager.score == expected_points, (
         f"Expected score {expected_points} after killing {tank_type} enemy, "
-        f"got {gm.score}"
+        f"got {gm.player_manager.score}"
     )

--- a/tests/integration/test_ice_slide.py
+++ b/tests/integration/test_ice_slide.py
@@ -12,6 +12,7 @@ from src.utils.constants import (
     ICE_SLIDE_DISTANCE,
     SUB_TILE_SIZE,
 )
+from tests.integration.conftest import first_player
 
 _DIRECTION_TO_KEY = {direction: key for key, direction in KEY_TO_DIRECTION.items()}
 
@@ -27,11 +28,11 @@ def _place_ice_patch(game, grid_x, grid_y, width=4, height=4):
 
 def _move_player_to(game, px, py):
     """Teleport the player tank to a pixel position."""
-    game.player_tank.x = float(px)
-    game.player_tank.y = float(py)
-    game.player_tank.prev_x = float(px)
-    game.player_tank.prev_y = float(py)
-    game.player_tank.rect.topleft = (round(px), round(py))
+    first_player(game).x = float(px)
+    first_player(game).y = float(py)
+    first_player(game).prev_x = float(px)
+    first_player(game).prev_y = float(py)
+    first_player(game).rect.topleft = (round(px), round(py))
 
 
 def _set_input(game, direction):
@@ -75,7 +76,7 @@ class TestPlayerIceSlide:
         _place_ice_patch(game, 4, 4, width=8, height=8)
         # Move player to center of ice patch (pixel coords)
         _move_player_to(game, 6 * SUB_TILE_SIZE, 6 * SUB_TILE_SIZE)
-        game.player_tank.direction = Direction.UP
+        first_player(game).direction = Direction.UP
         return game
 
     def test_slide_on_key_release(self, ice_game):
@@ -85,17 +86,17 @@ class TestPlayerIceSlide:
         # Move UP for a few frames
         _set_input(game, Direction.UP)
         _tick(game, 5)
-        assert game.player_tank.direction == Direction.UP
+        assert first_player(game).direction == Direction.UP
 
         # Release keys — should start sliding UP
         _clear_input(game)
         _tick(game, 1)  # triggers slide
-        assert game.player_tank.is_sliding is True
-        assert game.player_tank._slide_direction == Direction.UP
+        assert first_player(game).is_sliding is True
+        assert first_player(game)._slide_direction == Direction.UP
 
-        pos_before = game.player_tank.y
+        pos_before = first_player(game).y
         _tick(game, 1)  # first frame of slide movement
-        assert game.player_tank.y < pos_before, "Tank should slide UP (decreasing y)"
+        assert first_player(game).y < pos_before, "Tank should slide UP (decreasing y)"
 
     def test_slide_on_perpendicular_direction_change(self, ice_game):
         """Player slides in old direction when changing to perpendicular."""
@@ -108,16 +109,16 @@ class TestPlayerIceSlide:
         # Now press LEFT (perpendicular) — should slide UP first
         _set_input(game, Direction.LEFT)
         _tick(game, 1)  # triggers slide
-        assert game.player_tank.is_sliding is True, (
+        assert first_player(game).is_sliding is True, (
             "Tank should start sliding on perpendicular direction change"
         )
-        assert game.player_tank._slide_direction == Direction.UP, (
+        assert first_player(game)._slide_direction == Direction.UP, (
             "Slide should be in the OLD direction (UP)"
         )
 
-        pos_before_y = game.player_tank.y
+        pos_before_y = first_player(game).y
         _tick(game, 1)  # first frame of slide movement
-        assert game.player_tank.y < pos_before_y, (
+        assert first_player(game).y < pos_before_y, (
             "Tank should continue moving UP during slide"
         )
 
@@ -126,22 +127,22 @@ class TestPlayerIceSlide:
         game = ice_game
 
         # Move RIGHT for a few frames
-        game.player_tank.direction = Direction.RIGHT
+        first_player(game).direction = Direction.RIGHT
         _set_input(game, Direction.RIGHT)
         _tick(game, 5)
 
         # Release — trigger slide, then capture position
         _clear_input(game)
         _tick(game, 1)  # triggers slide
-        pos_before = game.player_tank.x
+        pos_before = first_player(game).x
 
         # Let slide complete
         for _ in range(120):
             _tick(game, 1)
-            if not game.player_tank.is_sliding:
+            if not first_player(game).is_sliding:
                 break
 
-        distance = game.player_tank.x - pos_before
+        distance = first_player(game).x - pos_before
         assert abs(distance - ICE_SLIDE_DISTANCE) < 2.0, (
             f"Slide distance {distance:.1f} should be ~{ICE_SLIDE_DISTANCE}"
         )
@@ -154,15 +155,15 @@ class TestPlayerIceSlide:
         _clear_input(game)
         _tick(game, 1)
 
-        assert game.player_tank.is_sliding is False
+        assert first_player(game).is_sliding is False
 
     def test_slide_cancelled_by_wall(self, ice_game):
         """Slide stops when tank hits a wall/obstacle."""
         game = ice_game
 
         # Place a brick wall 1 tile to the right of player
-        px = game.player_tank.x
-        py = game.player_tank.y
+        px = first_player(game).x
+        py = first_player(game).y
         wall_grid_x = int(px // SUB_TILE_SIZE) + 2
         wall_grid_y = int(py // SUB_TILE_SIZE)
         for dy in range(2):
@@ -171,7 +172,7 @@ class TestPlayerIceSlide:
                 game.map.set_tile_type(tile, TileType.BRICK)
 
         # Move RIGHT then release to slide into wall
-        game.player_tank.direction = Direction.RIGHT
+        first_player(game).direction = Direction.RIGHT
         _set_input(game, Direction.RIGHT)
         _tick(game, 3)
         _clear_input(game)
@@ -179,10 +180,12 @@ class TestPlayerIceSlide:
         # Tick until slide ends
         for _ in range(60):
             _tick(game, 1)
-            if not game.player_tank.is_sliding:
+            if not first_player(game).is_sliding:
                 break
 
-        assert game.player_tank.is_sliding is False, "Slide should have been cancelled"
+        assert first_player(game).is_sliding is False, (
+            "Slide should have been cancelled"
+        )
 
     def test_slide_on_opposite_direction(self, ice_game):
         """Player slides when pressing opposite direction on ice."""
@@ -195,10 +198,10 @@ class TestPlayerIceSlide:
         # Press DOWN (opposite) — direction change triggers slide
         _set_input(game, Direction.DOWN)
         _tick(game, 1)  # triggers slide
-        assert game.player_tank.is_sliding is True, (
+        assert first_player(game).is_sliding is True, (
             "Tank should slide when pressing opposite direction"
         )
 
-        pos_before = game.player_tank.y
+        pos_before = first_player(game).y
         _tick(game, 1)  # first frame of slide movement
-        assert game.player_tank.y < pos_before, "Tank should continue sliding UP"
+        assert first_player(game).y < pos_before, "Tank should continue sliding UP"

--- a/tests/integration/test_player_integration.py
+++ b/tests/integration/test_player_integration.py
@@ -10,6 +10,7 @@ from src.utils.constants import (
     BULLET_HEIGHT,
 )
 from src.core.tile import Tile, TileType
+from tests.integration.conftest import first_player
 
 # Tests related to player actions: movement, shooting, respawn
 
@@ -28,7 +29,7 @@ def test_player_movement(key, axis, direction_sign, expected_direction):
     # Use fresh instance to avoid side effects from other tests
     game_manager = GameManager()
     game_manager._reset_game()
-    player_tank = game_manager.player_tank
+    player_tank = first_player(game_manager)
     game_map = game_manager.map
 
     # Manually set position to an open space (sub-tile grid 16, 16)
@@ -120,7 +121,7 @@ def test_player_movement_blocked_by_tile(
 ):
     """Test player tank movement is blocked by specific tile types."""
     game_manager = game_manager_fixture
-    player_tank = game_manager.player_tank
+    player_tank = first_player(game_manager)
     game_map = game_manager.map
 
     # Define target tile location (sub-tile grid coords)
@@ -274,7 +275,7 @@ def test_player_shooting():
     # Use fresh instance
     game_manager = GameManager()
     game_manager._reset_game()
-    player_tank = game_manager.player_tank
+    player_tank = first_player(game_manager)
 
     # 1. Initial state: No bullets
     assert len(game_manager.bullets) == 0, "No bullets should exist initially."
@@ -325,7 +326,7 @@ def test_player_bullet_movement(direction_str, axis_index, direction_sign):
     # Use fresh instance
     game_manager = GameManager()
     game_manager._reset_game()
-    player_tank = game_manager.player_tank
+    player_tank = first_player(game_manager)
 
     # Set tank direction and fire
     player_tank.direction = direction_str
@@ -376,7 +377,7 @@ def test_player_respawn():
     # Use fresh instance
     game_manager = GameManager()
     game_manager._reset_game()
-    player_tank = game_manager.player_tank
+    player_tank = first_player(game_manager)
 
     initial_lives = player_tank.lives
     initial_health = player_tank.health

--- a/tests/integration/test_power_up_effects.py
+++ b/tests/integration/test_power_up_effects.py
@@ -11,7 +11,7 @@ from src.utils.constants import (
     PowerUpType,
 )
 from src.core.tile import TileType
-from tests.integration.conftest import flush_pending_spawns, spawn_carrier
+from tests.integration.conftest import first_player, flush_pending_spawns, spawn_carrier
 
 
 class TestPowerUpEffectsIntegration:
@@ -25,27 +25,29 @@ class TestPowerUpEffectsIntegration:
         carrier.health = 0
         game.spawn_manager.remove_enemy(carrier)
         game.power_up_manager.spawn_power_up(
-            game.player_tank,
+            first_player(game),
             game.spawn_manager.enemy_tanks,
             power_up_type=power_up_type,
         )
         assert len(game.power_up_manager.active_power_ups) == 1
         # Move player to power-up location to trigger collision
         pu = game.power_up_manager.active_power_ups[0]
-        game.player_tank.set_position(pu.x, pu.y)
-        game.player_tank.rect.topleft = (round(pu.x), round(pu.y))
+        first_player(game).set_position(pu.x, pu.y)
+        first_player(game).rect.topleft = (round(pu.x), round(pu.y))
 
     def test_helmet_effect(self, game):
         self._collect_power_up(game, PowerUpType.HELMET)
         game.update()
-        assert game.player_tank.is_invincible is True
-        assert game.player_tank.invincibility_duration == HELMET_INVINCIBILITY_DURATION
+        assert first_player(game).is_invincible is True
+        assert (
+            first_player(game).invincibility_duration == HELMET_INVINCIBILITY_DURATION
+        )
 
     def test_extra_life_effect(self, game):
-        lives_before = game.player_tank.lives
+        lives_before = first_player(game).lives
         self._collect_power_up(game, PowerUpType.EXTRA_LIFE)
         game.update()
-        assert game.player_tank.lives == lives_before + 1
+        assert first_player(game).lives == lives_before + 1
 
     def test_bomb_effect(self, game):
         flush_pending_spawns(game)
@@ -74,6 +76,6 @@ class TestRemainingPowerUpEffects:
 
     def test_star_effect(self, game):
         game._apply_power_up(PowerUpType.STAR)
-        assert game.player_tank.star_level == 1
+        assert first_player(game).star_level == 1
         expected_speed = BULLET_SPEED * STAR_BULLET_SPEED_MULTIPLIER
-        assert game.player_tank.bullet_speed == expected_speed
+        assert first_player(game).bullet_speed == expected_speed

--- a/tests/integration/test_power_up_system.py
+++ b/tests/integration/test_power_up_system.py
@@ -5,7 +5,7 @@ Uses real objects (no mocks) with SDL_VIDEODRIVER=dummy for headless execution.
 
 import pytest
 from src.utils.constants import POWERUP_TIMEOUT
-from tests.integration.conftest import spawn_carrier
+from tests.integration.conftest import first_player, spawn_carrier
 
 
 class TestPowerUpIntegration:
@@ -28,7 +28,7 @@ class TestPowerUpIntegration:
         carrier.health = 0
         game.spawn_manager.remove_enemy(carrier)
         game.power_up_manager.spawn_power_up(
-            game.player_tank, game.spawn_manager.enemy_tanks
+            first_player(game), game.spawn_manager.enemy_tanks
         )
         assert len(game.power_up_manager.active_power_ups) == 1
 
@@ -37,7 +37,7 @@ class TestPowerUpIntegration:
         carrier.health = 0
         game.spawn_manager.remove_enemy(carrier)
         game.power_up_manager.spawn_power_up(
-            game.player_tank, game.spawn_manager.enemy_tanks
+            first_player(game), game.spawn_manager.enemy_tanks
         )
         game.power_up_manager.update(POWERUP_TIMEOUT + 0.1)
         assert len(game.power_up_manager.active_power_ups) == 0
@@ -47,9 +47,9 @@ class TestPowerUpIntegration:
         carrier.health = 0
         game.spawn_manager.remove_enemy(carrier)
         game.power_up_manager.spawn_power_up(
-            game.player_tank, game.spawn_manager.enemy_tanks
+            first_player(game), game.spawn_manager.enemy_tanks
         )
         game.power_up_manager.spawn_power_up(
-            game.player_tank, game.spawn_manager.enemy_tanks
+            first_player(game), game.spawn_manager.enemy_tanks
         )
         assert len(game.power_up_manager.active_power_ups) == 2

--- a/tests/integration/test_shield_integration.py
+++ b/tests/integration/test_shield_integration.py
@@ -4,34 +4,35 @@ from src.utils.constants import (
     FPS,
     SHIELD_FAST_FLICKER_INTERVAL,
 )
+from tests.integration.conftest import first_player
 
 
 class TestShieldIntegration:
     def test_shield_active_after_spawn(self, game_manager_fixture):
         """Player tank has shield active after game start (spawn invincibility)."""
         gm = game_manager_fixture
-        assert gm.player_tank.is_invincible
-        assert gm.player_tank.is_invincible
+        assert first_player(gm).is_invincible
+        assert first_player(gm).is_invincible
 
     def test_shield_stays_active_during_warning_phase(self, game_manager_fixture):
         """Shield remains active in warning phase but flickers faster."""
         gm = game_manager_fixture
         # 3s duration, at 1.5s elapsed → 1.5s remaining (in warning phase)
-        gm.player_tank.invincibility_timer = 1.5
-        assert gm.player_tank.is_invincible is True
-        assert gm.player_tank.shield_flicker_interval == SHIELD_FAST_FLICKER_INTERVAL
+        first_player(gm).invincibility_timer = 1.5
+        assert first_player(gm).is_invincible is True
+        assert first_player(gm).shield_flicker_interval == SHIELD_FAST_FLICKER_INTERVAL
 
     def test_draw_with_shield_does_not_raise(self, game_manager_fixture):
         """Verify draw() works during shield phase."""
         gm = game_manager_fixture
-        assert gm.player_tank.is_invincible
+        assert first_player(gm).is_invincible
         for _ in range(5):
             gm.update()
 
     def test_shield_deactivates_when_invincibility_expires(self, game_manager_fixture):
         """Shield gone after invincibility expires."""
         gm = game_manager_fixture
-        gm.player_tank.invincibility_timer = 4.0  # past 3s duration
-        gm.player_tank.update(1.0 / FPS)
-        assert not gm.player_tank.is_invincible
-        assert not gm.player_tank.is_invincible
+        first_player(gm).invincibility_timer = 4.0  # past 3s duration
+        first_player(gm).update(1.0 / FPS)
+        assert not first_player(gm).is_invincible
+        assert not first_player(gm).is_invincible

--- a/tests/integration/test_sound_integration.py
+++ b/tests/integration/test_sound_integration.py
@@ -2,6 +2,7 @@
 
 from src.states.game_state import GameState
 from src.utils.constants import FPS
+from tests.integration.conftest import first_player
 
 
 class TestEngineSoundWiring:
@@ -19,17 +20,17 @@ class TestEngineSoundWiring:
         """Verify player tank reports is_moving after move()."""
         gm = game_manager_fixture
         dt = 1.0 / FPS
-        gm.player_tank.move(1, 0, dt)
-        assert gm.player_tank.is_moving is True
+        first_player(gm).move(1, 0, dt)
+        assert first_player(gm).is_moving is True
 
     def test_player_is_moving_resets_after_update(self, game_manager_fixture):
         """Verify is_moving resets to False after tank.update()."""
         gm = game_manager_fixture
         dt = 1.0 / FPS
-        gm.player_tank.move(1, 0, dt)
-        assert gm.player_tank.is_moving is True
-        gm.player_tank.update(dt)
-        assert gm.player_tank.is_moving is False
+        first_player(gm).move(1, 0, dt)
+        assert first_player(gm).is_moving is True
+        first_player(gm).update(dt)
+        assert first_player(gm).is_moving is False
 
 
 class TestVictoryTransition:
@@ -71,7 +72,9 @@ class TestPowerupBlinkWiring:
         """Verify update() doesn't error when powerups are active."""
         gm = game_manager_fixture
         # Spawn a powerup directly
-        gm.power_up_manager.spawn_power_up(gm.player_tank, gm.spawn_manager.enemy_tanks)
+        gm.power_up_manager.spawn_power_up(
+            first_player(gm), gm.spawn_manager.enemy_tanks
+        )
         assert len(gm.power_up_manager.get_power_ups()) > 0
         # Run a frame — should not raise
         gm.update()


### PR DESCRIPTION
Closes #167. Also closes #161 — the test-only-surface item was the last outstanding piece from that bundle.

## Summary
\`GameManager.player_tank\`, \`GameManager.score\`, and \`PlayerManager.add_bullet\` existed only for integration-test convenience. This PR removes them and migrates the tests.

- Added \`first_player(game)\` helper to \`tests/integration/conftest.py\` — wraps \`game.player_manager.get_active_players()[0]\`. Concentrates the \"player 1 is the interesting player\" assumption in one test-side spot.
- Replaced 83 call sites of \`<obj>.player_tank\` with \`first_player(<obj>)\` across 11 integration test files.
- Replaced 4 \`.add_bullet(b)\` calls with direct \`._bullets.append(b)\`.
- Replaced 3 \`gm.score\` reads with \`gm.player_manager.score\`.
- Deleted the three members from \`GameManager\` / \`PlayerManager\`.

Net: −2 lines overall (production shrinks, tests grow by one import + a wrapper each), but the production surface no longer grows just to serve tests.

## Test plan
- [x] \`pytest\` — 877 passed
- [x] \`ruff check\` / \`ruff format --check\` clean for touched files