### PR TITLE
polish(tests): strip narration comments and commented-out code

### DIFF
--- a/tests/unit/core/test_enemy_tank.py
+++ b/tests/unit/core/test_enemy_tank.py
@@ -42,7 +42,6 @@ EXPECTED_PROPERTIES = {
     },
 }
 
-# Test cases covering all tank types
 TEST_CASES = [(tank_type, props) for tank_type, props in EXPECTED_PROPERTIES.items()]
 
 
@@ -51,7 +50,6 @@ def test_enemy_tank_initialization_properties(
     mock_texture_manager, tank_type: TankType, expected: dict
 ):
     """Test that EnemyTank initializes with correct properties for each type."""
-    # Minimal required positional args for EnemyTank
     x, y = 0, 0
     tile_size = TILE_SIZE
 
@@ -65,23 +63,19 @@ def test_enemy_tank_initialization_properties(
         map_height_px=16 * TILE_SIZE,
     )
 
-    # Assert core properties set by the type
     assert tank.tank_type == tank_type
     assert tank.speed == pytest.approx(expected["speed"])
     assert tank.bullet_speed == pytest.approx(expected["bullet_speed"])
     assert tank.health == expected["health"]
-    assert tank.max_health == expected["health"]  # Should also be set
+    assert tank.max_health == expected["health"]
     assert tank.shoot_interval == pytest.approx(expected["shoot_interval"])
     assert tank.direction_change_interval == pytest.approx(
         expected["direction_change_interval"]
     )
 
-    # Assert other relevant properties
     assert tank.owner_type == "enemy"
-    assert tank.lives == 1  # Enemies should have 1 life
-    assert (
-        tank.x == x
-    )  # Check grid alignment effect is handled if needed (0 should be fine)
+    assert tank.lives == 1
+    assert tank.x == x
     assert tank.y == y
 
 
@@ -127,12 +121,9 @@ class TestEnemyConfigLoading:
 def test_enemy_tank_grid_alignment(mock_texture_manager):
     """Test that initial position is aligned to the grid."""
     tile_size = 32
-    # Non-aligned positions
     initial_x, initial_y = 15, 40
-    expected_x, expected_y = (
-        0 * tile_size,
-        1 * tile_size,
-    )  # round(15/32)*32=0, round(40/32)*32=32
+    # round(15/32)*32=0, round(40/32)*32=32
+    expected_x, expected_y = (0 * tile_size, 1 * tile_size)
 
     tank = EnemyTank(
         initial_x,
@@ -164,7 +155,6 @@ def test_on_movement_blocked(mock_random_choice, mock_texture_manager):
         map_height_px=16 * TILE_SIZE,
         difficulty=Difficulty.EASY,
     )
-    # Now set a known direction and mock the next choice
     tank.direction = Direction.UP
     tank.direction_timer = 1.5
 

--- a/tests/unit/core/test_player_tank.py
+++ b/tests/unit/core/test_player_tank.py
@@ -163,14 +163,12 @@ class TestPlayerTank:
     def test_respawn_syncs_rect(self, player_tank):
         """Test that respawn() updates rect to match the new position."""
         dt = 1.0 / FPS
-        # Move the tank away from its initial position
         player_tank.prev_x = player_tank.x
         player_tank.prev_y = player_tank.y
         player_tank.move(0, 1, dt)
         player_tank.move(0, 1, dt)
         moved_rect = player_tank.rect.copy()
 
