### PR TITLE
polish(tests): replace stringly-typed owner_type / tank_type with enums

### DIFF
--- a/tests/integration/test_enemy_integration.py
+++ b/tests/integration/test_enemy_integration.py
@@ -5,6 +5,7 @@ from src.utils.constants import (
     Direction,
     Difficulty,
     FPS,
+    OwnerType,
     TILE_SIZE,
     SUB_TILE_SIZE,
     TankType,
@@ -572,7 +573,9 @@ def test_enemy_shooting(game_manager_fixture):
 
         # Check if an enemy bullet appeared in game_manager.bullets
         enemy_bullets = [
-            b for b in game_manager.bullets if b.owner_type == "enemy" and b.active
+            b
+            for b in game_manager.bullets
+            if b.owner_type == OwnerType.ENEMY and b.active
         ]
         if not bullet_fired and len(enemy_bullets) > 0:
             bullet_fired = True

--- a/tests/integration/test_gamestate_integration.py
+++ b/tests/integration/test_gamestate_integration.py
@@ -6,6 +6,7 @@ from src.utils.constants import (
     Direction,
     ENEMY_POINTS,
     FPS,
+    OwnerType,
     TILE_SIZE,
     SUB_TILE_SIZE,
     TankType,
@@ -96,7 +97,7 @@ def test_player_game_over_on_zero_lives():
     # --- Setup Mocks for Collision --- #
     # 1. Mock an enemy bullet involved in the collision
     mock_enemy_bullet = MagicMock(spec=Bullet)
-    mock_enemy_bullet.owner_type = "enemy"
+    mock_enemy_bullet.owner_type = OwnerType.ENEMY
     mock_enemy_bullet.active = True  # Needs to be active to be processed
 
     # 2. Mock the player tank's take_damage to return True (fatal hit)

--- a/tests/integration/test_player_integration.py
+++ b/tests/integration/test_player_integration.py
@@ -5,6 +5,7 @@ from src.managers.game_manager import GameManager
 from src.utils.constants import (
     Direction,
     FPS,
+    OwnerType,
     SUB_TILE_SIZE,
     BULLET_WIDTH,
     BULLET_HEIGHT,
@@ -289,7 +290,7 @@ def test_player_shooting():
     bullet = game_manager.bullets[0]
     assert bullet.active, "Bullet should be active after shooting."
     assert bullet.direction == Direction.RIGHT, "Bullet direction is incorrect."
-    assert bullet.owner_type == "player", "Bullet owner type is incorrect."
+    assert bullet.owner_type == OwnerType.PLAYER, "Bullet owner type is incorrect."
     assert bullet.owner is player_tank, "Bullet owner should be the player tank."
 
     # 4. Verify bullet initial position (centered on tank)

--- a/tests/unit/core/test_enemy_tank.py
+++ b/tests/unit/core/test_enemy_tank.py
@@ -4,6 +4,7 @@ from src.core.enemy_tank import EnemyTank, _get_enemy_config, _reset_enemy_confi
 from src.utils.constants import (
     TILE_SIZE,
     FPS,
+    OwnerType,
     TankType,
     Direction,
     Difficulty,
@@ -62,7 +63,7 @@ def test_enemy_tank_initialization_properties(
         expected["direction_change_interval"]
     )
 
-    assert tank.owner_type == "enemy"
+    assert tank.owner_type == OwnerType.ENEMY
     assert tank.lives == 1
     assert tank.x == 0
     assert tank.y == 0

--- a/tests/unit/managers/test_collision_manager.py
+++ b/tests/unit/managers/test_collision_manager.py
@@ -6,7 +6,7 @@ from src.core.tile import TileType, Tile
 from src.core.player_tank import PlayerTank
 from src.core.enemy_tank import EnemyTank
 from src.core.bullet import Bullet
-from src.utils.constants import TILE_SIZE
+from src.utils.constants import OwnerType, TILE_SIZE
 
 
 @pytest.fixture
@@ -20,25 +20,25 @@ def mock_objects(create_mock_sprite):
     """Provides a dictionary of mock game objects for collision tests."""
     tile_size = TILE_SIZE
     player = create_mock_sprite(
-        0, 0, tile_size, tile_size, spec=PlayerTank, owner_type="player"
+        0, 0, tile_size, tile_size, spec=PlayerTank, owner_type=OwnerType.PLAYER
     )
     enemy1 = create_mock_sprite(
-        100, 100, tile_size, tile_size, spec=EnemyTank, owner_type="enemy"
+        100, 100, tile_size, tile_size, spec=EnemyTank, owner_type=OwnerType.ENEMY
     )
     enemy2 = create_mock_sprite(
-        200, 200, tile_size, tile_size, spec=EnemyTank, owner_type="enemy"
+        200, 200, tile_size, tile_size, spec=EnemyTank, owner_type=OwnerType.ENEMY
     )
     p_bullet1 = create_mock_sprite(
-        50, 50, 5, 5, spec=Bullet, owner_type="player", active=True
+        50, 50, 5, 5, spec=Bullet, owner_type=OwnerType.PLAYER, active=True
     )
     p_bullet2 = create_mock_sprite(
-        60, 60, 5, 5, spec=Bullet, owner_type="player", active=True
+        60, 60, 5, 5, spec=Bullet, owner_type=OwnerType.PLAYER, active=True
     )
     e_bullet1 = create_mock_sprite(
-        150, 150, 5, 5, spec=Bullet, owner_type="enemy", active=True
+        150, 150, 5, 5, spec=Bullet, owner_type=OwnerType.ENEMY, active=True
     )
     e_bullet2 = create_mock_sprite(
-        160, 160, 5, 5, spec=Bullet, owner_type="enemy", active=True
+        160, 160, 5, 5, spec=Bullet, owner_type=OwnerType.ENEMY, active=True
     )
     brick1 = create_mock_sprite(
         300, 300, tile_size, tile_size, spec=Tile, type=TileType.BRICK

--- a/tests/unit/managers/test_collision_response_handler.py
+++ b/tests/unit/managers/test_collision_response_handler.py
@@ -58,8 +58,8 @@ def mock_bullet(make_bullet):
 @pytest.fixture
 def mock_enemy():
     e = MagicMock(spec=EnemyTank)
-    e.owner_type = "enemy"
-    e.tank_type = "basic"
+    e.owner_type = OwnerType.ENEMY
+    e.tank_type = TankType.BASIC
     e.take_damage = MagicMock(return_value=False)
     e.on_movement_blocked = MagicMock()
     e.revert_move = MagicMock()
@@ -70,7 +70,7 @@ def mock_enemy():
 @pytest.fixture
 def mock_player():
     p = MagicMock(spec=PlayerTank)
-    p.owner_type = "player"
+    p.owner_type = OwnerType.PLAYER
     p.is_invincible = False
     p.take_damage = MagicMock(return_value=False)
     p.respawn = MagicMock()
@@ -94,13 +94,13 @@ def mock_tile():
 class TestDispatch:
     def test_lookup_forward_order(self, handler, mock_bullet, mock_enemy):
         """Test registry finds handler with (Bullet, EnemyTank) order."""
-        mock_bullet.owner_type = "player"
+        mock_bullet.owner_type = OwnerType.PLAYER
         handler.process_collisions([(mock_bullet, mock_enemy)])
         assert not mock_bullet.active
 
     def test_lookup_swapped_order(self, handler, mock_bullet, mock_enemy):
         """Test registry finds handler with (EnemyTank, Bullet) order."""
-        mock_bullet.owner_type = "player"
+        mock_bullet.owner_type = OwnerType.PLAYER
         handler.process_collisions([(mock_enemy, mock_bullet)])
         assert not mock_bullet.active
 
@@ -117,20 +117,20 @@ class TestDispatch:
 
 class TestBulletVsEnemy:
     def test_player_bullet_damages_enemy(self, handler, mock_bullet, mock_enemy):
-        mock_bullet.owner_type = "player"
+        mock_bullet.owner_type = OwnerType.PLAYER
         handler.process_collisions([(mock_bullet, mock_enemy)])
         assert not mock_bullet.active
         mock_enemy.take_damage.assert_called_once()
 
     def test_player_bullet_destroys_enemy(self, handler, mock_bullet, mock_enemy):
-        mock_bullet.owner_type = "player"
+        mock_bullet.owner_type = OwnerType.PLAYER
         mock_enemy.take_damage.return_value = True
         enemies = handler.process_collisions([(mock_bullet, mock_enemy)])
         assert mock_enemy in enemies
 
     def test_enemy_bullet_does_not_damage_enemy(self, handler, make_bullet, mock_enemy):
         """Friendly fire — enemy bullet should not damage enemy."""
-        bullet = make_bullet(owner_type="enemy")
+        bullet = make_bullet(owner_type=OwnerType.ENEMY)
         handler.process_collisions([(bullet, mock_enemy)])
         mock_enemy.take_damage.assert_not_called()
         assert bullet.active  # Bullet not consumed
@@ -138,21 +138,21 @@ class TestBulletVsEnemy:
 
 class TestBulletVsPlayer:
     def test_enemy_bullet_damages_player(self, handler, make_bullet, mock_player):
-        bullet = make_bullet(owner_type="enemy")
+        bullet = make_bullet(owner_type=OwnerType.ENEMY)
         handler.process_collisions([(bullet, mock_player)])
         assert not bullet.active
         mock_player.take_damage.assert_called_once()
         mock_player.respawn.assert_called_once()
 
     def test_enemy_bullet_kills_player(self, handler, make_bullet, mock_player):
-        bullet = make_bullet(owner_type="enemy")
+        bullet = make_bullet(owner_type=OwnerType.ENEMY)
         mock_player.take_damage.return_value = True
         handler.process_collisions([(bullet, mock_player)])
         handler._set_game_state.assert_called_with(GameState.GAME_OVER)
         mock_player.respawn.assert_not_called()
 
     def test_bullet_vs_invincible_player(self, handler, make_bullet, mock_player):
-        bullet = make_bullet(owner_type="enemy")
+        bullet = make_bullet(owner_type=OwnerType.ENEMY)
         mock_player.is_invincible = True
         handler.process_collisions([(bullet, mock_player)])
         assert not bullet.active
@@ -358,7 +358,7 @@ class TestTracking:
         bullet = make_bullet()
         enemy2 = MagicMock(spec=EnemyTank)
         enemy2.take_damage = MagicMock(return_value=False)
-        enemy2.owner_type = "enemy"
+        enemy2.owner_type = OwnerType.ENEMY
         handler.process_collisions(
             [
                 (bullet, mock_enemy),
@@ -442,8 +442,8 @@ class TestExplosionEffects:
     ):
         bullet = make_bullet(rect=pygame.Rect(50, 50, 2, 2))
         enemy = MagicMock(spec=EnemyTank)
-        enemy.owner_type = "enemy"
-        enemy.tank_type = "basic"
+        enemy.owner_type = OwnerType.ENEMY
+        enemy.tank_type = TankType.BASIC
         enemy.take_damage = MagicMock(return_value=True)
         enemy.rect = pygame.Rect(100, 100, 32, 32)
         handler.process_collisions([(bullet, enemy)])
@@ -462,7 +462,7 @@ class TestExplosionEffects:
     def test_player_destroyed_spawns_large_explosion(
         self, handler, make_bullet, mock_player, mock_effect_manager
     ):
-        bullet = make_bullet(owner_type="enemy", rect=pygame.Rect(50, 50, 2, 2))
+        bullet = make_bullet(owner_type=OwnerType.ENEMY, rect=pygame.Rect(50, 50, 2, 2))
         mock_player.take_damage.return_value = True
         mock_player.rect = pygame.Rect(100, 100, 32, 32)
         handler.process_collisions([(bullet, mock_player)])

--- a/tests/unit/managers/test_game_manager.py
+++ b/tests/unit/managers/test_game_manager.py
@@ -7,6 +7,7 @@ from src.utils.constants import (
     Difficulty,
     MAX_STAGE,
     MenuAction,
+    TankType,
     VICTORY_PAUSE_DURATION,
     VOLUME_ADJUSTMENT_STEP,
 )
@@ -119,7 +120,7 @@ class TestGameManager:
         game_manager.player_manager = MagicMock()
         # Use a real list for enemy_tanks for the update loop check
         mock_enemy = MagicMock(spec=EnemyTank)
-        mock_enemy.tank_type = "basic"
+        mock_enemy.tank_type = TankType.BASIC
         game_manager.spawn_manager.enemy_tanks = [mock_enemy]
         game_manager.spawn_manager = MagicMock()
         game_manager.collision_response_handler = MagicMock()

--- a/tests/unit/managers/test_spawn_manager.py
+++ b/tests/unit/managers/test_spawn_manager.py
@@ -134,7 +134,7 @@ class TestSpawnManager:
 
         existing_enemy = MagicMock(spec=EnemyTank)
         existing_enemy.rect = pygame.Rect(spawn_x, spawn_y, TILE_SIZE, TILE_SIZE)
-        existing_enemy.tank_type = "basic"
+        existing_enemy.tank_type = TankType.BASIC
         spawn_manager.enemy_tanks = [existing_enemy]
         spawn_manager.total_enemy_spawns = 1
 


### PR DESCRIPTION
## Summary

- Replaces raw \`\"player\"\` / \`\"enemy\"\` / \`\"basic\"\` assignments and comparisons with \`OwnerType.PLAYER\` / \`OwnerType.ENEMY\` / \`TankType.BASIC\` across unit and integration tests.
- Both enums inherit \`str\`, so the strings worked at runtime — the rename is about making intent clear and letting type-checkers help.
- Leaves \`test_bullet.py\`'s \`\"test\"\` sentinel alone (deliberate non-enum value that proves \`owner_type\` flows through untouched).

Net: 8 files, +36 / −29.

Closes #174.

## Test plan

- [x] \`pytest\` — 877 pass
- [x] \`ruff check src/ tests/\` — clean
- [x] \`ruff format --check src/ tests/\` — clean