### PR TITLE
perf(tests): shrink oversized integration tick loops

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -69,7 +69,7 @@ def spawn_carrier(game):
     the small test map's spawn points.
     """
     first_carrier_index = POWERUP_CARRIER_INDICES[0]
-    max_attempts = (first_carrier_index + 1) * 5
+    max_attempts = first_carrier_index + 2
     for _ in range(max_attempts):
         if game.spawn_manager.total_enemy_spawns > first_carrier_index:
             break

--- a/tests/integration/test_collision_integration.py
+++ b/tests/integration/test_collision_integration.py
@@ -511,6 +511,8 @@ def test_enemy_bullet_hits_other_enemy(game_manager_fixture, mocker):
 
     for _ in range(num_updates):
         game_manager.update()
+        if not bullet.active:
+            break
 
     # --- Assertions --- #
     # Bullet should remain active as enemy bullets don't hit other enemies
@@ -681,20 +683,11 @@ def test_enemy_bullets_collide(game_manager_fixture, mocker):
     update_duration = 0.4  # Should be sufficient time
     num_updates = int(update_duration / dt)
 
-    # Record initial active states
-    initial_bullet1_active = bullet1.active
-    initial_bullet2_active = bullet2.active
-
     logger.info(f"Simulating {num_updates} updates to check bullet pass-through.")
-    for i in range(num_updates):
+    for _ in range(num_updates):
         game_manager.update()
-        # Check if bullets became inactive unexpectedly
-        if not bullet1.active and initial_bullet1_active:
-            logger.warning(f"Bullet 1 became inactive unexpectedly on update {i + 1}")
-            # Allow simulation to continue to check bullet 2
-        if not bullet2.active and initial_bullet2_active:
-            logger.warning(f"Bullet 2 became inactive unexpectedly on update {i + 1}")
-            # Allow simulation to continue to check bullet 1
+        if not (bullet1.active and bullet2.active):
+            break
 
     # --- Assertions --- #
     # Bullets should still be active after passing each other's paths

--- a/tests/integration/test_effect_integration.py
+++ b/tests/integration/test_effect_integration.py
@@ -43,7 +43,7 @@ class TestEffectLifecycle:
 
         # Run updates until the bullet hits the tile (or max iterations)
         effect_spawned = False
-        for _ in range(200):
+        for _ in range(30):
             gm.update()
             if gm.effect_manager.effects:
                 effect_spawned = True
@@ -55,7 +55,7 @@ class TestEffectLifecycle:
         assert len(gm.effect_manager.effects) >= 1
 
         # Now keep updating until the effect expires
-        for _ in range(100):
+        for _ in range(60):
             gm.effect_manager.update(dt)
             if not gm.effect_manager.effects:
                 break

--- a/tests/integration/test_stage_transition.py
+++ b/tests/integration/test_stage_transition.py
@@ -22,7 +22,9 @@ class TestStageTransition:
         assert game.state == GameState.VICTORY
 
         # Tick through entire transition
-        for _ in range(600):
+        # Total ~4s: VICTORY_PAUSE (1.0) + CURTAIN_CLOSE (0.75) + CURTAIN_STAGE_DISPLAY
+        # (1.5) + CURTAIN_OPEN (0.75). Allow comfortable margin.
+        for _ in range(300):
             game.update()
             if game.state == GameState.RUNNING:
                 break


### PR DESCRIPTION
## Summary

- `test_effect_integration.py`: `range(200)` → 30 for bullet-tile collision (collision happens in <10 ticks); `range(100)` → 60 for effect expiry (frame budgets are 12-18 ticks).
- `test_stage_transition.py`: `range(600)` → 300 (full transition is ~240 ticks; the 600-tick bound was 2.5× longer than needed).
- `test_collision_integration.py`: add early-exit `break` to two bullet-pass-through loops so regressions fail fast; drop unused `initial_bulletN_active` bookkeeping that only fed warning logs.
- `tests/integration/conftest.py` `spawn_carrier`: `max_attempts` from `(first_carrier_index + 1) * 5` (=20) down to `first_carrier_index + 2` (=5). The carrier is deterministic on the 4th spawn so the original bound was 4× larger than necessary.

Closes #186.

## Test plan

- [x] `pytest tests/integration/` — 99 passed
- [x] `ruff check` / `ruff format --check`