### PR TITLE
perf(tests): consume game_manager_fixture in player/controller tests

### DIFF
--- a/tests/integration/test_controller.py
+++ b/tests/integration/test_controller.py
@@ -37,11 +37,9 @@ class TestControllerGameplay:
     """Test controller input during gameplay via the SDL GameController API."""
 
     @pytest.mark.parametrize("source", ["dpad", "stick", "keyboard"])
-    def test_up_input_moves_player(self, source: str) -> None:
+    def test_up_input_moves_player(self, game_manager_fixture, source: str) -> None:
         """D-pad, left stick, and keyboard all move the player tank up."""
-        gm = GameManager()
-        gm._reset_game()
-        gm.state = GameState.RUNNING
+        gm = game_manager_fixture
         initial_y = first_player(gm).y
 
         _send_event(gm, _up_event(source))
@@ -49,11 +47,9 @@ class TestControllerGameplay:
 
         assert first_player(gm).y < initial_y
 
-    def test_ctrl_a_button_fires_bullet(self) -> None:
+    def test_ctrl_a_button_fires_bullet(self, game_manager_fixture) -> None:
         """Controller A button fires a bullet."""
-        gm = GameManager()
-        gm._reset_game()
-        gm.state = GameState.RUNNING
+        gm = game_manager_fixture
 
         event = pygame.event.Event(
             pygame.CONTROLLERBUTTONDOWN,

--- a/tests/integration/test_player_integration.py
+++ b/tests/integration/test_player_integration.py
@@ -1,7 +1,6 @@
 import pytest
 import pygame
 from loguru import logger
-from src.managers.game_manager import GameManager
 from src.utils.constants import (
     Direction,
     FPS,
@@ -25,11 +24,11 @@ from tests.integration.conftest import first_player
         (pygame.K_RIGHT, 0, 1, Direction.RIGHT),  # RIGHT: x-axis, positive
     ],
 )
-def test_player_movement(key, axis, direction_sign, expected_direction):
+def test_player_movement(
+    game_manager_fixture, key, axis, direction_sign, expected_direction
+):
     """Test player tank movement and direction in all four directions."""
-    # Use fresh instance to avoid side effects from other tests
-    game_manager = GameManager()
-    game_manager._reset_game()
+    game_manager = game_manager_fixture
     player_tank = first_player(game_manager)
     game_map = game_manager.map
 
@@ -271,11 +270,9 @@ def test_player_movement_blocked_by_tile(
     )
 
 
-def test_player_shooting():
+def test_player_shooting(game_manager_fixture):
     """Test player shooting mechanics."""
-    # Use fresh instance
-    game_manager = GameManager()
-    game_manager._reset_game()
+    game_manager = game_manager_fixture
     player_tank = first_player(game_manager)
 
     # 1. Initial state: No bullets
@@ -322,11 +319,11 @@ def test_player_shooting():
         (Direction.RIGHT, 0, 1),  # RIGHT: axis=0 (x), sign=1 (increase)
     ],
 )
-def test_player_bullet_movement(direction_str, axis_index, direction_sign):
+def test_player_bullet_movement(
+    game_manager_fixture, direction_str, axis_index, direction_sign
+):
     """Test that the player's bullet moves correctly after firing."""
-    # Use fresh instance
-    game_manager = GameManager()
-    game_manager._reset_game()
+    game_manager = game_manager_fixture
     player_tank = first_player(game_manager)
 
     # Set tank direction and fire
@@ -373,11 +370,9 @@ def test_player_bullet_movement(direction_str, axis_index, direction_sign):
     )
 
 
-def test_player_respawn():
+def test_player_respawn(game_manager_fixture):
     """Test player respawn mechanics after taking lethal damage with lives remaining."""
-    # Use fresh instance
-    game_manager = GameManager()
-    game_manager._reset_game()
+    game_manager = game_manager_fixture
     player_tank = first_player(game_manager)
 
     initial_lives = player_tank.lives


### PR DESCRIPTION
## Summary

Closes #185.

- Switch 4 tests in `test_player_integration.py` (`test_player_movement`, `test_player_shooting`, `test_player_bullet_movement`, `test_player_respawn`) from manual `GameManager() + _reset_game()` construction to the existing `game_manager_fixture`.
- Switch 2 gameplay tests in `test_controller.py` (`test_up_input_moves_player`, `test_ctrl_a_button_fires_bullet`) to the same fixture and drop the redundant `gm.state = GameState.RUNNING` lines (the fixture already calls `_reset_game()`, which sets that state).
- The 2 menu-navigation tests (`test_ctrl_dpad_navigates_title_screen`, `test_ctrl_a_confirms_title_selection`) keep their manual `GameManager()` construction — they operate on the title screen and must not call `_reset_game()`.

Fewer map/sprite loads per suite run; identical behavior.

## Test plan

- [x] `pytest tests/integration/test_player_integration.py tests/integration/test_controller.py` — 24 passed
- [x] `ruff check` + `ruff format --check` clean