### PR TITLE
polish(tests): parametrize the test_ctrl_* up-input trio

### DIFF
--- a/tests/integration/test_controller.py
+++ b/tests/integration/test_controller.py
@@ -1,6 +1,7 @@
 """Integration tests for SDL GameController gameplay input."""
 
 import pygame
+import pytest
 from src.managers.game_manager import GameManager
 from src.managers.player_input import AXIS_MAX
 from src.states.game_state import GameState
@@ -13,40 +14,37 @@ def _send_event(gm, event):
     gm.player_manager.handle_event(event)
 
 
-class TestControllerGameplay:
-    """Test controller input during gameplay via the SDL GameController API."""
-
-    def test_ctrl_dpad_moves_player(self) -> None:
-        """Controller D-pad UP moves the player tank up."""
-        gm = GameManager()
-        gm._reset_game()
-        gm.state = GameState.RUNNING
-        initial_y = first_player(gm).y
-
-        event = pygame.event.Event(
+def _up_event(source: str) -> pygame.event.Event:
+    if source == "dpad":
+        return pygame.event.Event(
             pygame.CONTROLLERBUTTONDOWN,
             button=pygame.CONTROLLER_BUTTON_DPAD_UP,
             instance_id=0,
         )
-        _send_event(gm, event)
-        gm.update()
-
-        assert first_player(gm).y < initial_y
-
-    def test_ctrl_stick_moves_player(self) -> None:
-        """Controller left stick UP moves the player tank up."""
-        gm = GameManager()
-        gm._reset_game()
-        gm.state = GameState.RUNNING
-        initial_y = first_player(gm).y
-
-        event = pygame.event.Event(
+    if source == "stick":
+        return pygame.event.Event(
             pygame.CONTROLLERAXISMOTION,
             axis=pygame.CONTROLLER_AXIS_LEFTY,
             value=int(-0.8 * AXIS_MAX),
             instance_id=0,
         )
-        _send_event(gm, event)
+    if source == "keyboard":
+        return pygame.event.Event(pygame.KEYDOWN, key=pygame.K_UP)
+    raise ValueError(f"Unknown input source: {source}")
+
+
+class TestControllerGameplay:
+    """Test controller input during gameplay via the SDL GameController API."""
+
+    @pytest.mark.parametrize("source", ["dpad", "stick", "keyboard"])
+    def test_up_input_moves_player(self, source: str) -> None:
+        """D-pad, left stick, and keyboard all move the player tank up."""
+        gm = GameManager()
+        gm._reset_game()
+        gm.state = GameState.RUNNING
+        initial_y = first_player(gm).y
+
+        _send_event(gm, _up_event(source))
         gm.update()
 
         assert first_player(gm).y < initial_y
@@ -66,19 +64,6 @@ class TestControllerGameplay:
         gm.update()
 
         assert len(gm.player_manager.get_all_bullets()) > 0
-
-    def test_keyboard_still_works(self) -> None:
-        """Keyboard input still works alongside controller."""
-        gm = GameManager()
-        gm._reset_game()
-        gm.state = GameState.RUNNING
-        initial_y = first_player(gm).y
-
-        key_event = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_UP)
-        _send_event(gm, key_event)
-        gm.update()
-
-        assert first_player(gm).y < initial_y
 
 
 class TestControllerMenuNavigation:


### PR DESCRIPTION
## Summary

- Collapse `test_ctrl_dpad_moves_player`, `test_ctrl_stick_moves_player`, and `test_keyboard_still_works` into a single parametrized `test_up_input_moves_player[dpad|stick|keyboard]`.
- Extract `_up_event(source)` helper to build the pygame event from a source id.
- `test_ctrl_a_button_fires_bullet` left alone — it asserts a different behavior.

Closes #187.

## Test plan

- [x] `pytest tests/integration/test_controller.py -v` — 6 passed (3 parametrized cases + 1 fire-bullet + 2 menu)
- [x] `ruff check` / `ruff format --check`