### PR TITLE
refactor(tests): add create_enemy_tank / create_player_tank / make_bullet factories

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,13 @@
 import pytest
 import pygame
-from unittest.mock import MagicMock
+from contextlib import nullcontext
+from unittest.mock import MagicMock, patch
+from src.core.bullet import Bullet
+from src.core.enemy_tank import EnemyTank
+from src.core.player_tank import PlayerTank
 from src.core.tank import Tank
 from src.managers.texture_manager import TextureManager
-from src.utils.constants import OwnerType, TILE_SIZE
+from src.utils.constants import Direction, OwnerType, TankType, TILE_SIZE
 
 
 @pytest.fixture
@@ -27,6 +31,77 @@ def create_tank(mock_texture_manager):
         )
         defaults.update(kwargs)
         return Tank(x, y, mock_texture_manager, **defaults)
+
+    return _create
+
+
+@pytest.fixture
+def create_enemy_tank(mock_texture_manager):
+    """Factory fixture to create EnemyTank instances with sensible defaults.
+
+    By default the EnemyTank __init__ call is wrapped in a patch that pins
+    random.choice to Direction.DOWN so test setup is deterministic. Pass
+    ``patch_random=False`` to opt out (e.g. for tests that exercise the
+    initial direction choice themselves).
+    """
+
+    def _create(x=0, y=0, tank_type=TankType.BASIC, patch_random=True, **kwargs):
+        defaults = dict(
+            tile_size=TILE_SIZE,
+            map_width_px=16 * TILE_SIZE,
+            map_height_px=16 * TILE_SIZE,
+        )
+        defaults.update(kwargs)
+        tile_size = defaults.pop("tile_size")
+        ctx = (
+            patch("src.core.enemy_tank.random.choice", return_value=Direction.DOWN)
+            if patch_random
+            else nullcontext()
+        )
+        with ctx:
+            return EnemyTank(
+                x, y, tile_size, mock_texture_manager, tank_type, **defaults
+            )
+
+    return _create
+
+
+@pytest.fixture
+def create_player_tank(mock_texture_manager):
+    """Factory fixture to create PlayerTank instances with sensible defaults."""
+
+    def _create(x=0, y=0, **kwargs):
+        defaults = dict(
+            tile_size=TILE_SIZE,
+            map_width_px=16 * TILE_SIZE,
+            map_height_px=16 * TILE_SIZE,
+        )
+        defaults.update(kwargs)
+        tile_size = defaults.pop("tile_size")
+        return PlayerTank(x, y, tile_size, mock_texture_manager, **defaults)
+
+    return _create
+
+
+@pytest.fixture
+def make_bullet():
+    """Factory fixture to build MagicMock(spec=Bullet) with sensible defaults.
+
+    Keyword overrides set attributes on the mock, so callers can do e.g.
+    ``make_bullet(owner_type=OwnerType.ENEMY, power_bullet=True, rect=...)``.
+    """
+
+    def _create(owner_type=OwnerType.PLAYER, **overrides):
+        b = MagicMock(spec=Bullet)
+        b.active = True
+        b.owner_type = owner_type
+        b.owner = MagicMock()
+        b.rect = pygame.Rect(0, 0, 2, 2)
+        b.direction = Direction.UP
+        b.power_bullet = False
+        for key, value in overrides.items():
+            setattr(b, key, value)
+        return b
 
     return _create
 
@@ -69,9 +144,7 @@ def ctrl_button_down_event():
 def ctrl_button_up_event():
     """Factory fixture to create CONTROLLERBUTTONUP events."""
 
-    def _ctrl_button_up_event(
-        button: int, instance_id: int = 0
-    ) -> pygame.event.Event:
+    def _ctrl_button_up_event(button: int, instance_id: int = 0) -> pygame.event.Event:
         return pygame.event.Event(
             pygame.CONTROLLERBUTTONUP, button=button, instance_id=instance_id
         )

