### PR TITLE
perf(tests): drop per-fixture pygame.init/quit and hoist GameManager fixtures

### DIFF
--- a/tests/unit/core/test_bullet.py
+++ b/tests/unit/core/test_bullet.py
@@ -17,7 +17,6 @@ class TestBullet:
     @pytest.fixture
     def bullet(self):
         """Create a bullet instance for testing."""
-        pygame.init()
         mock_owner = MagicMock()
         mock_owner.owner_type = "test"
         mock_owner.map_width_px = 16 * TILE_SIZE

--- a/tests/unit/managers/conftest.py
+++ b/tests/unit/managers/conftest.py
@@ -1,8 +1,65 @@
 import pytest
 import pygame
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+from src.managers.game_manager import GameManager
 from src.managers.texture_manager import TextureManager
 from src.utils.paths import resource_path
+
+
+@pytest.fixture
+def _mock_game_deps():
+    """Mock every external dependency GameManager pulls in at __init__.
+
+    Used by the `game_manager` / `game_manager_at_title` fixtures below.
+    Classes that construct GameManager differently (e.g. the curtain
+    and powerups tests) build their own instances and do not depend on
+    this fixture.
+    """
+    with (
+        patch("pygame.display.set_mode"),
+        patch("pygame.font.SysFont"),
+        patch("src.managers.game_manager.TextureManager") as MockTM,
+        patch("src.managers.game_manager.EffectManager"),
+        patch("src.managers.game_manager.Renderer"),
+        patch("src.managers.game_manager.SpawnManager"),
+        patch("src.managers.game_manager.Map") as MockMap,
+        patch("src.managers.game_manager.SettingsManager") as MockSM,
+        patch("src.managers.game_manager.PlayerManager") as MockPM,
+    ):
+        mock_tm_instance = MockTM.return_value
+        mock_tm_instance.get_sprite.return_value = MagicMock(spec=pygame.Surface)
+        mock_sm_instance = MockSM.return_value
+        mock_sm_instance.master_volume = 1.0
+        mock_map_instance = MockMap.return_value
+        mock_map_instance.width = 16
+        mock_map_instance.height = 16
+        mock_map_instance.player_spawn = (4, 12)
+        mock_map_instance.spawn_points = [(3, 1), (8, 1), (12, 1)]
+        mock_pm_instance = MockPM.return_value
+        mock_player = MagicMock()
+        mock_player.lives = 3
+        mock_player.health = 1
+        mock_player.x = 128
+        mock_player.y = 384
+        mock_player.is_moving = False
+        mock_pm_instance.get_active_players.return_value = [mock_player]
+        mock_pm_instance.score = 0
+        mock_pm_instance.get_all_bullets.return_value = []
+        yield
+
+
+@pytest.fixture
+def game_manager(_mock_game_deps):
+    """GameManager with game started (past title screen)."""
+    manager = GameManager()
+    manager._reset_game()
+    return manager
+
+
+@pytest.fixture
+def game_manager_at_title(_mock_game_deps):
+    """GameManager at the title screen (no _reset_game)."""
+    return GameManager()
 
 
 @pytest.fixture

--- a/tests/unit/managers/test_game_manager.py
+++ b/tests/unit/managers/test_game_manager.py
@@ -1,7 +1,6 @@
 import pytest
 import pygame
 from unittest.mock import patch, MagicMock