-        # Respawn should reset rect to initial position
         player_tank.respawn()
 
         assert player_tank.rect.topleft == (

--- a/tests/unit/core/test_tank.py
+++ b/tests/unit/core/test_tank.py
@@ -77,20 +77,16 @@ class TestTank:
 
     def test_invincibility(self, tank):
         """Test invincibility mechanics."""
-        # Set invincibility
         tank.is_invincible = True
         tank.invincibility_duration = 3.0
 
-        # Try to take damage while invincible
         assert not tank.take_damage()
         assert tank.health == 1
         assert tank.lives == 1
 
-        # Update with time less than duration
         tank.update(1.0)
         assert tank.is_invincible
 
-        # Update with time more than duration
         tank.update(3.0)
         assert not tank.is_invincible
 
@@ -113,7 +109,6 @@ class TestTank:
         """Test continuous movement functionality."""
         dt = 1.0 / FPS
 
-        # Store previous position before moving
         tank.prev_x = tank.x
         tank.prev_y = tank.y
 
@@ -122,7 +117,6 @@ class TestTank:
         assert tank.x == pytest.approx(TANK_SPEED * dt)
         assert tank.y == 0
 
-        # Move again without any timer reset needed
         # Steering assist nudges x toward nearest grid line (0) when moving vertically
         tank.prev_x = tank.x
         tank.prev_y = tank.y
@@ -134,7 +128,6 @@ class TestTank:
         """Test edge cases for movement attempts."""
         dt = 1.0 / FPS
 
-        # Test moving with zero delta — should return False and not change state
         tank.prev_x = tank.x
         tank.prev_y = tank.y
         initial_frame = tank.animation_frame
@@ -143,11 +136,9 @@ class TestTank:
         assert tank.y == 0
         assert tank.animation_frame == initial_frame
 
-        # Test moving diagonally (should return False)
         tank.prev_x = tank.x
         tank.prev_y = tank.y
         assert not tank._move(1, 1, dt)
-        # Position should not change after failed diagonal attempt
         assert tank.x == 0
         assert tank.y == 0
 
@@ -218,10 +209,8 @@ class TestTank:
         tank = create_tank(x=max_x, y=max_y)
         tank.prev_x = tank.x
         tank.prev_y = tank.y
-        # Move right — should clamp at max_x
         tank._move(1, 0, 1.0 / FPS)
         assert tank.x <= max_x
-        # Move down — should clamp at max_y
         tank._move(0, 1, 1.0 / FPS)
         assert tank.y <= max_y
 
@@ -231,15 +220,12 @@ class TestTank:
         tank.prev_x = initial_x
         tank.prev_y = initial_y
 
-        # Simulate a move
         tank.x = initial_x + TILE_SIZE
         tank.y = initial_y
         tank.rect.topleft = (tank.x, tank.y)
 
-        # Revert the move
         tank.revert_move()
 
-        # Assert position is back to the stored previous position
         assert tank.x == initial_x
         assert tank.y == initial_y
         assert tank.rect.topleft == (initial_x, initial_y)

--- a/tests/unit/managers/test_game_manager.py
+++ b/tests/unit/managers/test_game_manager.py
@@ -77,11 +77,9 @@ class TestGameManager:
 
     def test_handle_events_quit(self, game_manager):
         """Test handling quit event sets state to EXIT."""
-        # with pytest.raises(SystemExit): # Should not raise SystemExit anymore
         event = pygame.event.Event(pygame.QUIT)
         pygame.event.post(event)
         game_manager.handle_events()
-        # Check if state is set to EXIT
         assert game_manager.state == GameState.EXIT
 
     def test_handle_events_escape_during_running_pauses(


### PR DESCRIPTION
## Summary

- Deletes comments that restate the next line in English (e.g. \`# Set invincibility\`, \`# Try to take damage\`, \`# Assert core properties\`).
- Deletes the stale commented-out \`pytest.raises(SystemExit)\` line in \`test_game_manager.py\`.
- Keeps comments that document WHY — hidden invariants (\"no timer gating\"), surprising behavior (steering assist), or reference math (\`round(15/32)*32=0\`).

Net: 4 files, +5 / −33 lines. No behavior change.

Closes #175.

## Test plan

- [x] \`pytest\` — 877 pass
- [x] \`ruff check src/ tests/\` — clean
- [x] \`ruff format --check\` on touched files — clean (one unrelated pre-existing format warning in test_player_tank.py left alone)