--- a/tests/unit/core/test_enemy_tank.py
+++ b/tests/unit/core/test_enemy_tank.py
@@ -47,21 +47,10 @@ TEST_CASES = [(tank_type, props) for tank_type, props in EXPECTED_PROPERTIES.ite
 
 @pytest.mark.parametrize("tank_type, expected", TEST_CASES)
 def test_enemy_tank_initialization_properties(
-    mock_texture_manager, tank_type: TankType, expected: dict
+    create_enemy_tank, tank_type: TankType, expected: dict
 ):
     """Test that EnemyTank initializes with correct properties for each type."""
-    x, y = 0, 0
-    tile_size = TILE_SIZE
-
-    tank = EnemyTank(
-        x,
-        y,
-        tile_size,
-        mock_texture_manager,
-        tank_type,
-        map_width_px=16 * TILE_SIZE,
-        map_height_px=16 * TILE_SIZE,
-    )
+    tank = create_enemy_tank(tank_type=tank_type)
 
     assert tank.tank_type == tank_type
     assert tank.speed == pytest.approx(expected["speed"])
@@ -75,8 +64,8 @@ def test_enemy_tank_initialization_properties(
 
     assert tank.owner_type == "enemy"
     assert tank.lives == 1
-    assert tank.x == x
-    assert tank.y == y
+    assert tank.x == 0
+    assert tank.y == 0
 
 
 class TestEnemyConfigLoading:
@@ -118,22 +107,13 @@ class TestEnemyConfigLoading:
             assert "player_bias_multiplier" in config[tank_type]
 
 
-def test_enemy_tank_grid_alignment(mock_texture_manager):
+def test_enemy_tank_grid_alignment(create_enemy_tank):
     """Test that initial position is aligned to the grid."""
-    tile_size = 32
     initial_x, initial_y = 15, 40
     # round(15/32)*32=0, round(40/32)*32=32
-    expected_x, expected_y = (0 * tile_size, 1 * tile_size)
+    expected_x, expected_y = (0, TILE_SIZE)
 
-    tank = EnemyTank(
-        initial_x,
-        initial_y,
-        tile_size,
-        mock_texture_manager,
-        tank_type=TankType.BASIC,
-        map_width_px=16 * TILE_SIZE,
-        map_height_px=16 * TILE_SIZE,
-    )
+    tank = create_enemy_tank(x=initial_x, y=initial_y)
 
     assert tank.x == expected_x
     assert tank.y == expected_y
@@ -142,19 +122,10 @@ def test_enemy_tank_grid_alignment(mock_texture_manager):
 
 
 @patch("src.core.enemy_tank.random.choice")
-def test_on_movement_blocked(mock_random_choice, mock_texture_manager):
+def test_on_movement_blocked(mock_random_choice, create_enemy_tank):
     """Test that on_movement_blocked changes direction and resets direction_timer."""
     mock_random_choice.return_value = Direction.DOWN
-    tank = EnemyTank(
-        0,
-        0,
-        TILE_SIZE,
-        mock_texture_manager,
-        tank_type=TankType.BASIC,
-        map_width_px=16 * TILE_SIZE,
-        map_height_px=16 * TILE_SIZE,
-        difficulty=Difficulty.EASY,
-    )
+    tank = create_enemy_tank(patch_random=False, difficulty=Difficulty.EASY)
     tank.direction = Direction.UP
     tank.direction_timer = 1.5
 
@@ -167,19 +138,10 @@ def test_on_movement_blocked(mock_random_choice, mock_texture_manager):
 
 
 @patch("src.core.enemy_tank.random.choice")
-def test_blocked_avoids_blocked_dirs(mock_random_choice, mock_texture_manager):
+def test_blocked_avoids_blocked_dirs(mock_random_choice, create_enemy_tank):
     """Test that consecutive wall hits accumulate blocked directions."""
     mock_random_choice.return_value = Direction.DOWN
-    tank = EnemyTank(
-        0,
-        0,
-        TILE_SIZE,
-        mock_texture_manager,
-        tank_type=TankType.BASIC,
-        map_width_px=16 * TILE_SIZE,
-        map_height_px=16 * TILE_SIZE,
-        difficulty=Difficulty.EASY,
-    )
+    tank = create_enemy_tank(patch_random=False, difficulty=Difficulty.EASY)
     # Block UP, then RIGHT — only DOWN and LEFT remain as candidates
     tank.direction = Direction.UP
     tank._blocked_directions.add(Direction.UP)
@@ -193,20 +155,11 @@ def test_blocked_avoids_blocked_dirs(mock_random_choice, mock_texture_manager):
 
 @patch("src.core.enemy_tank.random.choice")
 def test_blocked_directions_persist_until_movement(
-    mock_random_choice, mock_texture_manager
+    mock_random_choice, create_enemy_tank
 ):
     """Blocked directions persist while stuck, clear on successful move."""
     mock_random_choice.return_value = Direction.DOWN
-    tank = EnemyTank(
-        0,
-        0,
-        TILE_SIZE,
-        mock_texture_manager,
-        tank_type=TankType.BASIC,
-        map_width_px=16 * TILE_SIZE,
-        map_height_px=16 * TILE_SIZE,
-        difficulty=Difficulty.EASY,
-    )
+    tank = create_enemy_tank(patch_random=False, difficulty=Difficulty.EASY)
     tank._blocked_directions.add(Direction.UP)
     tank._blocked_directions.add(Direction.LEFT)
     # Simulate a frame where the tank doesn't move (stuck)
@@ -222,20 +175,11 @@ def test_blocked_directions_persist_until_movement(
 
 @patch("src.core.enemy_tank.random.choice")
 def test_blocked_directions_cleared_on_successful_move(
-    mock_random_choice, mock_texture_manager
+    mock_random_choice, create_enemy_tank
 ):
     """Blocked directions are cleared once the tank moves successfully."""
     mock_random_choice.return_value = Direction.DOWN
-    tank = EnemyTank(
-        0,
-        0,
-        TILE_SIZE,
-        mock_texture_manager,
-        tank_type=TankType.BASIC,
-        map_width_px=16 * TILE_SIZE,
-        map_height_px=16 * TILE_SIZE,
-        difficulty=Difficulty.EASY,
-    )
+    tank = create_enemy_tank(patch_random=False, difficulty=Difficulty.EASY)
     tank._blocked_directions.add(Direction.UP)
     # Simulate prev position differing from current (tank moved last frame)
     tank.prev_x = 32.0
@@ -244,17 +188,9 @@ def test_blocked_directions_cleared_on_successful_move(
     assert len(tank._blocked_directions) == 0
 
 
-def test_consume_shoot_after_timer(mock_texture_manager):
+def test_consume_shoot_after_timer(create_enemy_tank):
     """Test that EnemyTank signals shoot intent when timer fires."""
-    tank = EnemyTank(
-        0,
-        0,
-        TILE_SIZE,
-        mock_texture_manager,
-        tank_type=TankType.BASIC,
-        map_width_px=16 * TILE_SIZE,
-        map_height_px=16 * TILE_SIZE,
-    )
+    tank = create_enemy_tank()
     assert not tank.consume_shoot()
 
     tank.shoot_timer = tank.shoot_interval + 0.1
@@ -267,20 +203,11 @@ def test_consume_shoot_after_timer(mock_texture_manager):
 @patch("src.core.enemy_tank.random.choice")
 @patch("src.core.enemy_tank.random.uniform", return_value=0.0)
 def test_update_moves_in_current_direction(
-    mock_uniform, mock_choice, mock_texture_manager
+    mock_uniform, mock_choice, create_enemy_tank
 ):
     """Test that update() moves the tank in its current direction."""
     mock_choice.return_value = Direction.DOWN
-    tank = EnemyTank(
-        0,
-        0,
-        TILE_SIZE,
-        mock_texture_manager,
-        tank_type=TankType.BASIC,
-        map_width_px=16 * TILE_SIZE,
-        map_height_px=16 * TILE_SIZE,
-        difficulty=Difficulty.EASY,
-    )
+    tank = create_enemy_tank(patch_random=False, difficulty=Difficulty.EASY)
     tank.direction = Direction.RIGHT
     # Set timers low so they don't trigger direction/shoot changes
     tank.direction_timer = 0
@@ -298,33 +225,25 @@ class TestEnemyTankCarrier:
     """Tests for the power-up carrier mechanic."""
 
     @pytest.fixture
-    def carrier_tank(self, mock_texture_manager):
-        with patch("src.core.enemy_tank.random.choice", return_value=Direction.DOWN):
-            tank = EnemyTank(
-                100,
-                100,
-                TILE_SIZE,
-                mock_texture_manager,
-                tank_type=TankType.BASIC,
-                map_width_px=512,
-                map_height_px=512,
-                is_carrier=True,
-            )
+    def carrier_tank(self, create_enemy_tank):
+        tank = create_enemy_tank(
+            x=100,
+            y=100,
+            map_width_px=512,
+            map_height_px=512,
+            is_carrier=True,
+        )
         tank.direction = Direction.DOWN
         return tank
 
     @pytest.fixture
-    def normal_tank(self, mock_texture_manager):
-        with patch("src.core.enemy_tank.random.choice", return_value=Direction.DOWN):
-            tank = EnemyTank(
-                100,
-                100,
-                TILE_SIZE,
-                mock_texture_manager,
-                tank_type=TankType.BASIC,
-                map_width_px=512,
-                map_height_px=512,
-            )
+    def normal_tank(self, create_enemy_tank):
+        tank = create_enemy_tank(
+            x=100,
+            y=100,
+            map_width_px=512,
+            map_height_px=512,
+        )
         tank.direction = Direction.DOWN
         return tank
 
@@ -383,17 +302,8 @@ class TestEnemyIceSlide:
     """Tests for enemy tank sliding on ice."""
 
     @pytest.fixture
-    def enemy(self, mock_texture_manager):
-        return EnemyTank(
-            128,
-            128,
-            TILE_SIZE,
-            mock_texture_manager,
-            TankType.BASIC,
-            map_width_px=16 * TILE_SIZE,
-            map_height_px=16 * TILE_SIZE,
-            difficulty=Difficulty.EASY,
-        )
+    def enemy(self, create_enemy_tank):
+        return create_enemy_tank(x=128, y=128, difficulty=Difficulty.EASY)
 
     def test_direction_change_triggers_slide_on_ice(self, enemy):
         enemy._on_ice = True
@@ -431,82 +341,45 @@ class TestEnemyAIBiases:
         yield
         EnemyTank.base_position = None
 
-    def test_normal_difficulty_basic_tank_biases(self, mock_texture_manager):
+    def test_normal_difficulty_basic_tank_biases(self, create_enemy_tank):
         """Basic tank on Normal: 0.3*0.5=0.15 base, 0.2*0.5=0.1 player."""
-        with patch("src.core.enemy_tank.random.choice", return_value=Direction.DOWN):
-            tank = EnemyTank(
-                0,
-                0,
-                TILE_SIZE,
-                mock_texture_manager,
-                TankType.BASIC,
-                map_width_px=512,
-                map_height_px=512,
-            )
+        tank = create_enemy_tank(map_width_px=512, map_height_px=512)
         assert tank.effective_base_bias == pytest.approx(0.15)
         assert tank.effective_player_bias == pytest.approx(0.1)
 
-    def test_normal_difficulty_armor_tank_biases(self, mock_texture_manager):
+    def test_normal_difficulty_armor_tank_biases(self, create_enemy_tank):
         """Armor tank on Normal: 0.3*1.5=0.45 base, 0.2*0.5=0.1 player."""
-        with patch("src.core.enemy_tank.random.choice", return_value=Direction.DOWN):
-            tank = EnemyTank(
-                0,
-                0,
-                TILE_SIZE,
-                mock_texture_manager,
-                TankType.ARMOR,
-                map_width_px=512,
-                map_height_px=512,
-            )
+        tank = create_enemy_tank(
+            tank_type=TankType.ARMOR, map_width_px=512, map_height_px=512
+        )
         assert tank.effective_base_bias == pytest.approx(0.45)
         assert tank.effective_player_bias == pytest.approx(0.1)
 
-    def test_easy_difficulty_all_biases_zero(self, mock_texture_manager):
+    def test_easy_difficulty_all_biases_zero(self, create_enemy_tank):
         """On Easy, all biases should be zero regardless of type."""
-        with patch("src.core.enemy_tank.random.choice", return_value=Direction.DOWN):
-            tank = EnemyTank(
-                0,
-                0,
-                TILE_SIZE,
-                mock_texture_manager,
-                TankType.POWER,
-                map_width_px=512,
-                map_height_px=512,
-                difficulty=Difficulty.EASY,
-            )
+        tank = create_enemy_tank(
+            tank_type=TankType.POWER,
+            map_width_px=512,
+            map_height_px=512,
+            difficulty=Difficulty.EASY,
+        )
         assert tank.effective_base_bias == pytest.approx(0.0)
         assert tank.effective_player_bias == pytest.approx(0.0)
 
-    def test_aligned_shoot_multiplier_stored(self, mock_texture_manager):
+    def test_aligned_shoot_multiplier_stored(self, create_enemy_tank):
         """Aligned shoot multiplier should be stored from difficulty config."""
-        with patch("src.core.enemy_tank.random.choice", return_value=Direction.DOWN):
-            tank = EnemyTank(
-                0,
-                0,
-                TILE_SIZE,
-                mock_texture_manager,
-                TankType.BASIC,
-                map_width_px=512,
-                map_height_px=512,
-            )
+        tank = create_enemy_tank(map_width_px=512, map_height_px=512)
         assert tank.aligned_shoot_multiplier == pytest.approx(0.5)
 
     @patch("src.core.enemy_tank.random.choices")
     def test_change_direction_weights_toward_base(
-        self, mock_choices, mock_texture_manager
+        self, mock_choices, create_enemy_tank
     ):
         """When base is below, DOWN should get extra base_bias weight."""
         mock_choices.return_value = [Direction.DOWN]
-        with patch("src.core.enemy_tank.random.choice", return_value=Direction.DOWN):
-            tank = EnemyTank(
-                0,
-                0,
-                TILE_SIZE,
-                mock_texture_manager,
-                TankType.ARMOR,
-                map_width_px=512,
-                map_height_px=512,
-            )
+        tank = create_enemy_tank(
+            tank_type=TankType.ARMOR, map_width_px=512, map_height_px=512
+        )
         tank.direction = Direction.LEFT
         tank.direction_timer = tank.direction_change_interval + 1
         tank._blocked_directions.clear()
@@ -521,20 +394,13 @@ class TestEnemyAIBiases:
 
     @patch("src.core.enemy_tank.random.choices")
     def test_change_direction_weights_toward_player(
-        self, mock_choices, mock_texture_manager
+        self, mock_choices, create_enemy_tank
     ):
         """When player is to the right, RIGHT should get extra player_bias weight."""
         mock_choices.return_value = [Direction.RIGHT]
-        with patch("src.core.enemy_tank.random.choice", return_value=Direction.DOWN):
-            tank = EnemyTank(
-                0,
-                0,
-                TILE_SIZE,
-                mock_texture_manager,
-                TankType.FAST,
-                map_width_px=512,
-                map_height_px=512,
-            )
+        tank = create_enemy_tank(
+            tank_type=TankType.FAST, map_width_px=512, map_height_px=512
+        )
         tank.direction = Direction.UP
         tank.direction_timer = tank.direction_change_interval + 1
         tank._blocked_directions.clear()
@@ -548,20 +414,14 @@ class TestEnemyAIBiases:
         assert weights[right_idx] >= 1.0 + 0.3
 
     @patch("src.core.enemy_tank.random.choices")
-    def test_easy_difficulty_equal_weights(self, mock_choices, mock_texture_manager):
+    def test_easy_difficulty_equal_weights(self, mock_choices, create_enemy_tank):
         """On Easy, all candidate directions should have equal weight 1.0."""
         mock_choices.return_value = [Direction.DOWN]
-        with patch("src.core.enemy_tank.random.choice", return_value=Direction.DOWN):
-            tank = EnemyTank(
-                0,
-                0,
-                TILE_SIZE,
-                mock_texture_manager,
-                TankType.BASIC,
-                map_width_px=512,
-                map_height_px=512,
-                difficulty=Difficulty.EASY,
-            )
+        tank = create_enemy_tank(
+            map_width_px=512,
+            map_height_px=512,
+            difficulty=Difficulty.EASY,
+        )
         tank.direction = Direction.LEFT
         tank.direction_timer = tank.direction_change_interval + 1
         tank._blocked_directions.clear()
@@ -571,18 +431,11 @@ class TestEnemyAIBiases:
         # On Easy, biases are zero so random.choice is used, not random.choices
         mock_choices.assert_not_called()
 
-    def test_none_player_position_uses_base_only(self, mock_texture_manager):
+    def test_none_player_position_uses_base_only(self, create_enemy_tank):
         """When player_position is None, only base bias applies."""
-        with patch("src.core.enemy_tank.random.choice", return_value=Direction.DOWN):
-            tank = EnemyTank(
-                0,
-                0,
-                TILE_SIZE,
-                mock_texture_manager,
-                TankType.ARMOR,
-                map_width_px=512,
-                map_height_px=512,
-            )
+        tank = create_enemy_tank(
+            tank_type=TankType.ARMOR, map_width_px=512, map_height_px=512
+        )
         tank.direction = Direction.LEFT
         tank.direction_timer = tank.direction_change_interval + 1
 
@@ -595,18 +448,9 @@ class TestEnemyAIBiases:
             down_idx = candidates.index(Direction.DOWN)
             assert weights[down_idx] == pytest.approx(1.0 + 0.45)  # base only
 
-    def test_aligned_shooting_reduces_interval(self, mock_texture_manager):
+    def test_aligned_shooting_reduces_interval(self, create_enemy_tank):
         """When facing the player and aligned, shoot interval is reduced."""
-        with patch("src.core.enemy_tank.random.choice", return_value=Direction.DOWN):
-            tank = EnemyTank(
-                100,
-                0,
-                TILE_SIZE,
-                mock_texture_manager,
-                TankType.BASIC,
-                map_width_px=512,
-                map_height_px=512,
-            )
+        tank = create_enemy_tank(x=100, map_width_px=512, map_height_px=512)
         tank.direction = Direction.DOWN
         # Player is below and at similar X (within TILE_SIZE)
         player_pos = (100.0, 300.0)
@@ -618,18 +462,9 @@ class TestEnemyAIBiases:
 
         assert tank.consume_shoot() is True
 
-    def test_not_aligned_uses_normal_interval(self, mock_texture_manager):
+    def test_not_aligned_uses_normal_interval(self, create_enemy_tank):
         """When not aligned, normal shoot interval applies."""
-        with patch("src.core.enemy_tank.random.choice", return_value=Direction.DOWN):
-            tank = EnemyTank(
-                100,
-                0,
-                TILE_SIZE,
-                mock_texture_manager,
-                TankType.BASIC,
-                map_width_px=512,
-                map_height_px=512,
-            )
+        tank = create_enemy_tank(x=100, map_width_px=512, map_height_px=512)
         tank.direction = Direction.LEFT  # facing left, player is below
         player_pos = (100.0, 300.0)
         tank.shoot_timer = tank.shoot_interval * 0.5 + 0.01
@@ -652,18 +487,11 @@ class TestEnemyAIBiases:
         ],
     )
     def test_alignment_detection(
-        self, direction, tank_pos, target_pos, expected_aligned, mock_texture_manager
+        self, direction, tank_pos, target_pos, expected_aligned, create_enemy_tank
     ):
         """Test _is_aligned_with for various positions and directions."""
-        with patch("src.core.enemy_tank.random.choice", return_value=Direction.DOWN):
-            tank = EnemyTank(
-                tank_pos[0],
-                tank_pos[1],
-                TILE_SIZE,
-                mock_texture_manager,
-                TankType.BASIC,
-                map_width_px=512,
-                map_height_px=512,
-            )
+        tank = create_enemy_tank(
+            x=tank_pos[0], y=tank_pos[1], map_width_px=512, map_height_px=512
+        )
         tank.direction = direction
         assert tank._is_aligned_with(target_pos) == expected_aligned

--- a/tests/unit/core/test_player_tank.py
+++ b/tests/unit/core/test_player_tank.py
@@ -1,10 +1,8 @@
 import pytest
 import pygame
 from unittest.mock import MagicMock
-from src.core.player_tank import PlayerTank
 from src.utils.constants import (
     Direction,
-    TILE_SIZE,
     FPS,
     HELMET_INVINCIBILITY_DURATION,
     SPAWN_INVINCIBILITY_DURATION,
@@ -20,16 +18,9 @@ class TestPlayerTank:
     """Test cases for the PlayerTank class."""
 
     @pytest.fixture
-    def player_tank(self, mock_texture_manager):
+    def player_tank(self, create_player_tank):
         """Fixture to create a PlayerTank instance."""
-        return PlayerTank(
-            5,
-            12,
-            TILE_SIZE,
-            mock_texture_manager,
-            map_width_px=16 * TILE_SIZE,
-            map_height_px=16 * TILE_SIZE,
-        )
+        return create_player_tank(x=5, y=12)
 
     def test_player_tank_initialization(self, player_tank):
         """Test PlayerTank initialization aligns to grid and sets correct defaults."""
@@ -180,15 +171,8 @@ class TestPlayerTank:
 
 class TestActivateInvincibility:
     @pytest.fixture
-    def player(self, mock_texture_manager):
-        return PlayerTank(
-            96,
-            96,
-            TILE_SIZE,
-            mock_texture_manager,
-            map_width_px=512,
-            map_height_px=512,
-        )
+    def player(self, create_player_tank):
+        return create_player_tank(x=96, y=96, map_width_px=512, map_height_px=512)
 
     def test_sets_invincible(self, player):
         player.activate_invincibility(5.0)
@@ -223,15 +207,8 @@ class TestActivateInvincibility:
 
 class TestStarUpgrade:
     @pytest.fixture
-    def player(self, mock_texture_manager):
-        return PlayerTank(
-            96,
-            96,
-            TILE_SIZE,
-            mock_texture_manager,
-            map_width_px=512,
-            map_height_px=512,
-        )
+    def player(self, create_player_tank):
+        return create_player_tank(x=96, y=96, map_width_px=512, map_height_px=512)
 
     def test_initial_star_level(self, player):
         assert player.star_level == 0
@@ -278,39 +255,28 @@ class TestStarUpgrade:
 
 
 class TestPlayerTankPlayerId:
-    def test_default_player_id_is_1(self, mock_texture_manager):
+    def test_default_player_id_is_1(self, create_player_tank):
         """PlayerTank defaults to player_id=1."""
-        tank = PlayerTank(
-            0, 0, TILE_SIZE, mock_texture_manager,
-            map_width_px=512, map_height_px=512,
-        )
+        tank = create_player_tank(map_width_px=512, map_height_px=512)
         assert tank.player_id == 1
 
-    def test_player_id_2_accepted(self, mock_texture_manager):
+    def test_player_id_2_accepted(self, create_player_tank):
         """PlayerTank accepts player_id=2."""
-        tank = PlayerTank(
-            0, 0, TILE_SIZE, mock_texture_manager,
-            map_width_px=512, map_height_px=512,
-            player_id=2,
-        )
+        tank = create_player_tank(map_width_px=512, map_height_px=512, player_id=2)
         assert tank.player_id == 2
 
-    def test_player2_uses_player2_sprite_prefix(self, mock_texture_manager):
+    def test_player2_uses_player2_sprite_prefix(
+        self, create_player_tank, mock_texture_manager
+    ):
         """Player 2 tank requests sprites with 'player2_tank_' prefix."""
-        PlayerTank(
-            0, 0, TILE_SIZE, mock_texture_manager,
-            map_width_px=512, map_height_px=512,
-            player_id=2,
-        )
+        create_player_tank(map_width_px=512, map_height_px=512, player_id=2)
         mock_texture_manager.get_sprite.assert_any_call("player2_tank_tier0_up_1")
 
-    def test_player1_uses_player_tank_sprite_prefix(self, mock_texture_manager):
+    def test_player1_uses_player_tank_sprite_prefix(
+        self, create_player_tank, mock_texture_manager
+    ):
         """Player 1 tank requests sprites with 'player_tank_' prefix (unchanged)."""
-        PlayerTank(
-            0, 0, TILE_SIZE, mock_texture_manager,
-            map_width_px=512, map_height_px=512,
-            player_id=1,
-        )
+        create_player_tank(map_width_px=512, map_height_px=512, player_id=1)
         mock_texture_manager.get_sprite.assert_any_call("player_tank_tier0_up_1")
 
 
@@ -332,15 +298,8 @@ class TestShieldAnimation:
         return mock_tm
 
     @pytest.fixture
-    def player_tank(self, mock_texture_manager):
-        return PlayerTank(
-            5,
-            12,
-            TILE_SIZE,
-            mock_texture_manager,
-            map_width_px=16 * TILE_SIZE,
-            map_height_px=16 * TILE_SIZE,
-        )
+    def player_tank(self, create_player_tank):
+        return create_player_tank(x=5, y=12)
 
     def test_is_invincible_false_when_not_invincible(self, player_tank):
         assert player_tank.is_invincible is False
@@ -412,11 +371,8 @@ class TestShieldAnimation:
 
 class TestPlayerTankFreeze:
     @pytest.fixture
-    def player(self, mock_texture_manager):
-        return PlayerTank(
-            0, 0, TILE_SIZE, mock_texture_manager,
-            map_width_px=512, map_height_px=512,
-        )
+    def player(self, create_player_tank):
+        return create_player_tank(map_width_px=512, map_height_px=512)
 
     def test_not_frozen_by_default(self, player):
         """PlayerTank is not frozen initially."""

--- a/tests/unit/managers/test_collision_response_handler.py
+++ b/tests/unit/managers/test_collision_response_handler.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock
 from src.managers.collision_response_handler import CollisionResponseHandler
 from src.managers.effect_manager import EffectManager
 from src.managers.power_up_manager import PowerUpManager
-from src.core.bullet import Bullet
 from src.core.player_tank import PlayerTank
 from src.core.enemy_tank import EnemyTank
 from src.core.tile import Tile, TileType
@@ -52,13 +51,8 @@ def handler(mock_map, mock_effect_manager, mock_add_score):
 
 
 @pytest.fixture
-def mock_bullet():
-    b = MagicMock(spec=Bullet)
-    b.active = True
-    b.owner_type = "player"
-    b.owner = MagicMock()
-    b.rect = pygame.Rect(0, 0, 2, 2)
-    return b
+def mock_bullet(make_bullet):
+    return make_bullet()
 
 
 @pytest.fixture
@@ -134,49 +128,35 @@ class TestBulletVsEnemy:
         enemies = handler.process_collisions([(mock_bullet, mock_enemy)])
         assert mock_enemy in enemies
 
-    def test_enemy_bullet_does_not_damage_enemy(self, handler, mock_enemy):
+    def test_enemy_bullet_does_not_damage_enemy(self, handler, make_bullet, mock_enemy):
         """Friendly fire — enemy bullet should not damage enemy."""
-        bullet = MagicMock(spec=Bullet)
-        bullet.active = True
-        bullet.owner_type = "enemy"
-        bullet.owner = MagicMock()
+        bullet = make_bullet(owner_type="enemy")
         handler.process_collisions([(bullet, mock_enemy)])
         mock_enemy.take_damage.assert_not_called()
         assert bullet.active  # Bullet not consumed
 
 
 class TestBulletVsPlayer:
-    def test_enemy_bullet_damages_player(self, handler, mock_player):
-        bullet = MagicMock(spec=Bullet)
-        bullet.active = True
-        bullet.owner_type = "enemy"
-        bullet.owner = MagicMock()
+    def test_enemy_bullet_damages_player(self, handler, make_bullet, mock_player):
+        bullet = make_bullet(owner_type="enemy")
         handler.process_collisions([(bullet, mock_player)])
         assert not bullet.active
         mock_player.take_damage.assert_called_once()
         mock_player.respawn.assert_called_once()
 
-    def test_enemy_bullet_kills_player(self, handler, mock_player):
-        bullet = MagicMock(spec=Bullet)
-        bullet.active = True
-        bullet.owner_type = "enemy"
-        bullet.owner = MagicMock()
-        bullet.rect = pygame.Rect(0, 0, 2, 2)
+    def test_enemy_bullet_kills_player(self, handler, make_bullet, mock_player):
+        bullet = make_bullet(owner_type="enemy")
         mock_player.take_damage.return_value = True
         handler.process_collisions([(bullet, mock_player)])
         handler._set_game_state.assert_called_with(GameState.GAME_OVER)
         mock_player.respawn.assert_not_called()
 
-    def test_bullet_vs_invincible_player(self, handler, mock_player):
-        bullet = MagicMock(spec=Bullet)
-        bullet.active = True
-        bullet.owner_type = "enemy"
-        bullet.owner = MagicMock()
+    def test_bullet_vs_invincible_player(self, handler, make_bullet, mock_player):
+        bullet = make_bullet(owner_type="enemy")
         mock_player.is_invincible = True
         handler.process_collisions([(bullet, mock_player)])
         assert not bullet.active
         mock_player.take_damage.assert_not_called()
-
 
 
 class TestBulletVsTile:
@@ -186,14 +166,9 @@ class TestBulletVsTile:
     Full bricks become half-bricks on first hit, then destroyed on second.
     """
 
-    def test_bullet_damages_brick(self, handler, mock_map):
+    def test_bullet_damages_brick(self, handler, make_bullet, mock_map):
         """Bullet hitting a brick tile calls damage_brick with direction."""
-        bullet = MagicMock(spec=Bullet)
-        bullet.active = True
-        bullet.owner = MagicMock()
-        bullet.power_bullet = False
-        bullet.rect = pygame.Rect(64, 64, 4, 4)
-        bullet.direction = Direction.RIGHT
+        bullet = make_bullet(rect=pygame.Rect(64, 64, 4, 4), direction=Direction.RIGHT)
         tile = Tile(
             TileType.BRICK,
             4,
@@ -206,14 +181,9 @@ class TestBulletVsTile:
         assert not bullet.active
         mock_map.damage_brick.assert_called_once_with(tile, "right", bullet.rect)
 
-    def test_bullet_destroys_base(self, handler, mock_map):
+    def test_bullet_destroys_base(self, handler, make_bullet, mock_map):
         """Bullet hitting base triggers destroy_base and GAME_OVER."""
-        bullet = MagicMock(spec=Bullet)
-        bullet.active = True
-        bullet.owner = MagicMock()
-        bullet.power_bullet = False
-        bullet.rect = pygame.Rect(0, 0, 4, 4)
-        bullet.direction = Direction.DOWN
+        bullet = make_bullet(rect=pygame.Rect(0, 0, 4, 4), direction=Direction.DOWN)
         tile = MagicMock(spec=Tile)
         tile.type = TileType.BASE
         tile.blocks_bullets = True
@@ -226,12 +196,8 @@ class TestBulletVsTile:
 
     # -- Non-brick tiles --
 
-    def test_bullet_stops_at_steel(self, handler, mock_map):
-        bullet = MagicMock(spec=Bullet)
-        bullet.active = True
-        bullet.owner = MagicMock()
-        bullet.power_bullet = False
-        bullet.rect = pygame.Rect(0, 0, 2, 2)
+    def test_bullet_stops_at_steel(self, handler, make_bullet, mock_map):
+        bullet = make_bullet()
         tile = MagicMock(spec=Tile)
         tile.type = TileType.STEEL
         tile.blocks_bullets = True
@@ -242,15 +208,9 @@ class TestBulletVsTile:
 
 
 class TestBulletVsBullet:
-    def test_both_deactivated(self, handler):
-        b1 = MagicMock(spec=Bullet)
-        b2 = MagicMock(spec=Bullet)
-        b1.active = True
-        b1.owner = MagicMock()
-        b1.rect = pygame.Rect(0, 0, 2, 2)
-        b2.active = True
-        b2.owner = MagicMock()
-        b2.rect = pygame.Rect(2, 0, 2, 2)
+    def test_both_deactivated(self, handler, make_bullet):
+        b1 = make_bullet()
+        b2 = make_bullet(rect=pygame.Rect(2, 0, 2, 2))
         handler.process_collisions([(b1, b2)])
         assert not b1.active
         assert not b2.active
@@ -259,43 +219,18 @@ class TestBulletVsBullet:
 class TestTankVsTank:
     """Tank-vs-tank collision tests using real tank objects."""
 
-    MAP_PX = 16 * TILE_SIZE
-
-    def _make_player(self, mock_texture_manager, x, y):
-        """Create a real PlayerTank at the given position."""
-        tank = PlayerTank(
-            x,
-            y,
-            TILE_SIZE,
-            mock_texture_manager,
-            map_width_px=self.MAP_PX,
-            map_height_px=self.MAP_PX,
-        )
-        return tank
-
-    def _make_enemy(self, mock_texture_manager, x, y):
-        """Create a real EnemyTank at the given position."""
-        tank = EnemyTank(
-            x,
-            y,
-            TILE_SIZE,
-            mock_texture_manager,
-            tank_type=TankType.BASIC,
-            map_width_px=self.MAP_PX,
-            map_height_px=self.MAP_PX,
-        )
-        return tank
-
     @staticmethod
     def _simulate_move(tank, dx, dy, dt=1.0 / 60):
         """Move tank and set up prev position as Tank.update() would."""
         tank.prev_x, tank.prev_y = tank.x, tank.y
         tank._move(dx, dy, dt)
 
-    def test_both_moving_toward_each_other(self, handler, mock_texture_manager):
+    def test_both_moving_toward_each_other(
+        self, handler, create_player_tank, create_enemy_tank
+    ):
         """Both tanks moving toward each other: both reverted."""
-        player = self._make_player(mock_texture_manager, 96, 128)
-        enemy = self._make_enemy(mock_texture_manager, 96, 96)
+        player = create_player_tank(x=96, y=128)
+        enemy = create_enemy_tank(x=96, y=96)
         enemy.direction = Direction.DOWN
         self._simulate_move(player, 0, -1)
         self._simulate_move(enemy, 0, 1)
@@ -304,10 +239,12 @@ class TestTankVsTank:
         assert player.x == player.prev_x and player.y == player.prev_y
         assert enemy.x == enemy.prev_x and enemy.y == enemy.prev_y
 
-    def test_only_aggressor_reverted(self, handler, mock_texture_manager):
+    def test_only_aggressor_reverted(
+        self, handler, create_player_tank, create_enemy_tank
+    ):
         """Stationary enemy is not reverted when player moves into it."""
-        player = self._make_player(mock_texture_manager, 96, 128)
-        enemy = self._make_enemy(mock_texture_manager, 96, 96)
+        player = create_player_tank(x=96, y=128)
+        enemy = create_enemy_tank(x=96, y=96)
         enemy_pos_before = (enemy.x, enemy.y)
         self._simulate_move(player, 0, -1)
         # Enemy didn't move (prev == current)
@@ -316,10 +253,12 @@ class TestTankVsTank:
         assert player.x == player.prev_x and player.y == player.prev_y
         assert (enemy.x, enemy.y) == enemy_pos_before
 
-    def test_perpendicular_tank_not_reverted(self, handler, mock_texture_manager):
+    def test_perpendicular_tank_not_reverted(
+        self, handler, create_player_tank, create_enemy_tank
+    ):
         """Enemy moving perpendicular to collision axis keeps its move."""
-        player = self._make_player(mock_texture_manager, 96, 128)
-        enemy = self._make_enemy(mock_texture_manager, 96, 96)
+        player = create_player_tank(x=96, y=128)
+        enemy = create_enemy_tank(x=96, y=96)
         enemy.direction = Direction.RIGHT
         self._simulate_move(player, 0, -1)
         self._simulate_move(enemy, 1, 0)
@@ -329,10 +268,10 @@ class TestTankVsTank:
         assert player.x == player.prev_x and player.y == player.prev_y
         assert (enemy.x, enemy.y) == enemy_pos_after_move
 
-    def test_enemy_vs_enemy_both_moving_toward(self, handler, mock_texture_manager):
+    def test_enemy_vs_enemy_both_moving_toward(self, handler, create_enemy_tank):
         """Two enemies moving toward each other: both reverted."""
-        e1 = self._make_enemy(mock_texture_manager, 96, 96)
-        e2 = self._make_enemy(mock_texture_manager, 128, 96)
+        e1 = create_enemy_tank(x=96, y=96)
+        e2 = create_enemy_tank(x=128, y=96)
         e1.direction = Direction.RIGHT
         e2.direction = Direction.LEFT
         self._simulate_move(e1, 1, 0)
@@ -341,11 +280,11 @@ class TestTankVsTank:
         assert e1.x == e1.prev_x and e1.y == e1.prev_y
         assert e2.x == e2.prev_x and e2.y == e2.prev_y
 
-    def test_pre_existing_overlap_allows_movement(self, handler, mock_texture_manager):
+    def test_pre_existing_overlap_allows_movement(self, handler, create_enemy_tank):
         """When tanks are already overlapping (e.g. from spawn), neither
         should be reverted — both must be free to move apart."""
-        e1 = self._make_enemy(mock_texture_manager, 100, 100)
-        e2 = self._make_enemy(mock_texture_manager, 100, 100)
+        e1 = create_enemy_tank(x=100, y=100)
+        e2 = create_enemy_tank(x=100, y=100)
         e1.direction = Direction.LEFT
         e2.direction = Direction.RIGHT
         self._simulate_move(e1, -1, 0)
@@ -358,12 +297,12 @@ class TestTankVsTank:
         assert (e2.x, e2.y) == e2_pos_after_move
 
     def test_pre_existing_overlap_no_blocked_directions(
-        self, handler, mock_texture_manager
+        self, handler, create_enemy_tank
     ):
         """Pre-existing overlap should not add blocked directions,
         so tanks don't get permanently stuck."""
-        e1 = self._make_enemy(mock_texture_manager, 100, 100)
-        e2 = self._make_enemy(mock_texture_manager, 100, 100)
+        e1 = create_enemy_tank(x=100, y=100)
+        e2 = create_enemy_tank(x=100, y=100)
         e1.prev_x, e1.prev_y = e1.x, e1.y
         e2.prev_x, e2.prev_y = e2.x, e2.y
         handler.process_collisions([(e1, e2)])
@@ -371,16 +310,16 @@ class TestTankVsTank:
         assert len(e2._blocked_directions) == 0
 
     def test_cornered_enemy_blocked_direction_recorded(
-        self, handler, mock_texture_manager, mock_tile
+        self, handler, create_player_tank, create_enemy_tank, mock_tile
     ):
         """When a cornered enemy gets tile + tank collisions, its
         blocked direction is recorded from the tile hit."""
         mock_tile.type = TileType.STEEL
         mock_tile.rect = pygame.Rect(68, 100, TILE_SIZE, TILE_SIZE)
-        enemy = self._make_enemy(mock_texture_manager, 100, 100)
+        enemy = create_enemy_tank(x=100, y=100)
         enemy.direction = Direction.LEFT
         enemy.prev_x, enemy.prev_y = enemy.x, enemy.y
-        pusher = self._make_player(mock_texture_manager, 130, 100)
+        pusher = create_player_tank(x=130, y=100)
         self._simulate_move(pusher, -1, 0)
         handler.process_collisions(
             [
@@ -414,12 +353,9 @@ class TestTankVsTile:
 
 
 class TestTracking:
-    def test_processed_bullet_not_reprocessed(self, handler, mock_enemy):
+    def test_processed_bullet_not_reprocessed(self, handler, make_bullet, mock_enemy):
         """Same bullet in two events should only be processed once."""
-        bullet = MagicMock(spec=Bullet)
-        bullet.active = True
-        bullet.owner_type = "player"
-        bullet.owner = MagicMock()
+        bullet = make_bullet()
         enemy2 = MagicMock(spec=EnemyTank)
         enemy2.take_damage = MagicMock(return_value=False)
         enemy2.owner_type = "enemy"
@@ -456,7 +392,7 @@ class TestTracking:
 
 class TestExplosionEffects:
     def test_bullet_vs_brick_spawns_small_explosion(
-        self, handler, mock_map, mock_effect_manager
+        self, handler, make_bullet, mock_map, mock_effect_manager
     ):
         tile = Tile(
             TileType.BRICK,
@@ -467,22 +403,16 @@ class TestExplosionEffects:
             is_destructible=True,
         )
         mock_map.get_tile_at.return_value = Tile(TileType.EMPTY, 4, 5)
-        bullet = MagicMock(spec=Bullet)
-        bullet.active = True
-        bullet.owner = MagicMock()
-        bullet.direction = Direction.RIGHT
-        bullet.rect = pygame.Rect(64, 66, 2, 2)
+        bullet = make_bullet(direction=Direction.RIGHT, rect=pygame.Rect(64, 66, 2, 2))
         handler.process_collisions([(bullet, tile)])
         mock_effect_manager.spawn.assert_called_once_with(
             EffectType.SMALL_EXPLOSION, 65.0, 67.0
         )
 
-    def test_bullet_vs_steel_spawns_small_explosion(self, handler, mock_effect_manager):
-        bullet = MagicMock(spec=Bullet)
-        bullet.active = True
-        bullet.owner = MagicMock()
-        bullet.power_bullet = False
-        bullet.rect = pygame.Rect(50, 50, 2, 2)
+    def test_bullet_vs_steel_spawns_small_explosion(
+        self, handler, make_bullet, mock_effect_manager
+    ):
+        bullet = make_bullet(rect=pygame.Rect(50, 50, 2, 2))
         tile = MagicMock(spec=Tile)
         tile.type = TileType.STEEL
         tile.blocks_bullets = True
@@ -494,12 +424,9 @@ class TestExplosionEffects:
         )
 
     def test_bullet_vs_base_spawns_small_explosion(
-        self, handler, mock_map, mock_effect_manager
+        self, handler, make_bullet, mock_map, mock_effect_manager
     ):
-        bullet = MagicMock(spec=Bullet)
-        bullet.active = True
-        bullet.owner = MagicMock()
-        bullet.rect = pygame.Rect(50, 50, 2, 2)
+        bullet = make_bullet(rect=pygame.Rect(50, 50, 2, 2))
         tile = MagicMock(spec=Tile)
         tile.type = TileType.BASE
         tile.blocks_bullets = True
@@ -510,12 +437,10 @@ class TestExplosionEffects:
             EffectType.SMALL_EXPLOSION, 51.0, 51.0
         )
 
-    def test_enemy_destroyed_spawns_large_explosion(self, handler, mock_effect_manager):
-        bullet = MagicMock(spec=Bullet)
-        bullet.active = True
-        bullet.owner_type = "player"
-        bullet.owner = MagicMock()
-        bullet.rect = pygame.Rect(50, 50, 2, 2)
+    def test_enemy_destroyed_spawns_large_explosion(
+        self, handler, make_bullet, mock_effect_manager
+    ):
+        bullet = make_bullet(rect=pygame.Rect(50, 50, 2, 2))
         enemy = MagicMock(spec=EnemyTank)
         enemy.owner_type = "enemy"
         enemy.tank_type = "basic"
@@ -526,26 +451,18 @@ class TestExplosionEffects:
             EffectType.LARGE_EXPLOSION, 116.0, 116.0
         )
 
-    def test_bullet_vs_bullet_no_explosion(self, handler, mock_effect_manager):
-        b1 = MagicMock(spec=Bullet)
-        b1.active = True
-        b1.owner = MagicMock()
-        b1.rect = pygame.Rect(50, 50, 2, 2)
-        b2 = MagicMock(spec=Bullet)
-        b2.active = True
-        b2.owner = MagicMock()
-        b2.rect = pygame.Rect(52, 50, 2, 2)
+    def test_bullet_vs_bullet_no_explosion(
+        self, handler, make_bullet, mock_effect_manager
+    ):
+        b1 = make_bullet(rect=pygame.Rect(50, 50, 2, 2))
+        b2 = make_bullet(rect=pygame.Rect(52, 50, 2, 2))
         handler.process_collisions([(b1, b2)])
         mock_effect_manager.spawn.assert_not_called()
 
     def test_player_destroyed_spawns_large_explosion(
-        self, handler, mock_player, mock_effect_manager
+        self, handler, make_bullet, mock_player, mock_effect_manager
     ):
-        bullet = MagicMock(spec=Bullet)
-        bullet.active = True
-        bullet.owner_type = "enemy"
-        bullet.owner = MagicMock()
-        bullet.rect = pygame.Rect(50, 50, 2, 2)
+        bullet = make_bullet(owner_type="enemy", rect=pygame.Rect(50, 50, 2, 2))
         mock_player.take_damage.return_value = True
         mock_player.rect = pygame.Rect(100, 100, 32, 32)
         handler.process_collisions([(bullet, mock_player)])
@@ -674,24 +591,19 @@ class TestPlayerVsPowerUp:
 
 class TestPowerBulletVsSteel:
     @pytest.fixture
-    def power_bullet(self):
-        b = MagicMock(spec=Bullet)
-        b.active = True
-        b.owner_type = "player"
-        b.power_bullet = True
-        b.rect = pygame.Rect(100, 100, 4, 4)
-        b.direction = Direction.RIGHT
-        return b
+    def power_bullet(self, make_bullet):
+        return make_bullet(
+            power_bullet=True,
+            rect=pygame.Rect(100, 100, 4, 4),
+            direction=Direction.RIGHT,
+        )
 
     @pytest.fixture
-    def normal_bullet(self):
-        b = MagicMock(spec=Bullet)
-        b.active = True
-        b.owner_type = "player"
-        b.power_bullet = False
-        b.rect = pygame.Rect(100, 100, 4, 4)
-        b.direction = Direction.RIGHT
-        return b
+    def normal_bullet(self, make_bullet):
+        return make_bullet(
+            rect=pygame.Rect(100, 100, 4, 4),
+            direction=Direction.RIGHT,
+        )
 
     @pytest.fixture
     def steel_tile(self):
@@ -732,12 +644,9 @@ class TestPowerBulletVsSteel:
 
 
 class TestFriendlyFire:
-    def test_player_bullet_freezes_other_player(self, handler):
+    def test_player_bullet_freezes_other_player(self, handler, make_bullet):
         """Player bullet hitting another player freezes instead of damaging."""
-        bullet = MagicMock(spec=Bullet)
-        bullet.active = True
-        bullet.owner_type = OwnerType.PLAYER
-        bullet.owner = MagicMock(spec=PlayerTank)
+        bullet = make_bullet(owner=MagicMock(spec=PlayerTank))
 
         target = MagicMock(spec=PlayerTank)
         target.is_invincible = False
@@ -749,11 +658,11 @@ class TestFriendlyFire:
         target.freeze.assert_called_once_with(FRIENDLY_FIRE_FREEZE_DURATION)
         target.take_damage.assert_not_called()
 
-    def test_player_bullet_does_not_freeze_invincible_player(self, handler):
+    def test_player_bullet_does_not_freeze_invincible_player(
+        self, handler, make_bullet
+    ):
         """Friendly fire on invincible player deactivates bullet but doesn't freeze."""
-        bullet = MagicMock(spec=Bullet)
-        bullet.active = True
-        bullet.owner_type = OwnerType.PLAYER
+        bullet = make_bullet()
 
         target = MagicMock(spec=PlayerTank)
         target.is_invincible = True
@@ -764,15 +673,12 @@ class TestFriendlyFire:
         assert bullet.active is False
         target.freeze.assert_not_called()
 
-    def test_player_bullet_does_not_hit_self(self, handler):
+    def test_player_bullet_does_not_hit_self(self, handler, make_bullet):
         """A player's own bullet cannot hit themselves (self-hit guard)."""
         player = MagicMock(spec=PlayerTank)
         player.is_invincible = False
 
-        bullet = MagicMock(spec=Bullet)
-        bullet.active = True
-        bullet.owner_type = OwnerType.PLAYER
-        bullet.owner = player
+        bullet = make_bullet(owner=player)
 
         result = handler._handle_bullet_vs_player(bullet, player, [])
 
@@ -780,14 +686,12 @@ class TestFriendlyFire:
         assert bullet.active is True
         player.freeze.assert_not_called()
 
-    def test_enemy_bullet_still_damages_player(self, handler):
+    def test_enemy_bullet_still_damages_player(self, handler, make_bullet):
         """Enemy bullets still damage the player (unchanged behavior)."""
-        bullet = MagicMock(spec=Bullet)
-        bullet.active = True
-        bullet.owner_type = OwnerType.ENEMY
-        bullet.rect = MagicMock()
-        bullet.rect.centerx = 100
-        bullet.rect.centery = 100
+        rect = MagicMock()
+        rect.centerx = 100
+        rect.centery = 100
+        bullet = make_bullet(owner_type=OwnerType.ENEMY, rect=rect)
 
         target = MagicMock(spec=PlayerTank)
         target.is_invincible = False
@@ -798,14 +702,12 @@ class TestFriendlyFire:
         assert result is True
         target.take_damage.assert_called_once()
 
-    def test_enemy_bullet_hits_frozen_player(self, handler):
+    def test_enemy_bullet_hits_frozen_player(self, handler, make_bullet):
         """A frozen player can still be hit by enemy bullets (real damage)."""
-        bullet = MagicMock(spec=Bullet)
-        bullet.active = True
-        bullet.owner_type = OwnerType.ENEMY
-        bullet.rect = MagicMock()
-        bullet.rect.centerx = 100
-        bullet.rect.centery = 100
+        rect = MagicMock()
+        rect.centerx = 100
+        rect.centery = 100
+        bullet = make_bullet(owner_type=OwnerType.ENEMY, rect=rect)
 
         target = MagicMock(spec=PlayerTank)
         target.is_invincible = False
@@ -819,7 +721,9 @@ class TestFriendlyFire:
 
 
 class TestPerPlayerScoring:
-    def test_enemy_kill_awards_score_to_owner(self, mock_map, mock_effect_manager):
+    def test_enemy_kill_awards_score_to_owner(
+        self, make_bullet, mock_map, mock_effect_manager
+    ):
         """Score is routed to the player who fired the killing bullet."""
         scores_received = []
 
@@ -833,11 +737,9 @@ class TestPerPlayerScoring:
             add_score=track_score,
         )
 
-        bullet = MagicMock(spec=Bullet)
-        bullet.active = True
-        bullet.owner_type = OwnerType.PLAYER
-        bullet.owner = MagicMock(spec=PlayerTank)
-        bullet.owner.player_id = 2
+        owner = MagicMock(spec=PlayerTank)
+        owner.player_id = 2
+        bullet = make_bullet(owner=owner)
 
         enemy = MagicMock(spec=EnemyTank)
         enemy.tank_type = TankType.BASIC

--- a/tests/unit/managers/test_player_manager.py
+++ b/tests/unit/managers/test_player_manager.py
@@ -56,17 +56,6 @@ def mock_game_map():
 
 
 # ---------------------------------------------------------------------------
-# Helper: create a real PlayerTank backed by the mock texture manager
-# ---------------------------------------------------------------------------
-
-
-def _make_player(mock_tm, x=0, y=0, tile_size=TILE_SIZE, map_size_tiles=26):
-    """Return a real PlayerTank for use in tests."""
-    px = map_size_tiles * tile_size
-    return PlayerTank(x, y, tile_size, mock_tm, map_width_px=px, map_height_px=px)
-
-
-# ---------------------------------------------------------------------------
 # TestPlayerManagerCreation
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds three factory fixtures to \`tests/conftest.py\` that mirror the existing \`create_tank\`:
  - \`create_enemy_tank(x=0, y=0, tank_type=TankType.BASIC, patch_random=True, **kwargs)\` — wraps construction in \`patch(\"src.core.enemy_tank.random.choice\", return_value=Direction.DOWN)\` by default so setup is deterministic; pass \`patch_random=False\` for tests that already patch \`random.choice\` at decorator scope.
  - \`create_player_tank(x=0, y=0, **kwargs)\` — mirrors \`create_tank\` for \`PlayerTank\`.
  - \`make_bullet(owner_type=OwnerType.PLAYER, **overrides)\` — \`MagicMock(spec=Bullet)\` factory with sensible defaults; keyword overrides \`setattr\` onto the mock.
- Drops the \`TestTankVsTank._make_player\` / \`_make_enemy\` helpers in \`test_collision_response_handler.py\` and the dead module-level \`_make_player\` in \`test_player_manager.py\`.
- Replaces ~22 inline \`EnemyTank(...)\` constructions, ~9 inline \`PlayerTank(...)\` constructions, and ~25 inline \`MagicMock(spec=Bullet)\` sites with factory calls.

Net: 5 files, +280 / −532 lines.

Closes #171.

## Test plan

- [x] \`pytest\` — 877 pass in 5.4s
- [x] \`ruff check src/ tests/\` — clean
- [x] \`ruff format --check src/ tests/\` — clean