-from src.managers.game_manager import GameManager
 from src.states.game_state import GameState
 from src.core.enemy_tank import EnemyTank
 from src.utils.constants import (
@@ -15,58 +14,6 @@ from src.utils.constants import (
 
 class TestGameManager:
     """Unit test cases for the GameManager class."""
-
-    @pytest.fixture
-    def _mock_game_deps(self):
-        """Shared mock setup for GameManager fixtures."""
-        with (
-            patch("pygame.display.set_mode"),
-            patch("pygame.font.SysFont"),
-            patch("src.managers.game_manager.TextureManager") as MockTM,
-            patch("src.managers.game_manager.EffectManager"),
-            patch("src.managers.game_manager.Renderer"),
-            patch("src.managers.game_manager.SpawnManager"),
-            patch("src.managers.game_manager.Map") as MockMap,
-            patch("src.managers.game_manager.SettingsManager") as MockSM,
-            patch("src.managers.game_manager.PlayerManager") as MockPM,
-        ):
-            mock_tm_instance = MockTM.return_value
-            mock_tm_instance.get_sprite.return_value = MagicMock(spec=pygame.Surface)
-            mock_sm_instance = MockSM.return_value
-            mock_sm_instance.master_volume = 1.0
-            mock_map_instance = MockMap.return_value
-            mock_map_instance.width = 16
-            mock_map_instance.height = 16
-            mock_map_instance.player_spawn = (4, 12)
-            mock_map_instance.spawn_points = [(3, 1), (8, 1), (12, 1)]
-            mock_pm_instance = MockPM.return_value
-            mock_player = MagicMock()
-            mock_player.lives = 3
-            mock_player.health = 1
-            mock_player.x = 128
-            mock_player.y = 384
-            mock_player.is_moving = False
-            mock_pm_instance.get_active_players.return_value = [mock_player]
-            mock_pm_instance.score = 0
-            mock_pm_instance.get_all_bullets.return_value = []
-            yield
-
-    @pytest.fixture
-    def game_manager(self, _mock_game_deps):
-        """Create a GameManager with game started (past title screen)."""
-        pygame.init()
-        manager = GameManager()
-        manager._reset_game()
-        yield manager
-        pygame.quit()
-
-    @pytest.fixture
-    def game_manager_at_title(self, _mock_game_deps):
-        """Create a GameManager at the title screen (no _reset_game)."""
-        pygame.init()
-        manager = GameManager()
-        yield manager
-        pygame.quit()
 
     def test_initialization_starts_at_title_screen(self, game_manager_at_title):
         """Test that GameManager starts at the title screen."""
@@ -269,58 +216,6 @@ class TestGameManager:
 
 class TestGameManagerSoundWiring:
     @pytest.fixture
-    def _mock_game_deps(self):
-        """Shared mock setup for GameManager fixtures."""
-        with (
-            patch("pygame.display.set_mode"),
-            patch("pygame.font.SysFont"),
-            patch("src.managers.game_manager.TextureManager") as MockTM,
-            patch("src.managers.game_manager.EffectManager"),
-            patch("src.managers.game_manager.Renderer"),
-            patch("src.managers.game_manager.SpawnManager"),
-            patch("src.managers.game_manager.Map") as MockMap,
-            patch("src.managers.game_manager.SettingsManager") as MockSM,
-            patch("src.managers.game_manager.PlayerManager") as MockPM,
-        ):
-            mock_tm_instance = MockTM.return_value
-            mock_tm_instance.get_sprite.return_value = MagicMock(spec=pygame.Surface)
-            mock_sm_instance = MockSM.return_value
-            mock_sm_instance.master_volume = 1.0
-            mock_map_instance = MockMap.return_value
-            mock_map_instance.width = 16
-            mock_map_instance.height = 16
-            mock_map_instance.player_spawn = (4, 12)
-            mock_map_instance.spawn_points = [(3, 1), (8, 1), (12, 1)]
-            mock_pm_instance = MockPM.return_value
-            mock_player = MagicMock()
-            mock_player.lives = 3
-            mock_player.health = 1
-            mock_player.x = 128
-            mock_player.y = 384
-            mock_player.is_moving = False
-            mock_pm_instance.get_active_players.return_value = [mock_player]
-            mock_pm_instance.score = 0
-            mock_pm_instance.get_all_bullets.return_value = []
-            yield
-
-    @pytest.fixture
-    def game_manager(self, _mock_game_deps):
-        """Create a GameManager with game started (past title screen)."""
-        pygame.init()
-        manager = GameManager()
-        manager._reset_game()
-        yield manager
-        pygame.quit()
-
-    @pytest.fixture
-    def game_manager_at_title(self, _mock_game_deps):
-        """Create a GameManager at the title screen (no _reset_game)."""
-        pygame.init()
-        manager = GameManager()
-        yield manager
-        pygame.quit()
-
-    @pytest.fixture
     def gm_with_mock_sound(self, game_manager):
         """GameManager with SoundManager replaced by a mock."""
         game_manager.sound_manager = MagicMock()
@@ -356,50 +251,6 @@ class TestGameManagerSoundWiring:
 
 
 class TestStageProgression:
-    @pytest.fixture
-    def _mock_game_deps(self):
-        """Shared mock setup for GameManager fixtures."""
-        with (
-            patch("pygame.display.set_mode"),
-            patch("pygame.font.SysFont"),
-            patch("src.managers.game_manager.TextureManager") as MockTM,
-            patch("src.managers.game_manager.EffectManager"),
-            patch("src.managers.game_manager.Renderer"),
-            patch("src.managers.game_manager.SpawnManager"),
-            patch("src.managers.game_manager.Map") as MockMap,
-            patch("src.managers.game_manager.SettingsManager") as MockSM,
-            patch("src.managers.game_manager.PlayerManager") as MockPM,
-        ):
-            mock_tm_instance = MockTM.return_value
-            mock_tm_instance.get_sprite.return_value = MagicMock(spec=pygame.Surface)
-            mock_sm_instance = MockSM.return_value
-            mock_sm_instance.master_volume = 1.0
-            mock_map_instance = MockMap.return_value
-            mock_map_instance.width = 16
-            mock_map_instance.height = 16
-            mock_map_instance.player_spawn = (4, 12)
-            mock_map_instance.spawn_points = [(3, 1), (8, 1), (12, 1)]
-            mock_pm_instance = MockPM.return_value
-            mock_player = MagicMock()
-            mock_player.lives = 3
-            mock_player.health = 1
-            mock_player.x = 128
-            mock_player.y = 384
-            mock_player.is_moving = False
-            mock_pm_instance.get_active_players.return_value = [mock_player]
-            mock_pm_instance.score = 0
-            mock_pm_instance.get_all_bullets.return_value = []
-            yield
-
-    @pytest.fixture
-    def game_manager(self, _mock_game_deps):
-        """Create a GameManager with game started (past title screen)."""
-        pygame.init()
-        manager = GameManager()
-        manager._reset_game()
-        yield manager
-        pygame.quit()
-
     def test_load_stage_uses_current_stage_for_map_name(self, game_manager):
         game_manager.current_stage = 5
         with patch("src.managers.game_manager.os.path.exists", return_value=True):
@@ -452,55 +303,6 @@ class TestStageProgression:
 
 class TestPauseAndOptionsStateMachine:
     """Tests for PAUSED and OPTIONS_MENU state transitions."""
-
-    @pytest.fixture
-    def _mock_game_deps(self):
-        with (
-            patch("pygame.display.set_mode"),
-            patch("pygame.font.SysFont"),
-            patch("src.managers.game_manager.TextureManager") as MockTM,
-            patch("src.managers.game_manager.EffectManager"),
-            patch("src.managers.game_manager.Renderer"),
-            patch("src.managers.game_manager.SpawnManager"),
-            patch("src.managers.game_manager.Map") as MockMap,
-            patch("src.managers.game_manager.SettingsManager") as MockSM,
-            patch("src.managers.game_manager.PlayerManager") as MockPM,
-        ):
-            mock_tm_instance = MockTM.return_value
-            mock_tm_instance.get_sprite.return_value = MagicMock(spec=pygame.Surface)
-            mock_sm_instance = MockSM.return_value
-            mock_sm_instance.master_volume = 1.0
-            mock_map_instance = MockMap.return_value
-            mock_map_instance.width = 16
-            mock_map_instance.height = 16
-            mock_map_instance.player_spawn = (4, 12)
-            mock_map_instance.spawn_points = [(3, 1), (8, 1), (12, 1)]
-            mock_pm_instance = MockPM.return_value
-            mock_player = MagicMock()
-            mock_player.lives = 3
-            mock_player.health = 1
-            mock_player.x = 128
-            mock_player.y = 384
-            mock_player.is_moving = False
-            mock_pm_instance.get_active_players.return_value = [mock_player]
-            mock_pm_instance.score = 0
-            mock_pm_instance.get_all_bullets.return_value = []
-            yield
-
-    @pytest.fixture
-    def game_manager(self, _mock_game_deps):
-        pygame.init()
-        manager = GameManager()
-        manager._reset_game()
-        yield manager
-        pygame.quit()
-
-    @pytest.fixture
-    def game_manager_at_title(self, _mock_game_deps):
-        pygame.init()
-        manager = GameManager()
-        yield manager
-        pygame.quit()
 
     # --- ESC state transitions ---
 

--- a/tests/unit/managers/test_game_manager_curtain.py
+++ b/tests/unit/managers/test_game_manager_curtain.py
@@ -16,8 +16,6 @@ from src.utils.constants import (
 class TestNewGameAndLoadStage:
     @pytest.fixture
     def game(self):
-        pygame.init()
-        pygame.display.set_mode((1, 1), pygame.NOFRAME)
         gm = GameManager()
         gm._new_game()
         return gm
@@ -50,8 +48,6 @@ class TestNewGameAndLoadStage:
 class TestCurtainTransitions:
     @pytest.fixture
     def game(self):
-        pygame.init()
-        pygame.display.set_mode((1, 1), pygame.NOFRAME)
         gm = GameManager()
         gm._new_game()
         gm.state = GameState.RUNNING
@@ -142,8 +138,6 @@ class TestCurtainTransitions:
 class TestGameOverAnimation:
     @pytest.fixture
     def game(self):
-        pygame.init()
-        pygame.display.set_mode((1, 1), pygame.NOFRAME)
         gm = GameManager()
         gm._new_game()
         gm.state = GameState.RUNNING

--- a/tests/unit/managers/test_renderer.py
+++ b/tests/unit/managers/test_renderer.py
@@ -183,8 +183,6 @@ class TestRendererHUD:
 class TestRenderCurtain:
     @pytest.fixture
     def renderer(self):
-        pygame.init()
-        pygame.display.set_mode((1, 1), pygame.NOFRAME)
         screen = pygame.Surface((1024, 1024))
         return Renderer(screen, 512, 512, 416, 416)
 


### PR DESCRIPTION
## Summary

- The session-autouse `pygame_init` in `tests/unit/conftest.py` already initializes pygame and a 1x1 display for the whole suite. Per-test fixtures that called `pygame.quit()` on teardown were tearing down the session display, forcing every subsequent test to re-init pygame from scratch.
- Hoists the duplicated `_mock_game_deps` / `game_manager` / `game_manager_at_title` fixtures from four classes in `test_game_manager.py` into `tests/unit/managers/conftest.py`, so the nine-module mock tree lives in one place.

## Impact

| | Tests | Wall time |
|---|---|---|
| Before | 877 | 49.87s |
| After  | 877 | 5.44s |

Net: +58 / −208 lines across 5 files.

Closes #169.
Closes #170.

## Test plan

- [x] `pytest` — 877 pass
- [x] `pytest --durations=20` — no per-test setup over ~50ms (was ~0.7s for every `test_game_manager` test)
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check` on touched files — clean