### PR TITLE
refactor(map): extract load_spawn_points into a pure function

### DIFF
--- a/src/core/map.py
+++ b/src/core/map.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass, field
 from typing import Iterable, List, Optional, Tuple
 import pygame
 import pytmx
@@ -13,6 +14,65 @@ from src.utils.constants import (
     SUB_TILE_SIZE,
     TankType,
 )
+
+
+@dataclass(frozen=True)
+class SpawnPoints:
+    """Spawn-point layout parsed from a TMX map."""
+
+    player_spawn: Tuple[int, int]
+    player_spawn_2: Optional[Tuple[int, int]] = None
+    enemy_spawns: List[Tuple[int, int]] = field(default_factory=list)
+
+
+def load_spawn_points(
+    tiled_map: pytmx.TiledMap, map_width: int, map_height: int
+) -> SpawnPoints:
+    """Parse spawn points and player spawn(s) from a TMX object layer.
+
+    Converts TMX pixel coordinates to grid coordinates. Missing spawn
+    layers or missing player_spawn objects fall back to sensible defaults
+    derived from the map dimensions.
+    """
+    spawn_layer = next(
+        (g for g in tiled_map.objectgroups if g.name == "spawn_points"),
+        None,
+    )
+    if spawn_layer is None:
+        logger.warning("No 'spawn_points' object layer found in TMX")
+        return SpawnPoints(player_spawn=(map_width // 2 - 1, map_height - 2))
+
+    player_spawn: Optional[Tuple[int, int]] = None
+    player_spawn_2: Optional[Tuple[int, int]] = None
+    enemy_spawns: List[Tuple[int, int]] = []
+    tmx_tw = tiled_map.tilewidth
+    tmx_th = tiled_map.tileheight
+    for obj in spawn_layer:
+        grid_x = int(obj.x // tmx_tw)
+        grid_y = int(obj.y // tmx_th)
+
+        # Prefer spawn_point_type property, fall back to object name
+        obj_props = obj.properties if hasattr(obj, "properties") else {}
+        spawn_type = obj_props.get("spawn_point_type") if obj_props else None
+        if spawn_type is None:
+            spawn_type = obj.name
+
+        if spawn_type == "player_spawn":
+            player_spawn = (grid_x, grid_y)
+        elif spawn_type == "player_spawn_2":
+            player_spawn_2 = (grid_x, grid_y)
+        else:
+            enemy_spawns.append((grid_x, grid_y))
+
+    if player_spawn is None:
+        logger.warning("No 'player_spawn' object found, defaulting to bottom-center")
+        player_spawn = (map_width // 2 - 2, map_height - 4)
+
+    return SpawnPoints(
+        player_spawn=player_spawn,
+        player_spawn_2=player_spawn_2,
+        enemy_spawns=enemy_spawns,
+    )
 
 
 class Map:
@@ -154,7 +214,10 @@ class Map:
                     self.tiles[y][x] = Tile(TileType.EMPTY, x, y, self.tile_size)
 
         # Read spawn points from object layer
-        self._load_spawn_points(tiled_map)
+        spawns = load_spawn_points(tiled_map, self.width, self.height)
+        self.player_spawn = spawns.player_spawn
+        self.player_spawn_2 = spawns.player_spawn_2
+        self.spawn_points = spawns.enemy_spawns
 
         # Read enemy composition from map-level properties
         self._read_level_properties(tiled_map)
@@ -219,48 +282,6 @@ class Map:
         raw_img = tiled_map.get_tile_image_by_gid(gid)
         if raw_img:
             cache[key] = pygame.transform.scale(raw_img, (SUB_TILE_SIZE, SUB_TILE_SIZE))
-
-    def _load_spawn_points(self, tiled_map: pytmx.TiledMap) -> None:
-        """Read spawn points and player spawn from TMX object layers.
-
-        Converts TMX pixel coordinates to grid coordinates.
-        """
-        spawn_layer = next(
-            (g for g in tiled_map.objectgroups if g.name == "spawn_points"),
-            None,
-        )
-        if spawn_layer is None:
-            logger.warning("No 'spawn_points' object layer found in TMX")
-            self.player_spawn = (self.width // 2 - 1, self.height - 2)
-            return
-
-        player_spawn_found = False
-        tmx_tw = tiled_map.tilewidth
-        tmx_th = tiled_map.tileheight
-        for obj in spawn_layer:
-            # Convert pixel coords to grid coords using TMX tile dimensions
-            grid_x = int(obj.x // tmx_tw)
-            grid_y = int(obj.y // tmx_th)
-
-            # Prefer spawn_point_type property, fall back to object name
-            obj_props = obj.properties if hasattr(obj, "properties") else {}
-            spawn_type = obj_props.get("spawn_point_type") if obj_props else None
-            if spawn_type is None:
-                spawn_type = obj.name
-
-            if spawn_type == "player_spawn":
-                self.player_spawn = (grid_x, grid_y)
-                player_spawn_found = True
-            elif spawn_type == "player_spawn_2":
-                self.player_spawn_2 = (grid_x, grid_y)
-            else:
-                self.spawn_points.append((grid_x, grid_y))
-
-        if not player_spawn_found:
-            self.player_spawn = (self.width // 2 - 2, self.height - 4)
-            logger.warning(
-                "No 'player_spawn' object found, defaulting to bottom-center"
-            )
 
     def _read_level_properties(self, tiled_map: pytmx.TiledMap) -> None:
         """Read per-level properties from TMX map-level custom properties.

--- a/tests/unit/core/test_map.py
+++ b/tests/unit/core/test_map.py
@@ -1,6 +1,8 @@
+from typing import Optional
+
 import pytest
 from unittest.mock import MagicMock
-from src.core.map import Map
+from src.core.map import Map, load_spawn_points
 from src.core.tile import TileType
 from src.utils.constants import (
     Difficulty,
@@ -555,74 +557,85 @@ class TestGetBaseSurroundingTiles:
             assert tile.type != TileType.EMPTY
 
 
-class TestMapPlayerSpawn2:
+def _mock_spawn_obj(name: str, x: int, y: int, properties: Optional[dict] = None):
+    """Build a minimal TMX-like spawn object for load_spawn_points tests."""
+    obj = MagicMock()
+    obj.name = name
+    obj.x = x
+    obj.y = y
+    obj.properties = properties or {}
+    return obj
+
+
+def _mock_tiled_map(spawn_objects, tilewidth: int = 8, tileheight: int = 8):
+    """Build a minimal TMX-like map wrapping the given spawn objects."""
+    tiled = MagicMock()
+    tiled.tilewidth = tilewidth
+    tiled.tileheight = tileheight
+    layer = MagicMock()
+    layer.name = "spawn_points"
+    layer.__iter__ = lambda self: iter(spawn_objects)
+    tiled.objectgroups = [layer]
+    return tiled
+
+
+class TestLoadSpawnPoints:
+    """Unit tests for the pure load_spawn_points function."""
+
     def test_player_spawn_2_loaded_from_tmx(self):
         """player_spawn_2 is loaded from spawn_points object layer."""
-        map_obj = Map.__new__(Map)
-        map_obj.player_spawn = (0, 0)
-        map_obj.player_spawn_2 = None
-        map_obj.spawn_points = []
-        map_obj.width = 26
-        map_obj.height = 26
+        tiled = _mock_tiled_map(
+            [
+                _mock_spawn_obj("player_spawn", 64, 192),
+                _mock_spawn_obj("player_spawn_2", 128, 192),
+                _mock_spawn_obj("enemy_spawn", 0, 0),
+            ]
+        )
 
-        mock_tiled = MagicMock()
-        mock_tiled.tilewidth = 8
-        mock_tiled.tileheight = 8
+        result = load_spawn_points(tiled, map_width=26, map_height=26)
 
-        mock_obj_p1 = MagicMock()
-        mock_obj_p1.name = "player_spawn"
-        mock_obj_p1.x = 64
-        mock_obj_p1.y = 192
-        mock_obj_p1.properties = {}
-
-        mock_obj_p2 = MagicMock()
-        mock_obj_p2.name = "player_spawn_2"
-        mock_obj_p2.x = 128
-        mock_obj_p2.y = 192
-        mock_obj_p2.properties = {}
-
-        mock_obj_enemy = MagicMock()
-        mock_obj_enemy.name = "enemy_spawn"
-        mock_obj_enemy.x = 0
-        mock_obj_enemy.y = 0
-        mock_obj_enemy.properties = {}
-
-        mock_layer = MagicMock()
-        mock_layer.name = "spawn_points"
-        objs = [mock_obj_p1, mock_obj_p2, mock_obj_enemy]
-        mock_layer.__iter__ = lambda self: iter(objs)
-        mock_tiled.objectgroups = [mock_layer]
-
-        map_obj._load_spawn_points(mock_tiled)
-
-        assert map_obj.player_spawn == (8, 24)
-        assert map_obj.player_spawn_2 == (16, 24)
-        assert len(map_obj.spawn_points) == 1
+        assert result.player_spawn == (8, 24)
+        assert result.player_spawn_2 == (16, 24)
+        assert len(result.enemy_spawns) == 1
 
     def test_player_spawn_2_defaults_to_none(self):
         """player_spawn_2 is None when not present in TMX."""
-        map_obj = Map.__new__(Map)
-        map_obj.player_spawn = (0, 0)
-        map_obj.player_spawn_2 = None
-        map_obj.spawn_points = []
-        map_obj.width = 26
-        map_obj.height = 26
+        tiled = _mock_tiled_map([_mock_spawn_obj("player_spawn", 64, 192)])
 
-        mock_tiled = MagicMock()
-        mock_tiled.tilewidth = 8
-        mock_tiled.tileheight = 8
+        result = load_spawn_points(tiled, map_width=26, map_height=26)
 
-        mock_obj_p1 = MagicMock()
-        mock_obj_p1.name = "player_spawn"
-        mock_obj_p1.x = 64
-        mock_obj_p1.y = 192
-        mock_obj_p1.properties = {}
+        assert result.player_spawn_2 is None
 
-        mock_layer = MagicMock()
-        mock_layer.name = "spawn_points"
-        mock_layer.__iter__ = lambda self: iter([mock_obj_p1])
-        mock_tiled.objectgroups = [mock_layer]
+    def test_missing_spawn_layer_falls_back(self):
+        """A map with no spawn_points layer yields a centered-bottom default."""
+        tiled = MagicMock()
+        tiled.objectgroups = []
 
-        map_obj._load_spawn_points(mock_tiled)
+        result = load_spawn_points(tiled, map_width=26, map_height=26)
 
-        assert map_obj.player_spawn_2 is None
+        assert result.player_spawn == (26 // 2 - 1, 26 - 2)
+        assert result.player_spawn_2 is None
+        assert result.enemy_spawns == []
+
+    def test_missing_player_spawn_falls_back(self):
+        """Spawn layer with no player_spawn object uses bottom-center default."""
+        tiled = _mock_tiled_map([_mock_spawn_obj("enemy_spawn", 0, 0)])
+
+        result = load_spawn_points(tiled, map_width=26, map_height=26)
+
+        assert result.player_spawn == (26 // 2 - 2, 26 - 4)
+        assert result.enemy_spawns == [(0, 0)]
+
+    def test_spawn_point_type_property_wins_over_name(self):
+        """spawn_point_type property takes precedence over obj.name."""
+        tiled = _mock_tiled_map(
+            [
+                _mock_spawn_obj(
+                    "ignored", 64, 192, properties={"spawn_point_type": "player_spawn"}
+                ),
+            ]
+        )
+
+        result = load_spawn_points(tiled, map_width=26, map_height=26)
+
+        assert result.player_spawn == (8, 24)


### PR DESCRIPTION
## Summary

- Moves spawn-point parsing out of \`Map._load_spawn_points\` (a method mutating \`self\`) into a module-level pure function \`load_spawn_points(tiled_map, map_width, map_height) -> SpawnPoints\`. \`Map.__init__\` calls it and assigns \`player_spawn\` / \`player_spawn_2\` / \`spawn_points\`.
- Drops the \`Map.__new__(Map)\` bypass in the tests — they just feed a mock \`tiled_map\` into the function and assert on the returned dataclass.
- Adds coverage for the two fallback paths (no spawn layer, no \`player_spawn\` object) and the \`spawn_point_type\`-over-\`name\` precedence, which the prior tests did not exercise.

Net: 2 files, +144 / −110. Suite went from 877 to 880 tests (three new fallback tests).

Closes #173.

## Test plan

- [x] \`pytest\` — 880 pass
- [x] \`ruff check src/ tests/\` — clean
- [x] \`ruff format --check src/ tests/\` — clean