### PR TITLE
polish(tests): strip narration and banner comments from integration tests

### DIFF
--- a/tests/integration/test_collision_integration.py
+++ b/tests/integration/test_collision_integration.py
@@ -1,25 +1,22 @@
 import pytest
-from loguru import logger
 from src.utils.constants import Direction, FPS, TILE_SIZE, SUB_TILE_SIZE, TankType
 from src.states.game_state import GameState
 from src.core.tile import BrickVariant, Tile, TileDefaults, TileType
 from src.core.enemy_tank import EnemyTank
 from tests.integration.conftest import first_player
 
-# Tests related to collision interactions between different game objects
-
 
 @pytest.mark.parametrize(
     "tile_to_place, expected_bullet_active, expected_tile_type",
     [
-        (TileType.BRICK, False, TileType.BRICK),  # Bullet damages brick (full→half)
-        (TileType.STEEL, False, TileType.STEEL),  # Bullet hits steel, steel unchanged
-        (TileType.WATER, True, TileType.WATER),  # Bullet passes through water
-        (TileType.BUSH, True, TileType.BUSH),  # Bullet passes through bush
+        (TileType.BRICK, False, TileType.BRICK),
+        (TileType.STEEL, False, TileType.STEEL),
+        (TileType.WATER, True, TileType.WATER),
+        (TileType.BUSH, True, TileType.BUSH),
     ],
 )
 def test_player_bullet_vs_tile(
-    game_manager_fixture,  # Use the base fixture
+    game_manager_fixture,
     tile_to_place,
     expected_bullet_active,
     expected_tile_type,
@@ -29,11 +26,9 @@ def test_player_bullet_vs_tile(
     player_tank = first_player(game_manager)
     game_map = game_manager.map
 
-    # Define target tile location (sub-tile grid coords)
     target_x_grid = 14
     target_y_grid = 20
 
-    # Manually place the specified tile type at the target location
     if 0 <= target_y_grid < game_map.height and 0 <= target_x_grid < game_map.width:
         defaults = game_map._tile_collision_defaults.get(tile_to_place, TileDefaults())
         target_tile = Tile(
@@ -48,22 +43,18 @@ def test_player_bullet_vs_tile(
             is_slidable=defaults.is_slidable,
         )
         game_map.place_tile(target_x_grid, target_y_grid, target_tile)
-        logger.debug(
-            f"Placed {tile_to_place.name} tile at ({target_x_grid}, {target_y_grid})"
-        )
     else:
         pytest.fail(
             f"Target tile coordinates ({target_x_grid}, {target_y_grid}) "
             f"are out of bounds."
         )
 
-    # Clear sub-tiles around the target and between target and player position
-    # (2 sub-tiles wide for bullet path, plus player's own area)
+    # Clear 2 sub-tiles wide (bullet path) for 4 sub-tiles deep (target + player area),
+    # skipping the target itself.
     for y in range(target_y_grid, target_y_grid + 4):
         for dx in range(2):
             sx = target_x_grid + dx
             if 0 <= sx < game_map.width and 0 <= y < game_map.height:
-                # Skip the target tile itself
                 if sx == target_x_grid and y == target_y_grid:
                     continue
                 t = game_map.get_tile_at(sx, y)
@@ -72,46 +63,38 @@ def test_player_bullet_vs_tile(
                         sx, y, Tile(TileType.EMPTY, sx, y, SUB_TILE_SIZE)
                     )
 
-    # Position player below the target tile (2 sub-tiles = 1 tank height)
+    # Player below target (2 sub-tiles = 1 tank height).
     player_start_x = target_x_grid * SUB_TILE_SIZE
     player_start_y = (target_y_grid + 2) * SUB_TILE_SIZE
     player_tank.set_position(player_start_x, player_start_y)
     player_tank.prev_x, player_tank.prev_y = player_start_x, player_start_y
 
-    # Aim up and shoot via PlayerManager
     player_tank.direction = Direction.UP
     bullet_obj = player_tank.shoot()
     assert bullet_obj is not None, "Bullet failed to spawn."
     game_manager.player_manager._bullets.append(bullet_obj)
     bullet = bullet_obj
 
-    # Simulate game time until bullet should have hit (or passed)
     dt = 1.0 / FPS
-    update_duration = 0.2  # Sufficient time for bullet to travel one tile
+    update_duration = 0.2
     num_updates = int(update_duration / dt)
 
-    for i in range(num_updates):
-        game_manager.update()  # Update game (moves bullet, processes collisions)
-        # Stop checking early if bullet becomes inactive for relevant cases
+    for _ in range(num_updates):
+        game_manager.update()
         if not expected_bullet_active and not bullet.active:
-            logger.debug(f"Bullet became inactive as expected after {i + 1} updates.")
             break
 
-    # --- Assertions after updates ---
-    # 1. Verify bullet's final active state
     assert bullet.active == expected_bullet_active, (
         f"Bullet active state mismatch for {tile_to_place.name}. "
         f"Expected: {expected_bullet_active}, Got: {bullet.active}"
     )
 
-    # 2. Verify the tile's final type
     final_tile = game_map.get_tile_at(target_x_grid, target_y_grid)
     assert final_tile is not None, "Target tile somehow disappeared."
     assert final_tile.type == expected_tile_type, (
         f"Tile type mismatch for {tile_to_place.name}. "
         f"Expected: {expected_tile_type.name}, Got: {final_tile.type.name}"
     )
-    # For brick: verify it was damaged or destroyed
     if tile_to_place == TileType.BRICK:
         damaged = (
             final_tile.type == TileType.EMPTY
@@ -135,21 +118,16 @@ def test_player_bullet_destroys_enemy_tank(game_manager_fixture, mocker):
     game_manager = game_manager_fixture
     player_tank = first_player(game_manager)
 
-    # --- Spawn Enemy Tank --- #
     enemy_type = TankType.BASIC
-    enemy_x_grid = 14  # sub-tile grid coords
+    enemy_x_grid = 14
     enemy_y_grid = 10
     enemy_start_x = enemy_x_grid * SUB_TILE_SIZE
     enemy_start_y = enemy_y_grid * SUB_TILE_SIZE
 
-    # Clear 2x2 sub-tile blocks at entity positions so they don't collide with terrain
+    # Clear enemy + player (2 sub-tiles each = 4 total) across 2 columns.
     _clear_tiles(
         game_manager.map,
-        [
-            (enemy_x_grid + dx, enemy_y_grid + dy)
-            for dy in range(4)  # enemy + player below (2 sub-tiles each)
-            for dx in range(2)
-        ],
+        [(enemy_x_grid + dx, enemy_y_grid + dy) for dy in range(4) for dx in range(2)],
     )
 
     map_w_px = game_manager.map.width * SUB_TILE_SIZE
@@ -163,73 +141,43 @@ def test_player_bullet_destroys_enemy_tank(game_manager_fixture, mocker):
         map_width_px=map_w_px,
         map_height_px=map_h_px,
     )
-    # Prevent enemy from shooting so its bullets don't interfere
+    # Prevent enemy shooting so its bullets don't interfere with the player bullet.
     enemy_tank.shoot = lambda: None
-    # Replace existing enemies with just this one for a clean test
     game_manager.spawn_manager.enemy_tanks = [enemy_tank]
     initial_enemy_count = len(game_manager.spawn_manager.enemy_tanks)
-    logger.debug(
-        f"Manually added {enemy_type} enemy at ({enemy_x_grid}, {enemy_y_grid})"
-    )
-    # --- End Spawn --- #
 
-    # Position player below the enemy tank (2 sub-tiles = 1 tank height)
+    # Player below enemy (2 sub-tiles = 1 tank height).
     player_start_x = enemy_x_grid * SUB_TILE_SIZE
     player_start_y = (enemy_y_grid + 2) * SUB_TILE_SIZE
     player_tank.set_position(player_start_x, player_start_y)
     player_tank.prev_x, player_tank.prev_y = player_start_x, player_start_y
 
-    # Aim up and shoot via PlayerManager
     player_tank.direction = Direction.UP
     bullet_obj = player_tank.shoot()
     assert bullet_obj is not None, "Bullet failed to spawn."
     game_manager.player_manager._bullets.append(bullet_obj)
     bullet = bullet_obj
 
-    # Simulate game time until bullet should have hit
     dt = 1.0 / FPS
-    max_simulation_time = 0.5  # Increased timeout duration
+    max_simulation_time = 0.5
     max_updates = int(max_simulation_time / dt)
-    enemy_destroyed_during_loop = False
     bullet_became_inactive_during_loop = False
 
-    for i in range(max_updates):
-        game_manager.update()  # Update game (moves bullet, processes collisions)
+    for _ in range(max_updates):
+        game_manager.update()
         if not bullet.active:
-            logger.debug(f"Player bullet became inactive after {i + 1} updates.")
             bullet_became_inactive_during_loop = True
-            # If bullet is inactive, check if enemy is also destroyed
-            if enemy_tank not in game_manager.spawn_manager.enemy_tanks:
-                enemy_destroyed_during_loop = True
-            break  # Stop if bullet is inactive
-
+            break
         if enemy_tank not in game_manager.spawn_manager.enemy_tanks:
-            logger.debug(f"Enemy tank destroyed after {i + 1} updates.")
-            enemy_destroyed_during_loop = True
-            # If enemy destroyed, bullet might still be active if it passed through
             if not bullet.active:
                 bullet_became_inactive_during_loop = True
-            break  # Stop if enemy is destroyed
-    else:  # Loop finished without break
-        logger.warning(
-            f"Max updates ({max_updates}) reached. Bullet active: {bullet.active}, "
-            f"Enemy in list: {enemy_tank in game_manager.spawn_manager.enemy_tanks}"
-        )
+            break
 
-    # --- Assertions after updates ---
-    # 1. Bullet should be inactive if it hit the enemy.
-    # If enemy was destroyed, bullet may have passed through.
-    if enemy_destroyed_during_loop or (
-        enemy_tank not in game_manager.spawn_manager.enemy_tanks
-    ):
-        pass
-    else:
-        # Enemy survived — bullet must have become inactive.
+    if enemy_tank in game_manager.spawn_manager.enemy_tanks:
         assert bullet_became_inactive_during_loop, (
             "Bullet remained active but enemy was not destroyed."
         )
 
-    # 2. The enemy tank should have been removed from the list
     assert enemy_tank not in game_manager.spawn_manager.enemy_tanks, (
         "Enemy tank was not removed after being hit."
     )
@@ -242,11 +190,8 @@ def test_player_bullet_destroys_enemy_tank(game_manager_fixture, mocker):
     "player_initial_lives, player_is_invincible, expected_game_state, "
     "expected_player_lives_after_hit",
     [
-        # Case 1: Vulnerable player, final life -> Game Over animation
         (1, False, GameState.GAME_OVER_ANIMATION, 0),
-        # Case 2: Vulnerable player, multiple lives -> Respawn
         (3, False, GameState.RUNNING, 2),
-        # Case 3: Invincible player -> No effect
         (3, True, GameState.RUNNING, 3),
     ],
 )
@@ -264,27 +209,20 @@ def test_enemy_bullet_hits_player_tank(
     player_tank = first_player(game_manager)
     initial_spawn_pos = player_tank.initial_position
 
-    # --- Configure Player State ---
     player_tank.lives = player_initial_lives
     player_tank.is_invincible = player_is_invincible
-    player_tank.invincibility_timer = 0  # Reset timer if starting invincible
-    logger.debug(
-        f"Setting up player: lives={player_tank.lives}, "
-        f"invincible={player_tank.is_invincible}"
-    )
-    # --- End Player Config ---
+    player_tank.invincibility_timer = 0
 
-    # --- Spawn Enemy Tank Above Player --- #
     enemy_type = TankType.BASIC
     player_x_grid = int(player_tank.x // SUB_TILE_SIZE)
     player_y_grid = int(player_tank.y // SUB_TILE_SIZE)
     enemy_x_grid = player_x_grid
-    enemy_y_grid = player_y_grid - 4  # Place enemy 4 sub-tiles (2 tank heights) above
+    # 4 sub-tiles (= 2 tank heights) above the player.
+    enemy_y_grid = player_y_grid - 4
 
     enemy_start_x = enemy_x_grid * SUB_TILE_SIZE
     enemy_start_y = enemy_y_grid * SUB_TILE_SIZE
 
-    # Ensure enemy spawns within bounds
     if not (
         0 <= enemy_y_grid < game_manager.map.height
         and 0 <= enemy_x_grid < game_manager.map.width
@@ -294,7 +232,6 @@ def test_enemy_bullet_hits_player_tank(
             f"is out of bounds. Skipping."
         )
 
-    # Clear sub-tiles along the bullet path from enemy to player (2 cols wide)
     _clear_tiles(
         game_manager.map,
         [
@@ -315,49 +252,33 @@ def test_enemy_bullet_hits_player_tank(
         map_width_px=map_w_px,
         map_height_px=map_h_px,
     )
-    enemy_tank.direction = Direction.DOWN  # Aim at player
-    game_manager.spawn_manager.enemy_tanks = [enemy_tank]  # Replace default enemies
-    logger.debug(
-        f"Manually added {enemy_type} enemy at ({enemy_x_grid}, {enemy_y_grid}) "
-        f"aiming {enemy_tank.direction}"
-    )
-    # --- End Enemy Spawn --- #
+    enemy_tank.direction = Direction.DOWN
+    game_manager.spawn_manager.enemy_tanks = [enemy_tank]
 
-    # --- Fire Enemy Bullet --- #
     game_manager._try_shoot(enemy_tank)
     enemy_bullets = [b for b in game_manager.bullets if b.owner is enemy_tank]
     assert len(enemy_bullets) == 1, "Enemy bullet failed to spawn."
     enemy_bullet = enemy_bullets[0]
     assert enemy_bullet.active, "Enemy bullet spawned inactive."
-    # --- End Fire --- #
 
-    # --- Simulate game time until bullet should hit --- #
     dt = 1.0 / FPS
-    max_simulation_time = 0.6  # Increased timeout duration
+    max_simulation_time = 0.6
     max_updates = int(max_simulation_time / dt)
     interaction_processed = False
 
-    original_player_lives = player_tank.lives  # Store to check if lives changed
+    original_player_lives = player_tank.lives
 
     for i in range(max_updates):
-        game_manager.update()  # Update game (moves bullet, processes collisions)
+        game_manager.update()
 
         current_lives = player_tank.lives
         current_state = game_manager.state
 
-        # Check for interaction conditions
         if not player_is_invincible:
             if not enemy_bullet.active:
-                logger.debug(
-                    f"Enemy bullet inactive after {i + 1} updates (hit detected)."
-                )
                 interaction_processed = True
                 break
             if current_lives < original_player_lives:
-                logger.debug(
-                    f"Player lost a life (lives: "
-                    f"{current_lives}) after {i + 1} updates."
-                )
                 interaction_processed = True
                 break
             if current_state in (
@@ -367,45 +288,25 @@ def test_enemy_bullet_hits_player_tank(
                 GameState.GAME_OVER,
                 GameState.GAME_OVER_ANIMATION,
             ):
-                logger.debug(
-                    f"Game state became {current_state.name} as expected "
-                    f"after {i + 1} updates."
-                )
                 interaction_processed = True
                 break
-        else:  # Player is invincible
-            if i == max_updates - 1:  # Let simulation run for invincible case
-                interaction_processed = True  # Assume interaction window passed
+        else:
+            if i == max_updates - 1:
+                interaction_processed = True
                 break
 
-        # Early exit if game state changes definitively and unexpectedly
         if current_state != GameState.RUNNING and current_state != expected_game_state:
-            logger.warning(
-                f"Game state changed to "
-                f"{current_state.name} unexpectedly "
-                f"after {i + 1} updates."
-            )
             interaction_processed = True
             break
     else:
-        logger.warning(
-            f"Max updates ({max_updates}) reached. "
-            f"Bullet active: {enemy_bullet.active}, "
-            f"GameState: {game_manager.state.name}, "
-            f"PlayerLives: {player_tank.lives}"
-        )
-        # Loop finished — run assertions on final state
         interaction_processed = True
 
-    # --- Assertions after updates --- #
-    # If invincible, bullet may or may not be active.
     if not player_is_invincible:
         assert interaction_processed, (
             f"Enemy bullet interaction with vulnerable player not detected. "
             f"Bullet active: {enemy_bullet.active}, Player lives: {player_tank.lives}, "
             f"Game state: {game_manager.state.name}"
         )
-        # Vulnerable player hit — bullet should be inactive.
         if player_tank.lives < original_player_lives or game_manager.state in (
             GameState.GAME_OVER,
             GameState.GAME_OVER_ANIMATION,
@@ -415,19 +316,16 @@ def test_enemy_bullet_hits_player_tank(
                 "damaging player or causing game over."
             )
 
-    # 1. Assert Game State
     assert game_manager.state == expected_game_state, (
         f"Expected game state {expected_game_state.name}, "
         f"but got {game_manager.state.name}"
     )
 
-    # 2. Assert Player Lives
     assert player_tank.lives == expected_player_lives_after_hit, (
         f"Expected player lives {expected_player_lives_after_hit}, "
         f"but got {player_tank.lives}"
     )
 
-    # 3. Assert Respawn effects (if life lost but game not over)
     if (
         expected_player_lives_after_hit == player_initial_lives - 1
         and expected_game_state == GameState.RUNNING
@@ -436,7 +334,6 @@ def test_enemy_bullet_hits_player_tank(
             "Player did not return to spawn position after losing a life."
         )
         assert player_tank.is_invincible, "Player is not invincible after respawning."
-    # 4. Assert Invincible state persisted (if hit while invincible)
     elif player_is_invincible:
         assert player_tank.is_invincible, (
             "Player lost invincibility after being hit while invincible."
@@ -448,12 +345,11 @@ def test_enemy_bullet_hits_other_enemy(game_manager_fixture, mocker):
     mocker.patch("src.core.enemy_tank.random.uniform", return_value=0.0)
     game_manager = game_manager_fixture
 
-    # --- Spawn Two Enemy Tanks --- #
     enemy_type = TankType.BASIC
-    enemy1_x_grid, enemy1_y_grid = 16, 16  # Top enemy (shooter, sub-tile coords)
-    enemy2_x_grid, enemy2_y_grid = 16, 20  # Bottom enemy (target, 4 sub-tiles apart)
+    # enemy1 shoots down at enemy2 (4 sub-tiles apart).
+    enemy1_x_grid, enemy1_y_grid = 16, 16
+    enemy2_x_grid, enemy2_y_grid = 16, 20
 
-    # Clear sub-tiles at entity positions and the bullet path between them
     _clear_tiles(
         game_manager.map,
         [(16 + dx, y) for y in range(16, 22) for dx in range(2)],
@@ -475,7 +371,7 @@ def test_enemy_bullet_hits_other_enemy(game_manager_fixture, mocker):
         map_width_px=map_w_px,
         map_height_px=map_h_px,
     )
-    enemy1.direction = Direction.DOWN  # Aim at enemy2
+    enemy1.direction = Direction.DOWN
 
     enemy2 = EnemyTank(
         enemy2_start_x,
@@ -487,24 +383,18 @@ def test_enemy_bullet_hits_other_enemy(game_manager_fixture, mocker):
         map_height_px=map_h_px,
     )
 
-    game_manager.spawn_manager.enemy_tanks = [enemy1, enemy2]  # Set the enemies
+    game_manager.spawn_manager.enemy_tanks = [enemy1, enemy2]
     initial_enemy_count = len(game_manager.spawn_manager.enemy_tanks)
     initial_enemy2_health = enemy2.health
-    logger.debug(f"Spawned enemy1 at ({enemy1_x_grid}, {enemy1_y_grid}) aiming down.")
-    logger.debug(f"Spawned enemy2 at ({enemy2_x_grid}, {enemy2_y_grid}).")
-    # --- End Spawn --- #
 
-    # --- Fire Enemy Bullet --- #
     game_manager._try_shoot(enemy1)
     enemy1_bullets = [b for b in game_manager.bullets if b.owner is enemy1]
     assert len(enemy1_bullets) == 1, "Enemy1 bullet failed to spawn."
     bullet = enemy1_bullets[0]
     assert bullet.active, "Enemy1 bullet spawned inactive."
-    # --- End Fire --- #
 
-    # --- Simulate game time until bullet should hit --- #
     dt = 1.0 / FPS
-    update_duration = 0.4  # Time to cross ~2 tiles
+    update_duration = 0.4
     num_updates = int(update_duration / dt)
 
     initial_bullet_state = bullet.active
@@ -514,23 +404,18 @@ def test_enemy_bullet_hits_other_enemy(game_manager_fixture, mocker):
         if not bullet.active:
             break
 
-    # --- Assertions --- #
-    # Bullet should remain active as enemy bullets don't hit other enemies
     assert bullet.active == initial_bullet_state, "Bullet state changed unexpectedly."
     assert bullet.active, "Bullet should still be active after passing another enemy."
 
-    # 1. Enemy2 health should be unchanged
     assert enemy2.health == initial_enemy2_health, (
         f"Enemy2 health changed. Expected: {initial_enemy2_health}, "
         f"Got: {enemy2.health}"
     )
 
-    # 2. Enemy2 should still be in the list
     assert enemy2 in game_manager.spawn_manager.enemy_tanks, (
         "Enemy2 was removed from the list."
     )
 
-    # 3. Total enemy count should be unchanged
     assert len(game_manager.spawn_manager.enemy_tanks) == initial_enemy_count, (
         f"Enemy count changed. Expected: {initial_enemy_count}, "
         f"Got: {len(game_manager.spawn_manager.enemy_tanks)}"
@@ -543,18 +428,16 @@ def test_player_tank_vs_enemy_tank_no_overlap(game_manager_fixture, mocker):
     game_manager = game_manager_fixture
     player_tank = first_player(game_manager)
 
-    # --- Spawn an enemy tank directly above the player --- #
     enemy_type = TankType.BASIC
     player_x_grid = int(player_tank.x // SUB_TILE_SIZE)
     player_y_grid = int(player_tank.y // SUB_TILE_SIZE)
-    # Place enemy 2 sub-tiles above (exactly adjacent)
+    # 2 sub-tiles above = exactly adjacent (one tank-height gap).
     enemy_x_grid = player_x_grid
     enemy_y_grid = player_y_grid - 2
 
     enemy_start_x = enemy_x_grid * SUB_TILE_SIZE
     enemy_start_y = enemy_y_grid * SUB_TILE_SIZE
 
-    # Clear tiles between player and enemy
     _clear_tiles(
         game_manager.map,
         [
@@ -575,21 +458,18 @@ def test_player_tank_vs_enemy_tank_no_overlap(game_manager_fixture, mocker):
         map_width_px=map_w_px,
         map_height_px=map_h_px,
     )
-    # Make enemy stationary so only the player drives into it
+    # Pin the enemy so only the player moves; we want to test the collision, not AI.
     enemy_tank.speed = 0
     enemy_tank.direction_change_interval = 999
     enemy_tank.shoot_interval = 999
     game_manager.spawn_manager.enemy_tanks = [enemy_tank]
 
-    # Drive the player tank UP into the enemy for several frames
     dt = 1.0 / FPS
     for _ in range(30):
-        # Simulate player pressing UP
         player_tank.update(dt)
         player_tank.move(0, -1, dt)
         enemy_tank.update(dt)
 
-        # Run collision detection and response
         game_manager.collision_manager.check_collisions(
             player_tanks=[player_tank],
             player_bullets=[],
@@ -602,11 +482,9 @@ def test_player_tank_vs_enemy_tank_no_overlap(game_manager_fixture, mocker):
         events = game_manager.collision_manager.get_collision_events()
         game_manager.collision_response_handler.process_collisions(events)
 
-    # The tanks must NOT overlap
     assert not player_tank.rect.colliderect(enemy_tank.rect), (
         f"Player rect {player_tank.rect} overlaps enemy rect {enemy_tank.rect}"
     )
-    # Player should be pushed back to just below the enemy
     assert player_tank.rect.top >= enemy_tank.rect.bottom, (
         f"Player top ({player_tank.rect.top}) should be "
         f">= enemy bottom ({enemy_tank.rect.bottom})"
@@ -618,12 +496,10 @@ def test_enemy_bullets_collide(game_manager_fixture, mocker):
     mocker.patch("src.core.enemy_tank.random.uniform", return_value=0.0)
     game_manager = game_manager_fixture
 
-    # --- Spawn Two Enemy Tanks Facing Each Other --- #
     enemy_type = TankType.BASIC
-    enemy1_x_grid, enemy1_y_grid = 2, 16  # Left enemy (sub-tile coords)
-    enemy2_x_grid, enemy2_y_grid = 8, 16  # Right enemy (6 sub-tiles apart)
+    enemy1_x_grid, enemy1_y_grid = 2, 16
+    enemy2_x_grid, enemy2_y_grid = 8, 16
 
-    # Clear sub-tiles at entity positions and the bullet path between them
     _clear_tiles(
         game_manager.map,
         [(x, 16 + dy) for x in range(2, 10) for dy in range(2)],
@@ -645,7 +521,7 @@ def test_enemy_bullets_collide(game_manager_fixture, mocker):
         map_width_px=map_w_px,
         map_height_px=map_h_px,
     )
-    enemy1.direction = Direction.RIGHT  # Aim at enemy2
+    enemy1.direction = Direction.RIGHT
 
     enemy2 = EnemyTank(
         enemy2_start_x,
@@ -656,14 +532,10 @@ def test_enemy_bullets_collide(game_manager_fixture, mocker):
         map_width_px=map_w_px,
         map_height_px=map_h_px,
     )
-    enemy2.direction = Direction.LEFT  # Aim at enemy1
+    enemy2.direction = Direction.LEFT
 
-    game_manager.spawn_manager.enemy_tanks = [enemy1, enemy2]  # Set the enemies
-    logger.debug(f"Spawned enemy1 at ({enemy1_x_grid}, {enemy1_y_grid}) aiming right.")
-    logger.debug(f"Spawned enemy2 at ({enemy2_x_grid}, {enemy2_y_grid}) aiming left.")
-    # --- End Spawn --- #
+    game_manager.spawn_manager.enemy_tanks = [enemy1, enemy2]
 
-    # --- Fire Both Bullets Simultaneously --- #
     game_manager._try_shoot(enemy1)
     game_manager._try_shoot(enemy2)
 
@@ -675,27 +547,20 @@ def test_enemy_bullets_collide(game_manager_fixture, mocker):
     bullet2 = enemy2_bullets[0]
     assert bullet1.active, "Enemy1 bullet spawned inactive."
     assert bullet2.active, "Enemy2 bullet spawned inactive."
-    # --- End Fire --- #
 
-    # --- Simulate game time until bullets should have passed each other --- #
-    # They are 4 tiles apart, need to travel ~2 tiles each.
+    # Enemies are 6 sub-tiles apart; bullets need to cross before we check pass-through.
     dt = 1.0 / FPS
-    update_duration = 0.4  # Should be sufficient time
+    update_duration = 0.4
     num_updates = int(update_duration / dt)
 
-    logger.info(f"Simulating {num_updates} updates to check bullet pass-through.")
     for _ in range(num_updates):
         game_manager.update()
         if not (bullet1.active and bullet2.active):
             break
 
-    # --- Assertions --- #
-    # Bullets should still be active after passing each other's paths
     assert bullet1.active, (
         "Enemy1 bullet should still be active after passing enemy2 bullet."
     )
     assert bullet2.active, (
         "Enemy2 bullet should still be active after passing enemy1 bullet."
     )
-
-    logger.info("Enemy bullets correctly remained active after passing each other.")

--- a/tests/integration/test_effect_integration.py
+++ b/tests/integration/test_effect_integration.py
@@ -19,29 +19,24 @@ class TestEffectLifecycle:
         gm = game_manager_fixture
         dt = 1.0 / FPS
 
-        # Find a steel tile to shoot at
         steel_tiles = gm.map.get_tiles_by_type([TileType.STEEL])
         if not steel_tiles:
-            # If no steel, use brick
             steel_tiles = gm.map.get_tiles_by_type([TileType.BRICK])
         assert steel_tiles, "Need at least one destructible/steel tile"
         target = steel_tiles[0]
 
-        # Position player near the target and shoot toward it
         player = first_player(gm)
         player.x = float(target.rect.centerx)
         player.y = float(target.rect.bottom + 10)
         player.rect.topleft = (round(player.x), round(player.y))
 
-        # Clear enemies so they don't interfere (e.g., shooting the player)
+        # Clear enemies so they don't interfere (e.g., shoot the player instead).
         gm.spawn_manager.enemy_tanks.clear()
 
-        # Create a bullet aimed at the tile
         bullet = player.shoot()
         assert bullet is not None
         gm.bullets.append(bullet)
 
-        # Run updates until the bullet hits the tile (or max iterations)
         effect_spawned = False
         for _ in range(30):
             gm.update()
@@ -54,7 +49,6 @@ class TestEffectLifecycle:
         )
         assert len(gm.effect_manager.effects) >= 1
 
-        # Now keep updating until the effect expires
         for _ in range(60):
             gm.effect_manager.update(dt)
             if not gm.effect_manager.effects:
@@ -71,8 +65,6 @@ class TestEffectLifecycle:
         gm.effect_manager.spawn(EffectType.SMALL_EXPLOSION, 100.0, 100.0)
         old_effect_manager = gm.effect_manager
 
-        # Reset the game
         gm._reset_game()
 
-        # Should be a new EffectManager instance (old effects gone)
         assert gm.effect_manager is not old_effect_manager

--- a/tests/integration/test_enemy_integration.py
+++ b/tests/integration/test_enemy_integration.py
@@ -1,5 +1,4 @@
 import pytest
-from loguru import logger
 from unittest.mock import patch
 from src.utils.constants import (
     Direction,
@@ -16,22 +15,15 @@ from tests.integration.conftest import first_player, flush_pending_spawns
 import random
 
 
-# Tests related to enemy behavior: spawning, movement, shooting
-
-
 def test_enemy_spawning_rules(game_manager_fixture):
     """Test enemy spawning location, count, and limits."""
     game_manager = game_manager_fixture
 
-    # Convert spawn points (sub-tile grid coords) to possible pixel coords
     spawn_points_pixels = [
         (gx * SUB_TILE_SIZE, gy * SUB_TILE_SIZE)
         for gx, gy in game_manager.spawn_manager.spawn_points
     ]
 
-    # --- 1. Initial Spawn Verification --- #
-    logger.info("Verifying initial enemy spawn...")
-    # Run updates to let spawn animation finish and materialize the enemy
     for _ in range(60):
         game_manager.update()
         if game_manager.spawn_manager.enemy_tanks:
@@ -49,12 +41,10 @@ def test_enemy_spawning_rules(game_manager_fixture):
         "Initial total_enemy_spawns should be 1."
     )
 
-    # --- 2. Max Enemy Spawn Limit Verification --- #
-    logger.info("Verifying maximum enemy spawn limit...")
     max_spawns = game_manager.spawn_manager.max_enemy_spawns
 
-    # Reset state for this part of the test
-    # Rebuild spawn queue directly (reset() does an initial spawn which we don't want)
+    # Rebuild the spawn queue directly: reset() performs an initial spawn which
+    # we don't want here.
     game_manager.spawn_manager.enemy_tanks = []
     game_manager.spawn_manager.total_enemy_spawns = 0
     game_manager.spawn_manager._spawn_queue = (
@@ -65,23 +55,19 @@ def test_enemy_spawning_rules(game_manager_fixture):
     game_manager.spawn_manager.max_enemy_spawns = len(
         game_manager.spawn_manager._spawn_queue
     )
-    logger.debug(f"Cleared initial enemy. Max spawns to test: {max_spawns}")
 
-    max_attempts = max_spawns * 3  # Allow retries for blocked spawns
+    max_attempts = max_spawns * 3
     attempt = 0
     while game_manager.spawn_manager.total_enemy_spawns < max_spawns:
         attempt += 1
         if attempt > max_attempts:
-            break  # Prevent infinite loop
+            break
 
         total_spawned_before = game_manager.spawn_manager.total_enemy_spawns
 
-        # Clear existing enemies to avoid blocking spawn points on small maps
+        # Clear enemies so they don't block spawn points on the small test map.
         game_manager.spawn_manager.enemy_tanks = []
 
-        logger.debug(
-            f"Attempting spawn (Current total: {total_spawned_before}/{max_spawns})"
-        )
         spawn_success = game_manager.spawn_manager.spawn_enemy(
             game_manager.player_manager.get_active_players(), game_manager.map
         )
@@ -89,14 +75,12 @@ def test_enemy_spawning_rules(game_manager_fixture):
         total_spawned_after = game_manager.spawn_manager.total_enemy_spawns
 
         if spawn_success:
-            logger.debug("Spawn successful.")
             assert total_spawned_after == total_spawned_before + 1, (
                 f"Total spawn count mismatch after successful spawn. "
                 f"Before: {total_spawned_before}, "
                 f"After: {total_spawned_after}"
             )
             flush_pending_spawns(game_manager)
-            # Verify the newly spawned enemy position
             assert game_manager.spawn_manager.enemy_tanks, (
                 "Enemy should have materialized after spawn animation"
             )
@@ -108,15 +92,10 @@ def test_enemy_spawning_rules(game_manager_fixture):
                 f"{spawn_points_pixels}"
             )
         else:
-            logger.debug(
-                f"Spawn failed (likely blocked). Current total: "
-                f"{total_spawned_after}/{max_spawns}"
-            )
             assert total_spawned_after == total_spawned_before, (
                 "total_enemy_spawns increased even though spawn failed."
             )
 
-    # Assert final counts after the while loop finishes
     assert len(game_manager.spawn_manager.enemy_tanks) <= max_spawns, (
         "Exceeded max on-screen enemies"
     )
@@ -125,13 +104,10 @@ def test_enemy_spawning_rules(game_manager_fixture):
         f"{game_manager.spawn_manager.total_enemy_spawns}"
     )
 
-    # Attempt to spawn one more enemy beyond the limit
-    logger.info("Attempting to spawn beyond max limit...")
     spawn_success = game_manager.spawn_manager.spawn_enemy(
         first_player(game_manager), game_manager.map
     )
 
-    # Assert counts did NOT change and spawn failed
     assert not spawn_success, "Spawn succeeded unexpectedly beyond max limit."
     assert len(game_manager.spawn_manager.enemy_tanks) <= max_spawns, (
         f"Enemy count changed when spawning beyond limit. Expected <= {max_spawns}, "
@@ -141,7 +117,6 @@ def test_enemy_spawning_rules(game_manager_fixture):
         f"Total spawn count changed when spawning beyond limit. "
         f"Expected {max_spawns}, got {game_manager.spawn_manager.total_enemy_spawns}"
     )
-    logger.info("Maximum spawn limit verified.")
 
 
 def test_enemy_spawn_blocked(game_manager_fixture):
@@ -155,42 +130,29 @@ def test_enemy_spawn_blocked(game_manager_fixture):
     ]
     assert len(spawn_points_pixels) > 0, "No spawn points defined in GameManager."
 
-    # --- Block a Spawn Point --- #
-    # Choose the first spawn point to block
     blocked_spawn_point_pixels = spawn_points_pixels[0]
-    blocked_spawn_point_grid = spawn_points_grid[0]
-    # Move player tank to block it
+    # Park the player on the blocked spawn point to occupy it.
     player_tank.set_position(
         blocked_spawn_point_pixels[0], blocked_spawn_point_pixels[1]
     )
     player_tank.prev_x, player_tank.prev_y = blocked_spawn_point_pixels
-    logger.info(
-        f"Blocking spawn point {blocked_spawn_point_grid} with player at "
-        f"{blocked_spawn_point_pixels}"
-    )
-    # --- End Blocking --- #
 
-    # --- Reset Enemy State --- #
     game_manager.spawn_manager.enemy_tanks = []
     game_manager.spawn_manager._pending_spawns = []
     game_manager.spawn_manager.total_enemy_spawns = 0
     max_spawns = game_manager.spawn_manager.max_enemy_spawns
-    logger.debug(f"Cleared initial enemies. Will attempt to spawn up to {max_spawns}.")
-    # --- End Reset --- #
 
-    # --- Attempt Spawns with Blocking --- #
-    # Attempt more times than available spawn points to ensure selection cycles
+    # Attempt more times than there are spawn points so the selection cycles.
     max_attempts = len(spawn_points_pixels) * 5
 
-    for attempt in range(max_attempts):
+    for _ in range(max_attempts):
         if game_manager.spawn_manager.total_enemy_spawns >= max_spawns:
-            logger.debug("Reached max total spawns, stopping attempts.")
-            break  # Stop if limit reached (unlikely if one is blocked)
+            break
 
         spawned_count_before = len(game_manager.spawn_manager.enemy_tanks)
         spawn_success = game_manager.spawn_manager.spawn_enemy(
             game_manager.player_manager.get_active_players(), game_manager.map
-        )  # Attempt spawn
+        )
         spawned_count_after = len(game_manager.spawn_manager.enemy_tanks)
 
         if spawn_success:
@@ -199,29 +161,18 @@ def test_enemy_spawn_blocked(game_manager_fixture):
             assert spawned_count_after == spawned_count_before + 1
             new_enemy = game_manager.spawn_manager.enemy_tanks[-1]
             new_enemy_pos = new_enemy.get_position()
-            logger.debug(f"Attempt {attempt + 1}: Spawn successful at {new_enemy_pos}.")
-            # Assert the new enemy did NOT spawn at the blocked point
             assert new_enemy_pos != blocked_spawn_point_pixels, (
-                f"Enemy spawned at the blocked point {blocked_spawn_point_pixels} "
-                f"on attempt {attempt + 1}."
+                f"Enemy spawned at the blocked point {blocked_spawn_point_pixels}."
             )
         else:
             assert spawned_count_after == spawned_count_before
-            logger.debug(
-                f"Attempt {attempt + 1}: Spawn failed (possibly blocked). "
-                f"Total spawned: {game_manager.spawn_manager.total_enemy_spawns}"
-            )
 
-    # --- Assert Final State --- #
-    logger.info("Verifying final state after spawn attempts with blocking...")
-    # Check that no spawned enemy ended up at the blocked location
     for i, enemy in enumerate(game_manager.spawn_manager.enemy_tanks):
         assert enemy.get_position() != blocked_spawn_point_pixels, (
             f"Enemy {i} is located at the blocked spawn point "
             f"{blocked_spawn_point_pixels}."
         )
 
-    # Because one point is blocked, we might not reach max_spawns
     enemy_count = len(game_manager.spawn_manager.enemy_tanks)
     assert enemy_count <= max_spawns, (
         f"Enemy count ({enemy_count}) exceeded max spawns ({max_spawns})."
@@ -230,10 +181,8 @@ def test_enemy_spawn_blocked(game_manager_fixture):
     assert total_spawns <= max_spawns, (
         f"Total enemy spawns ({total_spawns}) exceeded max spawns ({max_spawns})."
     )
-    logger.info("Blocked spawn point test completed.")
 
 
-# Keep the original random.choice before patching
 original_random_choice = random.choice
 
 
@@ -245,15 +194,13 @@ def test_enemy_movement_and_direction_change(
     """Test that enemies move and change direction over time."""
     game_manager = game_manager_fixture
 
-    # --- Clear existing and Spawn one enemy in open space --- #
     game_manager.spawn_manager.enemy_tanks = []
     game_manager.spawn_manager.total_enemy_spawns = 0
     enemy_type = TankType.BASIC
-    start_x_grid, start_y_grid = 16, 16  # sub-tile grid coords
+    start_x_grid, start_y_grid = 16, 16
     start_x = start_x_grid * SUB_TILE_SIZE
     start_y = start_y_grid * SUB_TILE_SIZE
 
-    # Clear sub-tiles around starting position so enemy can move in any direction
     game_map = game_manager.map
     for dy in range(-4, 6):
         for dx in range(-4, 6):
@@ -265,7 +212,8 @@ def test_enemy_movement_and_direction_change(
                         nx, ny, Tile(TileType.EMPTY, nx, ny, SUB_TILE_SIZE)
                     )
 
-    # Use the original random.choice via side_effect for the __init__ call
+    # Use the unmocked random.choice during __init__, then force the direction
+    # change later.
     mock_choice.side_effect = lambda x: original_random_choice(x)
     map_w_px = game_manager.map.width * SUB_TILE_SIZE
     map_h_px = game_manager.map.height * SUB_TILE_SIZE
@@ -279,84 +227,55 @@ def test_enemy_movement_and_direction_change(
         map_height_px=map_h_px,
         difficulty=Difficulty.EASY,
     )
-    initial_direction = enemy_tank.direction  # Capture initial direction
+    initial_direction = enemy_tank.direction
 
-    # Set the mock_choice to return a different direction for the _change_direction call
     possible_directions = list(Direction)
     forced_new_direction = next(
         d for d in possible_directions if d != initial_direction
     )
-    mock_choice.side_effect = None  # Clear the side_effect
+    mock_choice.side_effect = None
     mock_choice.return_value = forced_new_direction
-    logger.debug(
-        f"Initial direction: {initial_direction}, "
-        f"Mock forced direction: {forced_new_direction}"
-    )
 
-    # Prevent enemy from shooting so bullets don't hit the base
-    # and cause GAME_OVER before the direction change timer fires
+    # Prevent enemy from shooting: otherwise a bullet can hit the base and trigger
+    # GAME_OVER before the direction-change timer fires.
     enemy_tank.shoot = lambda: None
 
     game_manager.spawn_manager.enemy_tanks.append(enemy_tank)
     game_manager.spawn_manager.total_enemy_spawns = 1
-    logger.debug(
-        f"Spawned single enemy at ({start_x_grid}, {start_y_grid}) for movement test."
-    )
-    # --- End Spawn --- #
 
     initial_pos = enemy_tank.get_position()
     observed_directions = {initial_direction}
 
-    # --- Simulate Game Time --- #
     dt = 1.0 / FPS
     direction_change_interval = enemy_tank.direction_change_interval
     simulation_duration = direction_change_interval + 0.1
     num_updates = int(simulation_duration / dt)
-    logger.info(
-        f"Simulating {simulation_duration:.1f}s ({num_updates} updates), "
-        f"expecting direction change to {forced_new_direction} after "
-        f"{direction_change_interval:.1f}s (mocked)..."
-    )
 
     direction_changed = False
     actual_new_direction = None
-    for i in range(num_updates):
+    for _ in range(num_updates):
         game_manager.update()
         current_direction = enemy_tank.direction
         observed_directions.add(current_direction)
         if current_direction != initial_direction and not direction_changed:
-            logger.info(
-                f"Direction changed from {initial_direction} to {current_direction} "
-                f"after {i + 1} updates."
-            )
             direction_changed = True
             actual_new_direction = current_direction
             break
 
-    # --- Assertions --- #
     final_pos = enemy_tank.get_position()
 
-    # 1. Verify movement occurred
     assert final_pos != initial_pos, (
         f"Enemy tank did not move. Start: {initial_pos}, End: {final_pos}"
     )
 
-    # 2. Verify direction changed
     assert direction_changed, (
         f"Enemy direction did not change. Initial: {initial_direction}, "
         f"Observed: {observed_directions}"
     )
 
-    # 3. Verify the direction changed to the one forced by the mock
     assert actual_new_direction == forced_new_direction, (
         f"Enemy changed direction, but not to the mocked value. "
         f"Expected: {forced_new_direction}, Got: {actual_new_direction}"
-    )
-
-    logger.info(
-        f"Enemy moved from {initial_pos} to {final_pos}. "
-        f"Direction changed to {actual_new_direction} as expected. "
-        f"Observed directions: {observed_directions}"
     )
 
 
@@ -372,10 +291,10 @@ def test_enemy_movement_and_direction_change(
 @pytest.mark.parametrize(
     "move_direction, start_pos_offset",
     [
-        (Direction.UP, (0, 1)),  # Try moving UP, start 1 tile below (2 sub-tiles)
-        (Direction.DOWN, (0, -1)),  # Try moving DOWN, start 1 tile above (2 sub-tiles)
-        (Direction.LEFT, (1, 0)),  # Try moving LEFT, start 1 tile right (2 sub-tiles)
-        (Direction.RIGHT, (-1, 0)),  # Try moving RIGHT, start 1 tile left (2 sub-tiles)
+        (Direction.UP, (0, 1)),
+        (Direction.DOWN, (0, -1)),
+        (Direction.LEFT, (1, 0)),
+        (Direction.RIGHT, (-1, 0)),
     ],
 )
 def test_enemy_movement_blocked_by_tile(
@@ -385,11 +304,10 @@ def test_enemy_movement_blocked_by_tile(
     game_manager = game_manager_fixture
     game_map = game_manager.map
 
-    # Define target tile location (sub-tile grid coords, use a known EMPTY spot)
+    # (20, 20) is a known-empty spot on the test map (avoids default water).
     target_x_grid = 20
-    target_y_grid = 20  # Changed from (7, 7) to avoid default water
+    target_y_grid = 20
 
-    # --- Place Blocking Tile (2x2 sub-tile block = 1 full tile) --- #
     if (
         0 <= target_y_grid + 1 < game_map.height
         and 0 <= target_x_grid + 1 < game_map.width
@@ -410,35 +328,26 @@ def test_enemy_movement_blocked_by_tile(
                     blocks_bullets=True,
                 )
                 game_map.place_tile(sx, sy, tile)
-        logger.debug(
-            f"Placed blocking {blocking_tile_type.name} 2x2 block at "
-            f"({target_x_grid}, {target_y_grid})"
-        )
     else:
         pytest.fail(
             f"Target tile coordinates ({target_x_grid}, {target_y_grid}) "
             f"are out of bounds."
         )
-    # --- End Tile Placement --- #
 
-    # --- Spawn Enemy Tank Adjacent --- #
-    # Clear existing enemies
     game_manager.spawn_manager.enemy_tanks = []
     game_manager.spawn_manager.total_enemy_spawns = 0
-    # Calculate start position: tank (32px) placed flush against 2x2 tile block (32px)
-    # Offsets are in tank-size units (2 sub-tiles)
+    # start_pos_offset is in tank-size units (2 sub-tiles), so the tank sits flush
+    # against the 2x2 blocking tile.
     start_grid_x = target_x_grid + start_pos_offset[0] * 2
     start_grid_y = target_y_grid + start_pos_offset[1] * 2
     start_x = start_grid_x * SUB_TILE_SIZE
     start_y = start_grid_y * SUB_TILE_SIZE
 
-    # Ensure start position is within bounds and EMPTY
     if not (0 <= start_grid_y < game_map.height and 0 <= start_grid_x < game_map.width):
         pytest.skip(
             f"Calculated enemy start pos ({start_grid_x}, {start_grid_y}) "
             f"is out of bounds. Skipping."
         )
-    # Clear the 2x2 sub-tile area for the enemy
     for dy in range(2):
         for dx in range(2):
             sx, sy = start_grid_x + dx, start_grid_y + dy
@@ -450,9 +359,7 @@ def test_enemy_movement_blocked_by_tile(
                         sy,
                         Tile(TileType.EMPTY, sx, sy, SUB_TILE_SIZE),
                     )
-    logger.debug(f"Cleared start area ({start_grid_x}, {start_grid_y}) to EMPTY.")
 
-    # Spawn the enemy
     map_w_px = game_manager.map.width * SUB_TILE_SIZE
     map_h_px = game_manager.map.height * SUB_TILE_SIZE
     enemy_tank = EnemyTank(
@@ -464,26 +371,18 @@ def test_enemy_movement_blocked_by_tile(
         map_width_px=map_w_px,
         map_height_px=map_h_px,
     )
-    # Force initial direction towards the obstacle
     enemy_tank.direction = move_direction
-    enemy_tank.direction_timer = 0  # Prevent immediate random change
+    enemy_tank.direction_timer = 0
     game_manager.spawn_manager.enemy_tanks.append(enemy_tank)
     game_manager.spawn_manager.total_enemy_spawns = 1
-    logger.debug(
-        f"Spawned enemy at ({start_grid_x}, {start_grid_y}) aiming "
-        f"{move_direction} towards {blocking_tile_type.name} tile."
-    )
-    # --- End Spawn --- #
 
     initial_pos = enemy_tank.get_position()
 
-    # --- Simulate Game Time --- #
-    # One update: the tank attempts movement and gets snapped back by collision.
-    # A second update would trigger _change_direction() away from the obstacle,
-    # so we only check after a single update.
+    # Check after a single update: the first update attempts movement and gets
+    # snapped back by the collision. A second update would trigger _change_direction()
+    # away from the obstacle, which would contaminate this test.
     game_manager.update()
 
-    # --- Assertions --- #
     final_pos = enemy_tank.get_position()
 
     assert final_pos == initial_pos, (
@@ -491,21 +390,15 @@ def test_enemy_movement_blocked_by_tile(
         f"{move_direction}. Start: {initial_pos}, End: {final_pos}"
     )
 
-    logger.info(
-        f"Enemy attempted move {move_direction} into {blocking_tile_type.name} "
-        f"and remained at {final_pos}. Final dir: {enemy_tank.direction}"
-    )
-
 
 def test_enemy_shooting(game_manager_fixture):
     """Test that enemies shoot periodically and their bullets travel correctly."""
     game_manager = game_manager_fixture
 
-    # --- Clear existing and Spawn one enemy in open space --- #
     game_manager.spawn_manager.enemy_tanks = []
     game_manager.spawn_manager.total_enemy_spawns = 0
-    enemy_type = TankType.BASIC  # Basic shoot_interval is 2.0s
-    start_x_grid, start_y_grid = 16, 16  # sub-tile grid coords
+    enemy_type = TankType.BASIC
+    start_x_grid, start_y_grid = 16, 16
     start_x = start_x_grid * SUB_TILE_SIZE
     start_y = start_y_grid * SUB_TILE_SIZE
 
@@ -520,28 +413,17 @@ def test_enemy_shooting(game_manager_fixture):
         map_width_px=map_w_px,
         map_height_px=map_h_px,
     )
-    # Set a known initial direction to predict bullet path
     initial_enemy_direction = Direction.RIGHT
     enemy_tank.direction = initial_enemy_direction
-    enemy_tank.shoot_timer = 0  # Reset shoot timer for predictable firing
+    enemy_tank.shoot_timer = 0
     game_manager.spawn_manager.enemy_tanks.append(enemy_tank)
     game_manager.spawn_manager.total_enemy_spawns = 1
-    logger.debug(
-        f"Spawned single enemy at ({start_x_grid}, {start_y_grid}) "
-        f"aiming {initial_enemy_direction}"
-    )
-    # --- End Spawn --- #
 
-    # --- Simulate Game Time --- #
-    # Duration should be longer than shoot_interval (2.0s) + time for bullet to move
+    # Run longer than shoot_interval so we're guaranteed to see a shot.
     dt = 1.0 / FPS
     shoot_interval = enemy_tank.shoot_interval
-    simulation_duration = shoot_interval + 0.5  # e.g., 2.5s
+    simulation_duration = shoot_interval + 0.5
     num_updates = int(simulation_duration / dt)
-    logger.info(
-        f"Simulating {simulation_duration}s ({num_updates} updates), "
-        f"expecting shot around {shoot_interval}s..."
-    )
 
     bullet_fired = False
     fired_bullet = None
@@ -552,7 +434,6 @@ def test_enemy_shooting(game_manager_fixture):
     for i in range(num_updates):
         game_manager.update()
 
-        # Check if an enemy bullet appeared in game_manager.bullets
         enemy_bullets = [
             b
             for b in game_manager.bullets
@@ -562,30 +443,20 @@ def test_enemy_shooting(game_manager_fixture):
             bullet_fired = True
             fired_bullet = enemy_bullets[0]
             bullet_start_pos = fired_bullet.get_position()
-            # Bullet direction is set based on tank direction AT time of firing
             bullet_start_dir = fired_bullet.direction
             fire_frame = i
-            logger.info(
-                f"---> Enemy bullet fired on frame {i + 1}! Dir: "
-                f"{bullet_start_dir}, Pos: {bullet_start_pos}"
-            )
-            # Continue simulation to check movement
 
-        # If bullet fired previously, check its movement
         elif bullet_fired and fired_bullet is not None and i > fire_frame:
-            # Check bullet still active (should be in open space)
             assert fired_bullet.active, (
                 f"Enemy bullet became inactive unexpectedly on frame {i + 1}"
             )
 
-            # Check bullet has moved from its start position
             current_bullet_pos = fired_bullet.get_position()
             assert current_bullet_pos != bullet_start_pos, (
                 f"Enemy bullet has not moved from start pos {bullet_start_pos} "
                 f"by frame {i + 1}"
             )
 
-            # Basic check: Ensure movement is roughly in the correct direction
             if bullet_start_dir == Direction.RIGHT:
                 assert current_bullet_pos[0] > bullet_start_pos[0], (
                     "Bullet not moving right"
@@ -602,11 +473,7 @@ def test_enemy_shooting(game_manager_fixture):
                 assert current_bullet_pos[1] < bullet_start_pos[1], (
                     "Bullet not moving up"
                 )
-
-            logger.info(
-                f"Bullet movement verified at frame {i + 1}. Pos: {current_bullet_pos}"
-            )
-            break  # Stop simulation after verifying movement
+            break
 
     assert bullet_fired, (
         f"Enemy did not fire a bullet within {simulation_duration}s "

--- a/tests/integration/test_gamestate_integration.py
+++ b/tests/integration/test_gamestate_integration.py
@@ -1,5 +1,4 @@
 import pytest
-from loguru import logger
 from src.utils.constants import (
     Direction,
     ENEMY_POINTS,
@@ -13,26 +12,22 @@ from src.core.tile import Tile, TileType
 from tests.integration.conftest import first_player
 from src.core.enemy_tank import EnemyTank
 
-# Tests related to game state transitions and initial state verification
-
 
 def test_initial_game_state(game_manager_fixture):
     """Test the initial state of the GameManager after initialization."""
     game_manager = game_manager_fixture
 
-    # 1. Verify initial game state enum
     assert game_manager.state == GameState.RUNNING, (
         f"Expected initial state RUNNING, got {game_manager.state.name}"
     )
 
-    # 2. Verify initial player lives
-    expected_initial_lives = 3  # Assuming PlayerTank defaults to 3
+    expected_initial_lives = 3
     assert first_player(game_manager).lives == expected_initial_lives, (
         f"Expected initial player lives {expected_initial_lives}, "
         f"got {first_player(game_manager).lives}"
     )
 
-    # 3. Verify initial number of enemies (may be pending spawn animation)
+    # Spawn animation may still be running, so count pending spawns too.
     total_enemies = len(game_manager.spawn_manager.enemy_tanks) + len(
         game_manager.spawn_manager._pending_spawns
     )
@@ -40,16 +35,13 @@ def test_initial_game_state(game_manager_fixture):
         f"Expected 1 initial enemy (active or pending), got {total_enemies}"
     )
 
-    # 4. Verify initial total spawn count
     spawns = game_manager.spawn_manager.total_enemy_spawns
     assert spawns == 1, f"Expected initial total_enemy_spawns 1, got {spawns}"
 
-    # 5. Verify map layout (basic check - e.g., base exists and corner tile)
     game_map = game_manager.map
     base_tile = game_map.get_base()
     assert base_tile is not None, "Base tile not found in initial map."
     assert base_tile.type == TileType.BASE, "Base tile type is not BASE."
-    # Base should be within map bounds
     assert 0 <= base_tile.x < game_map.width, (
         f"Base tile x={base_tile.x} out of map bounds (width={game_map.width})"
     )
@@ -57,14 +49,11 @@ def test_initial_game_state(game_manager_fixture):
         f"Base tile y={base_tile.y} out of map bounds (height={game_map.height})"
     )
 
-    # Check a corner tile type (EMPTY in level_01.tmx)
     corner_tile = game_map.get_tile_at(0, 0)
     assert corner_tile is not None, "Tile at (0,0) not found."
     assert corner_tile.type == TileType.EMPTY, (
         f"Tile at (0,0) should be EMPTY, got {corner_tile.type.name}"
     )
-
-    logger.info("Initial game state verified.")
 
 
 def test_player_bullet_hits_base(game_manager_fixture):
@@ -73,25 +62,21 @@ def test_player_bullet_hits_base(game_manager_fixture):
     player_tank = first_player(game_manager)
     game_map = game_manager.map
 
-    # Find the base tile
     base_tile = game_map.get_base()
     assert base_tile is not None, "Base tile not found in the map."
     assert base_tile.type == TileType.BASE, "Base tile initial type is not BASE."
     base_x_grid = base_tile.x
     base_y_grid = base_tile.y
-    logger.debug(f"Found base at ({base_x_grid}, {base_y_grid})")
 
-    # Position player above the base (2 sub-tiles = 1 tank height)
+    # Position player 2 sub-tiles (= 1 tank height) above the base.
     player_start_x = base_x_grid * SUB_TILE_SIZE
     player_start_y = (base_y_grid - 2) * SUB_TILE_SIZE
 
-    # Check if player start position is valid (not steel/water/etc.)
     if not (0 <= (base_y_grid - 2) < game_map.height):
         pytest.skip(
             f"Calculated player start position y={base_y_grid - 2} is out of "
             f"bounds. Skipping."
         )
-    # Clear the 2x2 sub-tile area where the player will be placed
     for dy in range(2):
         for dx in range(2):
             sx, sy = base_x_grid + dx, base_y_grid - 2 + dy
@@ -106,49 +91,37 @@ def test_player_bullet_hits_base(game_manager_fixture):
     player_tank.set_position(player_start_x, player_start_y)
     player_tank.prev_x, player_tank.prev_y = player_start_x, player_start_y
 
-    # Aim DOWN and shoot via PlayerManager
-    player_tank.direction = Direction.DOWN  # Aim down towards base
+    player_tank.direction = Direction.DOWN
     bullet = player_tank.shoot()
     assert bullet is not None, "Player bullet failed to spawn."
     game_manager.player_manager._bullets.append(bullet)
     assert bullet.active, "Player bullet spawned inactive."
 
-    # Assert initial game state is RUNNING
     assert game_manager.state == GameState.RUNNING, (
         "Game should start in RUNNING state."
     )
 
-    # Simulate game time until bullet should have hit the base
     dt = 1.0 / FPS
-    update_duration = 0.4  # Time to cross ~2 tiles
+    update_duration = 0.4
     num_updates = int(update_duration / dt)
     hit_processed = False
 
     for _ in range(num_updates):
         game_manager.update()
-        # Check if game state changed OR bullet became inactive
         if game_manager.state != GameState.RUNNING or not bullet.active:
-            logger.debug(
-                f"Base hit processed after {_ + 1} updates (State: "
-                f"{game_manager.state.name}, Bullet Active: {bullet.active})"
-            )
             hit_processed = True
             break
 
-    # --- Assertions --- #
     assert hit_processed, (
         "Base destruction/collision was not processed within simulation time."
     )
 
-    # 1. Base tile type should be BASE_DESTROYED
     assert base_tile.type == TileType.BASE_DESTROYED, (
         f"Base tile type did not change to BASE_DESTROYED. Is: {base_tile.type.name}"
     )
 
-    # 2. Player bullet should be inactive
     assert not bullet.active, "Player bullet should be inactive after hitting base."
 
-    # 3. Game state should be GAME_OVER
     assert game_manager.state in (
         GameState.GAME_OVER,
         GameState.GAME_OVER_ANIMATION,
@@ -163,23 +136,20 @@ def test_enemy_bullet_destroys_base_game_over(game_manager_fixture):
     game_manager = game_manager_fixture
     game_map = game_manager.map
 
-    # Find the base tile
     base_tile = game_map.get_base()
     assert base_tile is not None, "Base tile not found in the map."
     assert base_tile.type == TileType.BASE, "Base tile initial type is not BASE."
     base_x_grid = base_tile.x
     base_y_grid = base_tile.y
-    logger.debug(f"Found base at ({base_x_grid}, {base_y_grid})")
 
-    # --- Spawn Enemy Tank Above Base --- #
     enemy_type = TankType.BASIC
     enemy_x_grid = base_x_grid
-    enemy_y_grid = base_y_grid - 6  # Place enemy well above base perimeter bricks
+    # Place enemy well above the base perimeter bricks so the bullet path is clear.
+    enemy_y_grid = base_y_grid - 6
 
     enemy_start_x = enemy_x_grid * SUB_TILE_SIZE
     enemy_start_y = enemy_y_grid * SUB_TILE_SIZE
 
-    # Ensure enemy spawns within bounds
     if not (
         0 <= enemy_y_grid < game_manager.map.height
         and 0 <= enemy_x_grid < game_manager.map.width
@@ -189,8 +159,7 @@ def test_enemy_bullet_destroys_base_game_over(game_manager_fixture):
             f"is out of bounds. Skipping."
         )
 
-    # Clear tiles between enemy and base so bullet can reach the base
-    # Clear 4 columns wide to cover the full tank width
+    # Clear 4 columns between enemy and base to cover the full tank width.
     for y in range(enemy_y_grid, base_y_grid):
         for dx in range(4):
             tile = game_map.get_tile_at(enemy_x_grid + dx, y)
@@ -212,61 +181,43 @@ def test_enemy_bullet_destroys_base_game_over(game_manager_fixture):
         map_width_px=map_w_px,
         map_height_px=map_h_px,
     )
-    enemy_tank.direction = Direction.DOWN  # Aim at base
-    game_manager.spawn_manager.enemy_tanks = [enemy_tank]  # Replace default enemies
-    # Move player out of the bullet path
+    enemy_tank.direction = Direction.DOWN
+    game_manager.spawn_manager.enemy_tanks = [enemy_tank]
+    # Move player out of the bullet path.
     first_player(game_manager).set_position(0, 0)
     first_player(game_manager).rect.topleft = (0, 0)
-    logger.debug(
-        f"Manually added {enemy_type} enemy at ({enemy_x_grid}, {enemy_y_grid}) "
-        f"aiming {enemy_tank.direction}"
-    )
-    # --- End Enemy Spawn --- #
 
-    # --- Fire Enemy Bullet --- #
     game_manager._try_shoot(enemy_tank)
     enemy_bullets = [b for b in game_manager.bullets if b.owner is enemy_tank]
     assert len(enemy_bullets) == 1, "Enemy bullet failed to spawn."
     bullet = enemy_bullets[0]
     assert bullet.active, "Enemy bullet spawned inactive."
-    # --- End Fire --- #
 
-    # Assert initial game state is RUNNING
     assert game_manager.state == GameState.RUNNING, (
         "Game should start in RUNNING state."
     )
 
-    # --- Simulate game time until bullet should hit base --- #
     dt = 1.0 / FPS
-    update_duration = 1.0  # Time for bullet to reach base
+    update_duration = 1.0
     num_updates = int(update_duration / dt)
     hit_processed = False
 
     for _ in range(num_updates):
         game_manager.update()
-        # Check if game state changed OR bullet became inactive
         if game_manager.state != GameState.RUNNING or not bullet.active:
-            logger.debug(
-                f"Base hit processed after {_ + 1} updates (State: "
-                f"{game_manager.state.name}, Bullet Active: {bullet.active})"
-            )
             hit_processed = True
             break
 
-    # --- Assertions --- #
     assert hit_processed, (
         "Base destruction/collision was not processed within simulation time."
     )
 
-    # 1. Bullet should be inactive
     assert not bullet.active, "Enemy bullet should be inactive after hitting base."
 
-    # 2. Base tile type should be BASE_DESTROYED
     assert base_tile.type == TileType.BASE_DESTROYED, (
         f"Base tile type did not change to BASE_DESTROYED. Is: {base_tile.type.name}"
     )
 
-    # 3. Game state should be GAME_OVER
     assert game_manager.state in (
         GameState.GAME_OVER,
         GameState.GAME_OVER_ANIMATION,
@@ -281,35 +232,21 @@ def test_victory_condition(game_manager_fixture):
     and the total spawn count has reached the maximum."""
     game_manager = game_manager_fixture
 
-    # --- Setup Victory Condition --- #
-    # Simulate that all enemies have been spawned
     game_manager.spawn_manager.total_enemy_spawns = (
         game_manager.spawn_manager.max_enemy_spawns
     )
-    # Simulate that all on-screen enemies are destroyed
     game_manager.spawn_manager.enemy_tanks = []
     game_manager.spawn_manager._pending_spawns = []
-    logger.info(
-        f"Setting up victory condition: total_spawns="
-        f"{game_manager.spawn_manager.total_enemy_spawns}, on-screen enemies=0"
-    )
-    # --- End Setup --- #
 
-    # Assert initial state is RUNNING (or whatever state it might be in)
     assert game_manager.state == GameState.RUNNING, (
         "Test setup assumes starting in RUNNING state."
     )
 
-    # Call update(), which now checks victory condition after _process_collisions
-    logger.info("Calling update() to check victory condition...")
     game_manager.update()
 
-    # --- Assertions --- #
     assert game_manager.state == GameState.VICTORY, (
         f"Game state did not change to VICTORY. Is: {game_manager.state.name}"
     )
-
-    logger.info("Victory condition verified.")
 
 
 def test_score_accumulates_on_enemy_kill(game_manager_fixture):
@@ -317,7 +254,6 @@ def test_score_accumulates_on_enemy_kill(game_manager_fixture):
     gm = game_manager_fixture
     assert gm.player_manager.score == 0
 
-    # Wait for initial spawn animation to complete
     for _ in range(60):
         gm.update()
         if gm.spawn_manager.enemy_tanks:
@@ -327,28 +263,23 @@ def test_score_accumulates_on_enemy_kill(game_manager_fixture):
     tank_type = enemy.tank_type
     expected_points = ENEMY_POINTS.get(tank_type, 0)
 
-    # Position player near the enemy and shoot at it
     player = first_player(gm)
     player.x = float(enemy.x)
     player.y = float(enemy.y + TILE_SIZE + 10)
     player.rect.topleft = (round(player.x), round(player.y))
     player.direction = Direction.UP
 
-    # Fire a bullet via PlayerManager
     bullet = player.shoot()
     assert bullet is not None
     gm.player_manager._bullets.append(bullet)
 
-    # Clear other enemies to avoid interference
     gm.spawn_manager.enemy_tanks = [enemy]
     gm.spawn_manager._pending_spawns = []
 
-    # Set enemy to 1 HP so it dies in one hit, and freeze it in place
-    # so it doesn't move out of the bullet's path (enemy AI is random)
+    # Enemy AI chooses random directions; freeze it so it can't dodge the bullet.
     enemy.health = 1
     enemy.speed = 0
 
-    # Run updates until the enemy is destroyed or max iterations
     for _ in range(60):
         gm.update()
         if enemy not in gm.spawn_manager.enemy_tanks:

--- a/tests/integration/test_ice_slide.py
+++ b/tests/integration/test_ice_slide.py
@@ -63,7 +63,6 @@ class TestPlayerIceSlide:
     @pytest.fixture
     def game(self, game_manager_fixture):
         gm = game_manager_fixture
-        # Remove enemies so they don't interfere
         gm.spawn_manager.enemy_tanks.clear()
         gm.spawn_manager._pending_spawns.clear()
         gm.spawn_manager._spawn_queue.clear()
@@ -72,9 +71,7 @@ class TestPlayerIceSlide:
     @pytest.fixture
     def ice_game(self, game):
         """Game with player on a large ice patch."""
-        # Place ice at sub-tile grid (4,4) to (11,11) — a 8x8 patch
         _place_ice_patch(game, 4, 4, width=8, height=8)
-        # Move player to center of ice patch (pixel coords)
         _move_player_to(game, 6 * SUB_TILE_SIZE, 6 * SUB_TILE_SIZE)
         first_player(game).direction = Direction.UP
         return game
@@ -83,32 +80,28 @@ class TestPlayerIceSlide:
         """Player slides when releasing keys on ice."""
         game = ice_game
 
-        # Move UP for a few frames
         _set_input(game, Direction.UP)
         _tick(game, 5)
         assert first_player(game).direction == Direction.UP
 
-        # Release keys — should start sliding UP
         _clear_input(game)
-        _tick(game, 1)  # triggers slide
+        _tick(game, 1)
         assert first_player(game).is_sliding is True
         assert first_player(game)._slide_direction == Direction.UP
 
         pos_before = first_player(game).y
-        _tick(game, 1)  # first frame of slide movement
+        _tick(game, 1)
         assert first_player(game).y < pos_before, "Tank should slide UP (decreasing y)"
 
     def test_slide_on_perpendicular_direction_change(self, ice_game):
         """Player slides in old direction when changing to perpendicular."""
         game = ice_game
 
-        # Move UP for a few frames
         _set_input(game, Direction.UP)
         _tick(game, 5)
 
-        # Now press LEFT (perpendicular) — should slide UP first
         _set_input(game, Direction.LEFT)
-        _tick(game, 1)  # triggers slide
+        _tick(game, 1)
         assert first_player(game).is_sliding is True, (
             "Tank should start sliding on perpendicular direction change"
         )
@@ -117,7 +110,7 @@ class TestPlayerIceSlide:
         )
 
         pos_before_y = first_player(game).y
-        _tick(game, 1)  # first frame of slide movement
+        _tick(game, 1)
         assert first_player(game).y < pos_before_y, (
             "Tank should continue moving UP during slide"
         )
@@ -126,17 +119,14 @@ class TestPlayerIceSlide:
         """Slide covers approximately ICE_SLIDE_DISTANCE pixels."""
         game = ice_game
 
-        # Move RIGHT for a few frames
         first_player(game).direction = Direction.RIGHT
         _set_input(game, Direction.RIGHT)
         _tick(game, 5)
 
-        # Release — trigger slide, then capture position
         _clear_input(game)
-        _tick(game, 1)  # triggers slide
+        _tick(game, 1)
         pos_before = first_player(game).x
 
-        # Let slide complete
         for _ in range(120):
             _tick(game, 1)
             if not first_player(game).is_sliding:
@@ -149,7 +139,6 @@ class TestPlayerIceSlide:
 
     def test_no_slide_when_not_on_ice(self, game):
         """Player does NOT slide on normal tiles."""
-        # Player is on normal tiles (default map position)
         _set_input(game, Direction.RIGHT)
         _tick(game, 5)
         _clear_input(game)
@@ -161,7 +150,6 @@ class TestPlayerIceSlide:
         """Slide stops when tank hits a wall/obstacle."""
         game = ice_game
 
-        # Place a brick wall 1 tile to the right of player
         px = first_player(game).x
         py = first_player(game).y
         wall_grid_x = int(px // SUB_TILE_SIZE) + 2
@@ -171,13 +159,11 @@ class TestPlayerIceSlide:
             if tile is not None:
                 game.map.set_tile_type(tile, TileType.BRICK)
 
-        # Move RIGHT then release to slide into wall
         first_player(game).direction = Direction.RIGHT
         _set_input(game, Direction.RIGHT)
         _tick(game, 3)
         _clear_input(game)
 
-        # Tick until slide ends
         for _ in range(60):
             _tick(game, 1)
             if not first_player(game).is_sliding:
@@ -191,17 +177,15 @@ class TestPlayerIceSlide:
         """Player slides when pressing opposite direction on ice."""
         game = ice_game
 
-        # Move UP
         _set_input(game, Direction.UP)
         _tick(game, 5)
 
-        # Press DOWN (opposite) — direction change triggers slide
         _set_input(game, Direction.DOWN)
-        _tick(game, 1)  # triggers slide
+        _tick(game, 1)
         assert first_player(game).is_sliding is True, (
             "Tank should slide when pressing opposite direction"
         )
 
         pos_before = first_player(game).y
-        _tick(game, 1)  # first frame of slide movement
+        _tick(game, 1)
         assert first_player(game).y < pos_before, "Tank should continue sliding UP"

--- a/tests/integration/test_player_integration.py
+++ b/tests/integration/test_player_integration.py
@@ -13,33 +13,28 @@ from src.utils.constants import (
 from src.core.tile import Tile, TileType
 from tests.integration.conftest import first_player
 
-# Tests related to player actions: movement, shooting, respawn
-
 
 @pytest.mark.parametrize(
     "key, axis, direction_sign, expected_direction",
     [
-        (pygame.K_UP, 1, -1, Direction.UP),  # UP: y-axis, negative
-        (pygame.K_DOWN, 1, 1, Direction.DOWN),  # DOWN: y-axis, positive
-        (pygame.K_LEFT, 0, -1, Direction.LEFT),  # LEFT: x-axis, negative
-        (pygame.K_RIGHT, 0, 1, Direction.RIGHT),  # RIGHT: x-axis, positive
+        (pygame.K_UP, 1, -1, Direction.UP),
+        (pygame.K_DOWN, 1, 1, Direction.DOWN),
+        (pygame.K_LEFT, 0, -1, Direction.LEFT),
+        (pygame.K_RIGHT, 0, 1, Direction.RIGHT),
     ],
 )
 def test_player_movement(key, axis, direction_sign, expected_direction):
     """Test player tank movement and direction in all four directions."""
-    # Use fresh instance to avoid side effects from other tests
     game_manager = GameManager()
     game_manager._reset_game()
     player_tank = first_player(game_manager)
     game_map = game_manager.map
 
-    # Manually set position to an open space (sub-tile grid 16, 16)
     start_grid_x, start_grid_y = 16, 16
     new_x = start_grid_x * SUB_TILE_SIZE
     new_y = start_grid_y * SUB_TILE_SIZE
 
-    # Clear surrounding sub-tiles to ensure movement in all directions
-    # Tank is 2x2 sub-tiles, so clear a wider area
+    # Tank is 2x2 sub-tiles, so clear a wider area to allow movement in any direction.
     for dy in range(-2, 4):
         for dx in range(-2, 4):
             nx, ny = start_grid_x + dx, start_grid_y + dy
@@ -51,39 +46,33 @@ def test_player_movement(key, axis, direction_sign, expected_direction):
                     )
 
     player_tank.set_position(new_x, new_y)
-    player_tank.prev_x, player_tank.prev_y = new_x, new_y  # Sync previous position
+    player_tank.prev_x, player_tank.prev_y = new_x, new_y
 
     initial_pos = player_tank.get_position()
     dt = 1.0 / FPS
     update_duration = 0.2
     num_updates = int(update_duration / dt)
 
-    # Simulate key press
     key_down_event = pygame.event.Event(pygame.KEYDOWN, key=key)
     game_manager.input_handler.handle_event(key_down_event)
     game_manager.player_manager.handle_event(key_down_event)
 
-    # Update game state
     for _ in range(num_updates):
         game_manager.update()
 
-    # Simulate key release
     key_up_event = pygame.event.Event(pygame.KEYUP, key=key)
     game_manager.input_handler.handle_event(key_up_event)
     game_manager.player_manager.handle_event(key_up_event)
 
     final_pos = player_tank.get_position()
 
-    # Assert position changed
     assert final_pos != initial_pos
 
-    # Assert movement occurred in the correct direction
     if direction_sign == -1:
         assert final_pos[axis] < initial_pos[axis]
     else:
         assert final_pos[axis] > initial_pos[axis]
 
-    # Assert the tank's direction is correct
     assert player_tank.direction == expected_direction
 
 
@@ -92,29 +81,15 @@ def test_player_movement(key, axis, direction_sign, expected_direction):
     [
         TileType.STEEL,
         TileType.WATER,
-        # TileType.BRICK, # Can add later if needed
-        # TileType.BASE, # Can add later if needed
     ],
 )
 @pytest.mark.parametrize(
     "move_direction, key, start_pos_offset",
     [
-        (Direction.UP, pygame.K_UP, (0, 1)),  # UP: start 1 tile below (2 sub-tiles)
-        (
-            Direction.DOWN,
-            pygame.K_DOWN,
-            (0, -1),
-        ),  # DOWN: start 1 tile above (2 sub-tiles)
-        (
-            Direction.LEFT,
-            pygame.K_LEFT,
-            (1, 0),
-        ),  # LEFT: start 1 tile right (2 sub-tiles)
-        (
-            Direction.RIGHT,
-            pygame.K_RIGHT,
-            (-1, 0),
-        ),  # RIGHT: start 1 tile left (2 sub-tiles)
+        (Direction.UP, pygame.K_UP, (0, 1)),
+        (Direction.DOWN, pygame.K_DOWN, (0, -1)),
+        (Direction.LEFT, pygame.K_LEFT, (1, 0)),
+        (Direction.RIGHT, pygame.K_RIGHT, (-1, 0)),
     ],
 )
 def test_player_movement_blocked_by_tile(
@@ -125,11 +100,10 @@ def test_player_movement_blocked_by_tile(
     player_tank = first_player(game_manager)
     game_map = game_manager.map
 
-    # Define target tile location (sub-tile grid coords)
+    # Target location (14,14) is clear of default map obstacles.
     target_x_grid = 14
-    target_y_grid = 14  # Choose a location away from default obstacles
+    target_y_grid = 14
 
-    # Manually place the specified tile type as a 2x2 sub-tile block (= 1 full tile)
     if (
         0 <= target_y_grid + 1 < game_map.height
         and 0 <= target_x_grid + 1 < game_map.width
@@ -156,21 +130,19 @@ def test_player_movement_blocked_by_tile(
             f"are out of bounds."
         )
 
-    # Calculate player start position: tank (32px) flush against 2x2 block (32px)
-    # Offsets are in tile-size units (2 sub-tiles each)
+    # start_pos_offset is in tile-size units (2 sub-tiles each), so the tank
+    # sits flush against the 2x2 block.
     start_grid_x = target_x_grid + start_pos_offset[0] * 2
     start_grid_y = target_y_grid + start_pos_offset[1] * 2
     start_x = start_grid_x * SUB_TILE_SIZE
     start_y = start_grid_y * SUB_TILE_SIZE
 
-    # Ensure start position is within bounds
     if not (0 <= start_grid_y < game_map.height and 0 <= start_grid_x < game_map.width):
         pytest.skip(
             f"Calculated start position ({start_grid_x}, {start_grid_y}) is out of "
             f"bounds for target ({target_x_grid}, {target_y_grid}). Skipping."
         )
 
-    # Clear the 2x2 sub-tile area for the player to ensure no self-collision issue
     for dy in range(2):
         for dx in range(2):
             sx, sy = start_grid_x + dx, start_grid_y + dy
@@ -182,34 +154,28 @@ def test_player_movement_blocked_by_tile(
                 )
     logger.debug(f"Set player starting area ({start_grid_x}, {start_grid_y}) to EMPTY.")
 
-    # Place player
     player_tank.set_position(start_x, start_y)
     player_tank.prev_x, player_tank.prev_y = start_x, start_y
-    # Capture the initial rect based on rounded initial float positions
     initial_player_rect = pygame.Rect(
         round(start_x), round(start_y), player_tank.width, player_tank.height
     )
 
     dt = 1.0 / FPS
-    update_duration = 0.2  # Simulate for a short duration
+    update_duration = 0.2
     num_updates = int(update_duration / dt)
 
-    # Simulate key press
     key_down_event = pygame.event.Event(pygame.KEYDOWN, key=key)
     game_manager.input_handler.handle_event(key_down_event)
     game_manager.player_manager.handle_event(key_down_event)
 
-    # Update game state
     for _ in range(num_updates):
         game_manager.update()
 
-    # Simulate key release
     key_up_event = pygame.event.Event(pygame.KEYUP, key=key)
     game_manager.input_handler.handle_event(key_up_event)
     game_manager.player_manager.handle_event(key_up_event)
 
     final_player_rect = player_tank.rect
-    # The blocking tile is a 2x2 sub-tile block; compute its combined rect
     colliding_tile_rect = pygame.Rect(
         target_x_grid * SUB_TILE_SIZE,
         target_y_grid * SUB_TILE_SIZE,
@@ -217,11 +183,7 @@ def test_player_movement_blocked_by_tile(
         SUB_TILE_SIZE * 2,
     )
 
-    # Assert position has changed from initial (due to snapping) but is now flush
-    # The core idea is that the tank should be touching the obstacle.
-    # The exact final float (x,y) might vary slightly due to float arithmetic,
-    # but the rounded rect should be perfectly aligned.
-
+    # Float positions can drift; compare rounded rects for exact flush alignment.
     expected_message_base = (
         f"Tank not properly snapped to {blocking_tile_type.name} "
         f"when moving {move_direction}. Player Rect: {final_player_rect}, "
@@ -232,7 +194,6 @@ def test_player_movement_blocked_by_tile(
         assert final_player_rect.right == colliding_tile_rect.left, (
             f"{expected_message_base} Expected player.right == tile.left."
         )
-        # Also ensure it didn't overshoot on the other axis
         assert final_player_rect.top == initial_player_rect.top, (
             f"{expected_message_base} Player y-position changed unexpectedly. "
             f"Expected top {initial_player_rect.top}, got {final_player_rect.top}."
@@ -264,7 +225,6 @@ def test_player_movement_blocked_by_tile(
     else:
         pytest.fail(f"Unknown move_direction: {move_direction}")
 
-    # Assert the tank's direction is correct (it should face the obstacle)
     assert player_tank.direction == move_direction, (
         f"Tank direction incorrect when blocked by {blocking_tile_type.name}. "
         f"Expected {move_direction}, got {player_tank.direction}"
@@ -273,19 +233,15 @@ def test_player_movement_blocked_by_tile(
 
 def test_player_shooting():
     """Test player shooting mechanics."""
-    # Use fresh instance
     game_manager = GameManager()
     game_manager._reset_game()
     player_tank = first_player(game_manager)
 
-    # 1. Initial state: No bullets
     assert len(game_manager.bullets) == 0, "No bullets should exist initially."
 
-    # 2. Fire the first bullet
-    player_tank.direction = Direction.RIGHT  # Set a known direction
+    player_tank.direction = Direction.RIGHT
     game_manager._try_shoot(player_tank)
 
-    # 3. Verify bullet creation and properties
     assert len(game_manager.bullets) == 1, "One bullet should exist after shooting."
     bullet = game_manager.bullets[0]
     assert bullet.active, "Bullet should be active after shooting."
@@ -293,7 +249,6 @@ def test_player_shooting():
     assert bullet.owner_type == OwnerType.PLAYER, "Bullet owner type is incorrect."
     assert bullet.owner is player_tank, "Bullet owner should be the player tank."
 
-    # 4. Verify bullet initial position (centered on tank)
     expected_x = player_tank.x + player_tank.width // 2 - BULLET_WIDTH // 2
     expected_y = player_tank.y + player_tank.height // 2 - BULLET_HEIGHT // 2
     actual_pos = bullet.get_position()
@@ -302,10 +257,9 @@ def test_player_shooting():
         f"got {actual_pos}"
     )
 
-    # 5. Attempt to fire a second bullet immediately (one-bullet limit)
+    # One-bullet-per-tank limit: firing again while the first is active is a no-op.
     game_manager._try_shoot(player_tank)
 
-    # 6. Verify no new bullet was created
     assert len(game_manager.bullets) == 1, (
         "Firing again should not create a new bullet while the first is active."
     )
@@ -316,20 +270,18 @@ def test_player_shooting():
 @pytest.mark.parametrize(
     "direction_str, axis_index, direction_sign",
     [
-        (Direction.UP, 1, -1),  # UP: axis=1 (y), sign=-1 (decrease)
-        (Direction.DOWN, 1, 1),  # DOWN: axis=1 (y), sign=1 (increase)
-        (Direction.LEFT, 0, -1),  # LEFT: axis=0 (x), sign=-1 (decrease)
-        (Direction.RIGHT, 0, 1),  # RIGHT: axis=0 (x), sign=1 (increase)
+        (Direction.UP, 1, -1),
+        (Direction.DOWN, 1, 1),
+        (Direction.LEFT, 0, -1),
+        (Direction.RIGHT, 0, 1),
     ],
 )
 def test_player_bullet_movement(direction_str, axis_index, direction_sign):
     """Test that the player's bullet moves correctly after firing."""
-    # Use fresh instance
     game_manager = GameManager()
     game_manager._reset_game()
     player_tank = first_player(game_manager)
 
-    # Set tank direction and fire
     player_tank.direction = direction_str
     game_manager._try_shoot(player_tank)
 
@@ -340,20 +292,17 @@ def test_player_bullet_movement(direction_str, axis_index, direction_sign):
 
     initial_pos = bullet.get_position()
 
-    # Simulate game time
     dt = 1.0 / FPS
-    update_duration = 0.1  # Short duration to see movement
+    update_duration = 0.1
     num_updates = int(update_duration / dt)
 
     for _ in range(num_updates):
-        game_manager.update()  # Update game (which updates bullet)
+        game_manager.update()
 
     final_pos = bullet.get_position()
 
-    # Assert position changed
     assert final_pos != initial_pos, f"Bullet did not move from {initial_pos}"
 
-    # Assert movement occurred in the correct direction
     if direction_sign == -1:
         assert final_pos[axis_index] < initial_pos[axis_index], (
             f"Bullet moved wrong way ({direction_str}). "
@@ -365,7 +314,6 @@ def test_player_bullet_movement(direction_str, axis_index, direction_sign):
             f"Start: {initial_pos[axis_index]}, End: {final_pos[axis_index]}"
         )
 
-    # Assert movement occurred ONLY along the expected axis
     other_axis_index = 1 - axis_index
     assert final_pos[other_axis_index] == initial_pos[other_axis_index], (
         f"Bullet moved unexpectedly along axis {other_axis_index}. "
@@ -375,7 +323,6 @@ def test_player_bullet_movement(direction_str, axis_index, direction_sign):
 
 def test_player_respawn():
     """Test player respawn mechanics after taking lethal damage with lives remaining."""
-    # Use fresh instance
     game_manager = GameManager()
     game_manager._reset_game()
     player_tank = first_player(game_manager)
@@ -387,64 +334,50 @@ def test_player_respawn():
 
     assert initial_lives > 1, "Test requires player to start with more than 1 life."
 
-    # Disable spawn invincibility so damage lands
+    # Disable spawn invincibility so damage lands.
     player_tank.is_invincible = False
 
-    # Simulate taking lethal damage (enough to reduce health to 0 or less)
-    # We call take_damage directly to isolate the respawn logic test
+    # Call take_damage directly (rather than through the game loop) to isolate
+    # the respawn logic from collision/bullet plumbing.
     was_destroyed_permanently = player_tank.take_damage(amount=initial_health)
 
-    # Assert that the tank wasn't *permanently* destroyed (still had lives)
     assert not was_destroyed_permanently, "Tank was permanently destroyed unexpectedly."
 
-    # In the actual game loop, GameManager would call respawn here
-    # We call it directly for this integration test focused on respawn effects
+    # GameManager would call respawn() in the live loop; call it directly here.
     player_tank.respawn()
 
-    # 1. Verify lives decreased
     assert player_tank.lives == initial_lives - 1, (
         f"Player lives did not decrease. Expected {initial_lives - 1}, "
         f"got {player_tank.lives}"
     )
 
-    # 2. Verify health reset (assuming respawn resets health)
-    # Note: take_damage() already resets health if lives > 0
-    # respawn() itself doesn't reset health in the current implementation
-    # We check it was reset by take_damage
+    # take_damage() resets health when lives > 0; respawn() itself does not.
     assert player_tank.health == initial_max_health, (
         f"Player health not reset after taking damage. Expected {initial_max_health}, "
         f"got {player_tank.health}"
     )
 
-    # 3. Verify position reset to spawn point
     current_pos = player_tank.get_position()
     assert current_pos == spawn_pos, (
         f"Player did not respawn at initial position. Expected {spawn_pos}, "
         f"got {current_pos}"
     )
 
-    # 4. Verify invincibility is active
     assert player_tank.is_invincible, "Player should be invincible after respawning."
     assert player_tank.invincibility_timer == 0, "Invincibility timer should be reset."
 
-    # 5. Verify invincibility wears off after duration
     invincibility_duration = player_tank.invincibility_duration
     dt = 1.0 / FPS
-    # Calculate number of updates to *exceed* the duration slightly
     num_updates_to_exceed_duration = int(invincibility_duration / dt) + 2
 
-    # Update until invincibility should have worn off
     for i in range(num_updates_to_exceed_duration):
-        # Check if invincibility wore off early (optional, but good for debugging)
         if not player_tank.is_invincible and i * dt < invincibility_duration:
             logger.warning(
                 f"Invincibility wore off early at frame {i + 1} ({i * dt:.2f}s)"
             )
-            # We can continue or fail here depending on strictness
             break
-        game_manager.update()  # Need to update game manager for timers
+        game_manager.update()
 
-        # Exit loop once invincibility wears off
         if not player_tank.is_invincible:
             logger.info(
                 f"Invincibility wore off as expected at frame {i + 1} ({i * dt:.2f}s)"

--- a/tests/integration/test_shield_integration.py
+++ b/tests/integration/test_shield_integration.py
@@ -12,7 +12,6 @@ class TestShieldIntegration:
         """Player tank has shield active after game start (spawn invincibility)."""
         gm = game_manager_fixture
         assert first_player(gm).is_invincible
-        assert first_player(gm).is_invincible
 
     def test_shield_stays_active_during_warning_phase(self, game_manager_fixture):
         """Shield remains active in warning phase but flickers faster."""
@@ -34,5 +33,4 @@ class TestShieldIntegration:
         gm = game_manager_fixture
         first_player(gm).invincibility_timer = 4.0  # past 3s duration
         first_player(gm).update(1.0 / FPS)
-        assert not first_player(gm).is_invincible
         assert not first_player(gm).is_invincible

--- a/tests/integration/test_sound_integration.py
+++ b/tests/integration/test_sound_integration.py
@@ -12,7 +12,6 @@ class TestEngineSoundWiring:
         """Verify update() calls update_engine without error during RUNNING."""
         gm = game_manager_fixture
         assert gm.state == GameState.RUNNING
-        # Run a few frames — should not raise
         for _ in range(5):
             gm.update()
 
@@ -71,10 +70,8 @@ class TestPowerupBlinkWiring:
     def test_update_runs_with_active_powerups(self, game_manager_fixture):
         """Verify update() doesn't error when powerups are active."""
         gm = game_manager_fixture
-        # Spawn a powerup directly
         gm.power_up_manager.spawn_power_up(
             first_player(gm), gm.spawn_manager.enemy_tanks
         )
         assert len(gm.power_up_manager.get_power_ups()) > 0
-        # Run a frame — should not raise
         gm.update()

--- a/tests/integration/test_stage_progression.py
+++ b/tests/integration/test_stage_progression.py
@@ -11,7 +11,6 @@ class TestStageProgressionIntegration:
         assert gm.current_stage == 1
         gm._set_game_state(GameState.VICTORY)
         assert gm.state == GameState.VICTORY
-        # Advance past victory pause
         while gm.state == GameState.VICTORY:
             gm.update()
         assert gm.current_stage == 2
@@ -24,7 +23,7 @@ class TestStageProgressionIntegration:
         while gm.state == GameState.VICTORY:
             gm.update()
         assert gm.state == GameState.GAME_COMPLETE
-        assert gm.current_stage == MAX_STAGE  # not incremented
+        assert gm.current_stage == MAX_STAGE
 
     def test_game_complete_render_does_not_raise(self, game_manager_fixture):
         """Verify render() works in GAME_COMPLETE state."""
@@ -34,4 +33,4 @@ class TestStageProgressionIntegration:
         while gm.state == GameState.VICTORY:
             gm.update()
         assert gm.state == GameState.GAME_COMPLETE
-        gm.render()  # should not raise
+        gm.render()

--- a/tests/integration/test_stage_transition.py
+++ b/tests/integration/test_stage_transition.py
@@ -14,16 +14,14 @@ class TestStageTransition:
         assert game.state == GameState.RUNNING
         assert game.current_stage == 1
 
-        # Force victory
         game.spawn_manager.enemy_tanks = []
         game.spawn_manager._pending_spawns = []
         game.spawn_manager.total_enemy_spawns = game.spawn_manager.max_enemy_spawns
         game.update()
         assert game.state == GameState.VICTORY
 
-        # Tick through entire transition
-        # Total ~4s: VICTORY_PAUSE (1.0) + CURTAIN_CLOSE (0.75) + CURTAIN_STAGE_DISPLAY
-        # (1.5) + CURTAIN_OPEN (0.75). Allow comfortable margin.
+        # Transition ~4s: VICTORY_PAUSE (1.0) + CURTAIN_CLOSE (0.75) +
+        # CURTAIN_STAGE_DISPLAY (1.5) + CURTAIN_OPEN (0.75); 300 frames is comfortable.
         for _ in range(300):
             game.update()
             if game.state == GameState.RUNNING:


### PR DESCRIPTION
## Summary

Closes #188.

Delete narration / banner / ASCII-section comments from the integration test suite:

- `# --- Spawn --- #` / `# --- End Spawn --- #` banners
- Numbered assertion headers (`# 1.`, `# 2.`, `# 3.`)
- Arrange/Act/Assert section markers
- Sentence narration (`# Update game state`, `# Aim up and shoot`, etc.)
- Stale file-level comments
- Noisy logger.info/debug narration that wasn't asserting anything
- Duplicate assertions in `test_shield_integration.py` (lines 14/15 and 37/38)

Comments that explain non-obvious WHY (hidden constraints, unit conventions, workarounds) are kept or condensed — e.g. the "freeze enemy so AI can't dodge the bullet", "two-sub-tiles = one tank height" and the stage-transition timing breakdown remain.

Files touched: `test_collision_integration.py`, `test_effect_integration.py`, `test_enemy_integration.py`, `test_gamestate_integration.py`, `test_ice_slide.py`, `test_player_integration.py`, `test_shield_integration.py`, `test_sound_integration.py`, `test_stage_progression.py`, `test_stage_transition.py`. Net -436 lines.

## Test plan

- [x] `pytest tests/integration/` — 98 passed
- [x] `ruff check` + `ruff format --check` clean