### PR TITLE
fix(tests): assert invincibility window in test_player_respawn

### DIFF
--- a/tests/integration/test_player_integration.py
+++ b/tests/integration/test_player_integration.py
@@ -430,25 +430,20 @@ def test_player_respawn():
     # 5. Verify invincibility wears off after duration
     invincibility_duration = player_tank.invincibility_duration
     dt = 1.0 / FPS
-    # Calculate number of updates to *exceed* the duration slightly
-    num_updates_to_exceed_duration = int(invincibility_duration / dt) + 2
+    num_updates_during = int(invincibility_duration / dt)
 
-    # Update until invincibility should have worn off
-    for i in range(num_updates_to_exceed_duration):
-        # Check if invincibility wore off early (optional, but good for debugging)
-        if not player_tank.is_invincible and i * dt < invincibility_duration:
-            logger.warning(
-                f"Invincibility wore off early at frame {i + 1} ({i * dt:.2f}s)"
-            )
-            # We can continue or fail here depending on strictness
-            break
-        game_manager.update()  # Need to update game manager for timers
+    # While the elapsed game time is still within the invincibility window,
+    # invincibility MUST remain active. A regression that shortens the window
+    # should fail the test here rather than silently pass.
+    for i in range(num_updates_during):
+        assert player_tank.is_invincible, (
+            f"Invincibility wore off early at frame {i + 1} "
+            f"({i * dt:.2f}s of {invincibility_duration}s)"
+        )
+        game_manager.update()
 
-        # Exit loop once invincibility wears off
-        if not player_tank.is_invincible:
-            logger.info(
-                f"Invincibility wore off as expected at frame {i + 1} ({i * dt:.2f}s)"
-            )
-            break
+    # Tick past the threshold; invincibility should now have expired.
+    for _ in range(2):
+        game_manager.update()
 
     assert not player_tank.is_invincible, "Player invincibility did not wear off."


### PR DESCRIPTION
## Summary

Closes #190.

The invincibility-duration loop in `test_player_respawn` used to log a warning and `break` when `is_invincible` flipped early, silently passing the test. If the invincibility duration regressed below expectation, the test would still pass without alerting.

Restructure the loop:
- While elapsed game time is within `invincibility_duration`, hard-assert `player_tank.is_invincible` on every frame.
- After the window, tick two more frames and assert invincibility has worn off.

A regression that shortens the invincibility window now fails the test.

## Test plan

- [x] `pytest tests/integration/test_player_integration.py::test_player_respawn` — 1 passed
- [x] `ruff check` + `ruff format --check` clean