### PR TITLE
refactor(tests): extract shared integration-test helpers to conftest

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,8 +1,16 @@
 import os
 import pytest
 import pygame
+from src.core.enemy_tank import EnemyTank
+from src.core.tile import Tile, TileType
 from src.managers.game_manager import GameManager
-from src.utils.constants import FPS, POWERUP_CARRIER_INDICES
+from src.utils.constants import (
+    FPS,
+    POWERUP_CARRIER_INDICES,
+    SUB_TILE_SIZE,
+    TILE_SIZE,
+    TankType,
+)
 
 # Use a virtual framebuffer so integration tests don't open real windows.
 os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
@@ -82,3 +90,88 @@ def spawn_carrier(game):
     carriers = [e for e in game.spawn_manager.enemy_tanks if e.is_carrier]
     assert carriers, "No carrier found"
     return carriers[0]
+
+
+def clear_tiles(game_map, positions):
+    """Clear tiles at given sub-tile grid positions to EMPTY for test setup."""
+    for gx, gy in positions:
+        if 0 <= gx < game_map.width and 0 <= gy < game_map.height:
+            tile = game_map.get_tile_at(gx, gy)
+            if tile and tile.type != TileType.EMPTY:
+                game_map.place_tile(gx, gy, Tile(TileType.EMPTY, gx, gy, SUB_TILE_SIZE))
+
+
+def spawn_enemy_at(
+    game,
+    grid_x,
+    grid_y,
+    tank_type=TankType.BASIC,
+    direction=None,
+    replace=True,
+    **enemy_kwargs,
+):
+    """Spawn a single EnemyTank at the given sub-tile grid position.
+
+    If replace=True (default), replaces any existing enemies with just this one.
+    Otherwise, appends to the existing list. Extra kwargs (e.g. difficulty=...)
+    are forwarded to EnemyTank. Returns the new EnemyTank so callers can tweak
+    attributes (speed, shoot, etc.).
+    """
+    map_w_px = game.map.width * SUB_TILE_SIZE
+    map_h_px = game.map.height * SUB_TILE_SIZE
+    enemy = EnemyTank(
+        grid_x * SUB_TILE_SIZE,
+        grid_y * SUB_TILE_SIZE,
+        TILE_SIZE,
+        game.texture_manager,
+        tank_type,
+        map_width_px=map_w_px,
+        map_height_px=map_h_px,
+        **enemy_kwargs,
+    )
+    if direction is not None:
+        enemy.direction = direction
+    if replace:
+        game.spawn_manager.enemy_tanks = [enemy]
+    else:
+        game.spawn_manager.enemy_tanks.append(enemy)
+    return enemy
+
+
+def fire_bullet_from(game, tank):
+    """Fire a bullet from `tank` via GameManager._try_shoot and return it."""
+    game._try_shoot(tank)
+    return next(b for b in game.bullets if b.owner is tank)
+
+
+def place_player_at(game, x, y, player=None):
+    """Place the (first) player at pixel coords, syncing prev_x/prev_y and rect."""
+    p = player if player is not None else first_player(game)
+    p.set_position(x, y)
+    p.prev_x, p.prev_y = x, y
+    p.rect.topleft = (round(x), round(y))
+
+
+def clear_enemies(game, reset_total=True):
+    """Reset enemy_tanks, _pending_spawns, and optionally total_enemy_spawns."""
+    game.spawn_manager.enemy_tanks = []
+    game.spawn_manager._pending_spawns = []
+    if reset_total:
+        game.spawn_manager.total_enemy_spawns = 0
+
+
+def tick(game, n=1):
+    """Run n update frames."""
+    for _ in range(n):
+        game.update()
+
+
+def tick_for(game, seconds):
+    """Run update frames totaling approximately `seconds` at FPS dt."""
+    tick(game, int(seconds * FPS))
+
+
+def send_event(game, event):
+    """Dispatch an event to both the input handler and the player manager."""
+    game.input_handler.handle_event(event)
+    game.player_manager.handle_event(event)

--- a/tests/integration/test_collision_integration.py
+++ b/tests/integration/test_collision_integration.py
@@ -1,9 +1,14 @@
 import pytest
-from src.utils.constants import Direction, FPS, TILE_SIZE, SUB_TILE_SIZE, TankType
+from src.utils.constants import Direction, FPS, SUB_TILE_SIZE
 from src.states.game_state import GameState
 from src.core.tile import BrickVariant, Tile, TileDefaults, TileType
-from src.core.enemy_tank import EnemyTank
-from tests.integration.conftest import first_player
+from tests.integration.conftest import (
+    clear_tiles,
+    fire_bullet_from,
+    first_player,
+    place_player_at,
+    spawn_enemy_at,
+)
 
 
 @pytest.mark.parametrize(
@@ -51,29 +56,28 @@ def test_player_bullet_vs_tile(
 
     # Clear 2 sub-tiles wide (bullet path) for 4 sub-tiles deep (target + player area),
     # skipping the target itself.
-    for y in range(target_y_grid, target_y_grid + 4):
-        for dx in range(2):
-            sx = target_x_grid + dx
-            if 0 <= sx < game_map.width and 0 <= y < game_map.height:
-                if sx == target_x_grid and y == target_y_grid:
-                    continue
-                t = game_map.get_tile_at(sx, y)
-                if t and t.type != TileType.EMPTY:
-                    game_map.place_tile(
-                        sx, y, Tile(TileType.EMPTY, sx, y, SUB_TILE_SIZE)
-                    )
+    clear_tiles(
+        game_map,
+        [
+            (target_x_grid + dx, y)
+            for y in range(target_y_grid, target_y_grid + 4)
+            for dx in range(2)
+            if not (dx == 0 and y == target_y_grid)
+        ],
+    )
 
     # Player below target (2 sub-tiles = 1 tank height).
-    player_start_x = target_x_grid * SUB_TILE_SIZE
-    player_start_y = (target_y_grid + 2) * SUB_TILE_SIZE
-    player_tank.set_position(player_start_x, player_start_y)
-    player_tank.prev_x, player_tank.prev_y = player_start_x, player_start_y
+    place_player_at(
+        game_manager,
+        target_x_grid * SUB_TILE_SIZE,
+        (target_y_grid + 2) * SUB_TILE_SIZE,
+        player=player_tank,
+    )
 
     player_tank.direction = Direction.UP
-    bullet_obj = player_tank.shoot()
-    assert bullet_obj is not None, "Bullet failed to spawn."
-    game_manager.player_manager._bullets.append(bullet_obj)
-    bullet = bullet_obj
+    bullet = player_tank.shoot()
+    assert bullet is not None, "Bullet failed to spawn."
+    game_manager.player_manager._bullets.append(bullet)
 
     dt = 1.0 / FPS
     update_duration = 0.2
@@ -103,60 +107,38 @@ def test_player_bullet_vs_tile(
         assert damaged, "Brick should be damaged or destroyed after being hit."
 
 
-def _clear_tiles(game_map, positions):
-    """Clear tiles at given sub-tile grid positions to EMPTY for test setup."""
-    for gx, gy in positions:
-        if 0 <= gx < game_map.width and 0 <= gy < game_map.height:
-            tile = game_map.get_tile_at(gx, gy)
-            if tile and tile.type != TileType.EMPTY:
-                game_map.place_tile(gx, gy, Tile(TileType.EMPTY, gx, gy, SUB_TILE_SIZE))
-
-
 def test_player_bullet_destroys_enemy_tank(game_manager_fixture, mocker):
     """Test player bullet hitting and destroying a basic enemy tank."""
     mocker.patch("src.core.enemy_tank.random.uniform", return_value=0.0)
     game_manager = game_manager_fixture
     player_tank = first_player(game_manager)
 
-    enemy_type = TankType.BASIC
     enemy_x_grid = 14
     enemy_y_grid = 10
-    enemy_start_x = enemy_x_grid * SUB_TILE_SIZE
-    enemy_start_y = enemy_y_grid * SUB_TILE_SIZE
 
     # Clear enemy + player (2 sub-tiles each = 4 total) across 2 columns.
-    _clear_tiles(
+    clear_tiles(
         game_manager.map,
         [(enemy_x_grid + dx, enemy_y_grid + dy) for dy in range(4) for dx in range(2)],
     )
 
-    map_w_px = game_manager.map.width * SUB_TILE_SIZE
-    map_h_px = game_manager.map.height * SUB_TILE_SIZE
-    enemy_tank = EnemyTank(
-        enemy_start_x,
-        enemy_start_y,
-        TILE_SIZE,
-        game_manager.texture_manager,
-        enemy_type,
-        map_width_px=map_w_px,
-        map_height_px=map_h_px,
-    )
+    enemy_tank = spawn_enemy_at(game_manager, enemy_x_grid, enemy_y_grid)
     # Prevent enemy shooting so its bullets don't interfere with the player bullet.
     enemy_tank.shoot = lambda: None
-    game_manager.spawn_manager.enemy_tanks = [enemy_tank]
     initial_enemy_count = len(game_manager.spawn_manager.enemy_tanks)
 
     # Player below enemy (2 sub-tiles = 1 tank height).
-    player_start_x = enemy_x_grid * SUB_TILE_SIZE
-    player_start_y = (enemy_y_grid + 2) * SUB_TILE_SIZE
-    player_tank.set_position(player_start_x, player_start_y)
-    player_tank.prev_x, player_tank.prev_y = player_start_x, player_start_y
+    place_player_at(
+        game_manager,
+        enemy_x_grid * SUB_TILE_SIZE,
+        (enemy_y_grid + 2) * SUB_TILE_SIZE,
+        player=player_tank,
+    )
 
     player_tank.direction = Direction.UP
-    bullet_obj = player_tank.shoot()
-    assert bullet_obj is not None, "Bullet failed to spawn."
-    game_manager.player_manager._bullets.append(bullet_obj)
-    bullet = bullet_obj
+    bullet = player_tank.shoot()
+    assert bullet is not None, "Bullet failed to spawn."
+    game_manager.player_manager._bullets.append(bullet)
 
     dt = 1.0 / FPS
     max_simulation_time = 0.5
@@ -213,15 +195,11 @@ def test_enemy_bullet_hits_player_tank(
     player_tank.is_invincible = player_is_invincible
     player_tank.invincibility_timer = 0
 
-    enemy_type = TankType.BASIC
     player_x_grid = int(player_tank.x // SUB_TILE_SIZE)
     player_y_grid = int(player_tank.y // SUB_TILE_SIZE)
     enemy_x_grid = player_x_grid
     # 4 sub-tiles (= 2 tank heights) above the player.
     enemy_y_grid = player_y_grid - 4
-
-    enemy_start_x = enemy_x_grid * SUB_TILE_SIZE
-    enemy_start_y = enemy_y_grid * SUB_TILE_SIZE
 
     if not (
         0 <= enemy_y_grid < game_manager.map.height
@@ -232,7 +210,7 @@ def test_enemy_bullet_hits_player_tank(
             f"is out of bounds. Skipping."
         )
 
-    _clear_tiles(
+    clear_tiles(
         game_manager.map,
         [
             (enemy_x_grid + dx, y)
@@ -241,24 +219,11 @@ def test_enemy_bullet_hits_player_tank(
         ],
     )
 
-    map_w_px = game_manager.map.width * SUB_TILE_SIZE
-    map_h_px = game_manager.map.height * SUB_TILE_SIZE
-    enemy_tank = EnemyTank(
-        enemy_start_x,
-        enemy_start_y,
-        TILE_SIZE,
-        game_manager.texture_manager,
-        enemy_type,
-        map_width_px=map_w_px,
-        map_height_px=map_h_px,
+    enemy_tank = spawn_enemy_at(
+        game_manager, enemy_x_grid, enemy_y_grid, direction=Direction.DOWN
     )
-    enemy_tank.direction = Direction.DOWN
-    game_manager.spawn_manager.enemy_tanks = [enemy_tank]
 
-    game_manager._try_shoot(enemy_tank)
-    enemy_bullets = [b for b in game_manager.bullets if b.owner is enemy_tank]
-    assert len(enemy_bullets) == 1, "Enemy bullet failed to spawn."
-    enemy_bullet = enemy_bullets[0]
+    enemy_bullet = fire_bullet_from(game_manager, enemy_tank)
     assert enemy_bullet.active, "Enemy bullet spawned inactive."
 
     dt = 1.0 / FPS
@@ -345,52 +310,24 @@ def test_enemy_bullet_hits_other_enemy(game_manager_fixture, mocker):
     mocker.patch("src.core.enemy_tank.random.uniform", return_value=0.0)
     game_manager = game_manager_fixture
 
-    enemy_type = TankType.BASIC
     # enemy1 shoots down at enemy2 (4 sub-tiles apart).
     enemy1_x_grid, enemy1_y_grid = 16, 16
     enemy2_x_grid, enemy2_y_grid = 16, 20
 
-    _clear_tiles(
+    clear_tiles(
         game_manager.map,
         [(16 + dx, y) for y in range(16, 22) for dx in range(2)],
     )
 
-    enemy1_start_x = enemy1_x_grid * SUB_TILE_SIZE
-    enemy1_start_y = enemy1_y_grid * SUB_TILE_SIZE
-    enemy2_start_x = enemy2_x_grid * SUB_TILE_SIZE
-    enemy2_start_y = enemy2_y_grid * SUB_TILE_SIZE
-
-    map_w_px = game_manager.map.width * SUB_TILE_SIZE
-    map_h_px = game_manager.map.height * SUB_TILE_SIZE
-    enemy1 = EnemyTank(
-        enemy1_start_x,
-        enemy1_start_y,
-        TILE_SIZE,
-        game_manager.texture_manager,
-        enemy_type,
-        map_width_px=map_w_px,
-        map_height_px=map_h_px,
+    enemy1 = spawn_enemy_at(
+        game_manager, enemy1_x_grid, enemy1_y_grid, direction=Direction.DOWN
     )
-    enemy1.direction = Direction.DOWN
+    enemy2 = spawn_enemy_at(game_manager, enemy2_x_grid, enemy2_y_grid, replace=False)
 
-    enemy2 = EnemyTank(
-        enemy2_start_x,
-        enemy2_start_y,
-        TILE_SIZE,
-        game_manager.texture_manager,
-        enemy_type,
-        map_width_px=map_w_px,
-        map_height_px=map_h_px,
-    )
-
-    game_manager.spawn_manager.enemy_tanks = [enemy1, enemy2]
     initial_enemy_count = len(game_manager.spawn_manager.enemy_tanks)
     initial_enemy2_health = enemy2.health
 
-    game_manager._try_shoot(enemy1)
-    enemy1_bullets = [b for b in game_manager.bullets if b.owner is enemy1]
-    assert len(enemy1_bullets) == 1, "Enemy1 bullet failed to spawn."
-    bullet = enemy1_bullets[0]
+    bullet = fire_bullet_from(game_manager, enemy1)
     assert bullet.active, "Enemy1 bullet spawned inactive."
 
     dt = 1.0 / FPS
@@ -428,17 +365,13 @@ def test_player_tank_vs_enemy_tank_no_overlap(game_manager_fixture, mocker):
     game_manager = game_manager_fixture
     player_tank = first_player(game_manager)
 
-    enemy_type = TankType.BASIC
     player_x_grid = int(player_tank.x // SUB_TILE_SIZE)
     player_y_grid = int(player_tank.y // SUB_TILE_SIZE)
     # 2 sub-tiles above = exactly adjacent (one tank-height gap).
     enemy_x_grid = player_x_grid
     enemy_y_grid = player_y_grid - 2
 
-    enemy_start_x = enemy_x_grid * SUB_TILE_SIZE
-    enemy_start_y = enemy_y_grid * SUB_TILE_SIZE
-
-    _clear_tiles(
+    clear_tiles(
         game_manager.map,
         [
             (enemy_x_grid + dx, y)
@@ -447,22 +380,11 @@ def test_player_tank_vs_enemy_tank_no_overlap(game_manager_fixture, mocker):
         ],
     )
 
-    map_w_px = game_manager.map.width * SUB_TILE_SIZE
-    map_h_px = game_manager.map.height * SUB_TILE_SIZE
-    enemy_tank = EnemyTank(
-        enemy_start_x,
-        enemy_start_y,
-        TILE_SIZE,
-        game_manager.texture_manager,
-        enemy_type,
-        map_width_px=map_w_px,
-        map_height_px=map_h_px,
-    )
+    enemy_tank = spawn_enemy_at(game_manager, enemy_x_grid, enemy_y_grid)
     # Pin the enemy so only the player moves; we want to test the collision, not AI.
     enemy_tank.speed = 0
     enemy_tank.direction_change_interval = 999
     enemy_tank.shoot_interval = 999
-    game_manager.spawn_manager.enemy_tanks = [enemy_tank]
 
     dt = 1.0 / FPS
     for _ in range(30):
@@ -496,55 +418,27 @@ def test_enemy_bullets_collide(game_manager_fixture, mocker):
     mocker.patch("src.core.enemy_tank.random.uniform", return_value=0.0)
     game_manager = game_manager_fixture
 
-    enemy_type = TankType.BASIC
     enemy1_x_grid, enemy1_y_grid = 2, 16
     enemy2_x_grid, enemy2_y_grid = 8, 16
 
-    _clear_tiles(
+    clear_tiles(
         game_manager.map,
         [(x, 16 + dy) for x in range(2, 10) for dy in range(2)],
     )
 
-    enemy1_start_x = enemy1_x_grid * SUB_TILE_SIZE
-    enemy1_start_y = enemy1_y_grid * SUB_TILE_SIZE
-    enemy2_start_x = enemy2_x_grid * SUB_TILE_SIZE
-    enemy2_start_y = enemy2_y_grid * SUB_TILE_SIZE
-
-    map_w_px = game_manager.map.width * SUB_TILE_SIZE
-    map_h_px = game_manager.map.height * SUB_TILE_SIZE
-    enemy1 = EnemyTank(
-        enemy1_start_x,
-        enemy1_start_y,
-        TILE_SIZE,
-        game_manager.texture_manager,
-        enemy_type,
-        map_width_px=map_w_px,
-        map_height_px=map_h_px,
+    enemy1 = spawn_enemy_at(
+        game_manager, enemy1_x_grid, enemy1_y_grid, direction=Direction.RIGHT
     )
-    enemy1.direction = Direction.RIGHT
-
-    enemy2 = EnemyTank(
-        enemy2_start_x,
-        enemy2_start_y,
-        TILE_SIZE,
-        game_manager.texture_manager,
-        enemy_type,
-        map_width_px=map_w_px,
-        map_height_px=map_h_px,
+    enemy2 = spawn_enemy_at(
+        game_manager,
+        enemy2_x_grid,
+        enemy2_y_grid,
+        direction=Direction.LEFT,
+        replace=False,
     )
-    enemy2.direction = Direction.LEFT
 
-    game_manager.spawn_manager.enemy_tanks = [enemy1, enemy2]
-
-    game_manager._try_shoot(enemy1)
-    game_manager._try_shoot(enemy2)
-
-    enemy1_bullets = [b for b in game_manager.bullets if b.owner is enemy1]
-    enemy2_bullets = [b for b in game_manager.bullets if b.owner is enemy2]
-    assert len(enemy1_bullets) == 1, "Enemy1 bullet failed to spawn."
-    assert len(enemy2_bullets) == 1, "Enemy2 bullet failed to spawn."
-    bullet1 = enemy1_bullets[0]
-    bullet2 = enemy2_bullets[0]
+    bullet1 = fire_bullet_from(game_manager, enemy1)
+    bullet2 = fire_bullet_from(game_manager, enemy2)
     assert bullet1.active, "Enemy1 bullet spawned inactive."
     assert bullet2.active, "Enemy2 bullet spawned inactive."
 

--- a/tests/integration/test_controller.py
+++ b/tests/integration/test_controller.py
@@ -5,13 +5,7 @@ import pytest
 from src.managers.game_manager import GameManager
 from src.managers.player_input import AXIS_MAX
 from src.states.game_state import GameState
-from tests.integration.conftest import first_player
-
-
-def _send_event(gm, event):
-    """Send event to both input_handler and player_manager."""
-    gm.input_handler.handle_event(event)
-    gm.player_manager.handle_event(event)
+from tests.integration.conftest import first_player, send_event
 
 
 def _up_event(source: str) -> pygame.event.Event:
@@ -44,7 +38,7 @@ class TestControllerGameplay:
         gm.state = GameState.RUNNING
         initial_y = first_player(gm).y
 
-        _send_event(gm, _up_event(source))
+        send_event(gm, _up_event(source))
         gm.update()
 
         assert first_player(gm).y < initial_y
@@ -60,7 +54,7 @@ class TestControllerGameplay:
             button=pygame.CONTROLLER_BUTTON_A,
             instance_id=0,
         )
-        _send_event(gm, event)
+        send_event(gm, event)
         gm.update()
 
         assert len(gm.player_manager.get_all_bullets()) > 0

--- a/tests/integration/test_enemy_integration.py
+++ b/tests/integration/test_enemy_integration.py
@@ -5,13 +5,15 @@ from src.utils.constants import (
     Difficulty,
     FPS,
     OwnerType,
-    TILE_SIZE,
     SUB_TILE_SIZE,
-    TankType,
 )
 from src.core.tile import Tile, TileType
-from src.core.enemy_tank import EnemyTank
-from tests.integration.conftest import first_player, flush_pending_spawns
+from tests.integration.conftest import (
+    clear_enemies,
+    first_player,
+    flush_pending_spawns,
+    spawn_enemy_at,
+)
 import random
 
 
@@ -45,8 +47,7 @@ def test_enemy_spawning_rules(game_manager_fixture):
 
     # Rebuild the spawn queue directly: reset() performs an initial spawn which
     # we don't want here.
-    game_manager.spawn_manager.enemy_tanks = []
-    game_manager.spawn_manager.total_enemy_spawns = 0
+    clear_enemies(game_manager)
     game_manager.spawn_manager._spawn_queue = (
         game_manager.spawn_manager._build_spawn_queue(
             game_manager.map.enemy_composition
@@ -137,9 +138,7 @@ def test_enemy_spawn_blocked(game_manager_fixture):
     )
     player_tank.prev_x, player_tank.prev_y = blocked_spawn_point_pixels
 
-    game_manager.spawn_manager.enemy_tanks = []
-    game_manager.spawn_manager._pending_spawns = []
-    game_manager.spawn_manager.total_enemy_spawns = 0
+    clear_enemies(game_manager)
     max_spawns = game_manager.spawn_manager.max_enemy_spawns
 
     # Attempt more times than there are spawn points so the selection cycles.
@@ -194,12 +193,8 @@ def test_enemy_movement_and_direction_change(
     """Test that enemies move and change direction over time."""
     game_manager = game_manager_fixture
 
-    game_manager.spawn_manager.enemy_tanks = []
-    game_manager.spawn_manager.total_enemy_spawns = 0
-    enemy_type = TankType.BASIC
+    clear_enemies(game_manager)
     start_x_grid, start_y_grid = 16, 16
-    start_x = start_x_grid * SUB_TILE_SIZE
-    start_y = start_y_grid * SUB_TILE_SIZE
 
     game_map = game_manager.map
     for dy in range(-4, 6):
@@ -215,17 +210,8 @@ def test_enemy_movement_and_direction_change(
     # Use the unmocked random.choice during __init__, then force the direction
     # change later.
     mock_choice.side_effect = lambda x: original_random_choice(x)
-    map_w_px = game_manager.map.width * SUB_TILE_SIZE
-    map_h_px = game_manager.map.height * SUB_TILE_SIZE
-    enemy_tank = EnemyTank(
-        start_x,
-        start_y,
-        TILE_SIZE,
-        game_manager.texture_manager,
-        enemy_type,
-        map_width_px=map_w_px,
-        map_height_px=map_h_px,
-        difficulty=Difficulty.EASY,
+    enemy_tank = spawn_enemy_at(
+        game_manager, start_x_grid, start_y_grid, difficulty=Difficulty.EASY
     )
     initial_direction = enemy_tank.direction
 
@@ -239,8 +225,6 @@ def test_enemy_movement_and_direction_change(
     # Prevent enemy from shooting: otherwise a bullet can hit the base and trigger
     # GAME_OVER before the direction-change timer fires.
     enemy_tank.shoot = lambda: None
-
-    game_manager.spawn_manager.enemy_tanks.append(enemy_tank)
     game_manager.spawn_manager.total_enemy_spawns = 1
 
     initial_pos = enemy_tank.get_position()
@@ -334,14 +318,11 @@ def test_enemy_movement_blocked_by_tile(
             f"are out of bounds."
         )
 
-    game_manager.spawn_manager.enemy_tanks = []
-    game_manager.spawn_manager.total_enemy_spawns = 0
+    clear_enemies(game_manager)
     # start_pos_offset is in tank-size units (2 sub-tiles), so the tank sits flush
     # against the 2x2 blocking tile.
     start_grid_x = target_x_grid + start_pos_offset[0] * 2
     start_grid_y = target_y_grid + start_pos_offset[1] * 2
-    start_x = start_grid_x * SUB_TILE_SIZE
-    start_y = start_grid_y * SUB_TILE_SIZE
 
     if not (0 <= start_grid_y < game_map.height and 0 <= start_grid_x < game_map.width):
         pytest.skip(
@@ -360,20 +341,10 @@ def test_enemy_movement_blocked_by_tile(
                         Tile(TileType.EMPTY, sx, sy, SUB_TILE_SIZE),
                     )
 
-    map_w_px = game_manager.map.width * SUB_TILE_SIZE
-    map_h_px = game_manager.map.height * SUB_TILE_SIZE
-    enemy_tank = EnemyTank(
-        start_x,
-        start_y,
-        TILE_SIZE,
-        game_manager.texture_manager,
-        tank_type=TankType.BASIC,
-        map_width_px=map_w_px,
-        map_height_px=map_h_px,
+    enemy_tank = spawn_enemy_at(
+        game_manager, start_grid_x, start_grid_y, direction=move_direction
     )
-    enemy_tank.direction = move_direction
     enemy_tank.direction_timer = 0
-    game_manager.spawn_manager.enemy_tanks.append(enemy_tank)
     game_manager.spawn_manager.total_enemy_spawns = 1
 
     initial_pos = enemy_tank.get_position()
@@ -395,28 +366,9 @@ def test_enemy_shooting(game_manager_fixture):
     """Test that enemies shoot periodically and their bullets travel correctly."""
     game_manager = game_manager_fixture
 
-    game_manager.spawn_manager.enemy_tanks = []
-    game_manager.spawn_manager.total_enemy_spawns = 0
-    enemy_type = TankType.BASIC
-    start_x_grid, start_y_grid = 16, 16
-    start_x = start_x_grid * SUB_TILE_SIZE
-    start_y = start_y_grid * SUB_TILE_SIZE
-
-    map_w_px = game_manager.map.width * SUB_TILE_SIZE
-    map_h_px = game_manager.map.height * SUB_TILE_SIZE
-    enemy_tank = EnemyTank(
-        start_x,
-        start_y,
-        TILE_SIZE,
-        game_manager.texture_manager,
-        enemy_type,
-        map_width_px=map_w_px,
-        map_height_px=map_h_px,
-    )
-    initial_enemy_direction = Direction.RIGHT
-    enemy_tank.direction = initial_enemy_direction
+    clear_enemies(game_manager)
+    enemy_tank = spawn_enemy_at(game_manager, 16, 16, direction=Direction.RIGHT)
     enemy_tank.shoot_timer = 0
-    game_manager.spawn_manager.enemy_tanks.append(enemy_tank)
     game_manager.spawn_manager.total_enemy_spawns = 1
 
     # Run longer than shoot_interval so we're guaranteed to see a shot.

--- a/tests/integration/test_gamestate_integration.py
+++ b/tests/integration/test_gamestate_integration.py
@@ -5,12 +5,16 @@ from src.utils.constants import (
     FPS,
     TILE_SIZE,
     SUB_TILE_SIZE,
-    TankType,
 )
 from src.states.game_state import GameState
 from src.core.tile import Tile, TileType
-from tests.integration.conftest import first_player
-from src.core.enemy_tank import EnemyTank
+from tests.integration.conftest import (
+    clear_enemies,
+    fire_bullet_from,
+    first_player,
+    place_player_at,
+    spawn_enemy_at,
+)
 
 
 def test_initial_game_state(game_manager_fixture):
@@ -142,13 +146,9 @@ def test_enemy_bullet_destroys_base_game_over(game_manager_fixture):
     base_x_grid = base_tile.x
     base_y_grid = base_tile.y
 
-    enemy_type = TankType.BASIC
     enemy_x_grid = base_x_grid
     # Place enemy well above the base perimeter bricks so the bullet path is clear.
     enemy_y_grid = base_y_grid - 6
-
-    enemy_start_x = enemy_x_grid * SUB_TILE_SIZE
-    enemy_start_y = enemy_y_grid * SUB_TILE_SIZE
 
     if not (
         0 <= enemy_y_grid < game_manager.map.height
@@ -170,27 +170,13 @@ def test_enemy_bullet_destroys_base_game_over(game_manager_fixture):
                     Tile(TileType.EMPTY, enemy_x_grid + dx, y, SUB_TILE_SIZE),
                 )
 
-    map_w_px = game_manager.map.width * SUB_TILE_SIZE
-    map_h_px = game_manager.map.height * SUB_TILE_SIZE
-    enemy_tank = EnemyTank(
-        enemy_start_x,
-        enemy_start_y,
-        TILE_SIZE,
-        game_manager.texture_manager,
-        enemy_type,
-        map_width_px=map_w_px,
-        map_height_px=map_h_px,
+    enemy_tank = spawn_enemy_at(
+        game_manager, enemy_x_grid, enemy_y_grid, direction=Direction.DOWN
     )
-    enemy_tank.direction = Direction.DOWN
-    game_manager.spawn_manager.enemy_tanks = [enemy_tank]
     # Move player out of the bullet path.
-    first_player(game_manager).set_position(0, 0)
-    first_player(game_manager).rect.topleft = (0, 0)
+    place_player_at(game_manager, 0, 0)
 
-    game_manager._try_shoot(enemy_tank)
-    enemy_bullets = [b for b in game_manager.bullets if b.owner is enemy_tank]
-    assert len(enemy_bullets) == 1, "Enemy bullet failed to spawn."
-    bullet = enemy_bullets[0]
+    bullet = fire_bullet_from(game_manager, enemy_tank)
     assert bullet.active, "Enemy bullet spawned inactive."
 
     assert game_manager.state == GameState.RUNNING, (
@@ -232,11 +218,10 @@ def test_victory_condition(game_manager_fixture):
     and the total spawn count has reached the maximum."""
     game_manager = game_manager_fixture
 
+    clear_enemies(game_manager, reset_total=False)
     game_manager.spawn_manager.total_enemy_spawns = (
         game_manager.spawn_manager.max_enemy_spawns
     )
-    game_manager.spawn_manager.enemy_tanks = []
-    game_manager.spawn_manager._pending_spawns = []
 
     assert game_manager.state == GameState.RUNNING, (
         "Test setup assumes starting in RUNNING state."
@@ -264,9 +249,7 @@ def test_score_accumulates_on_enemy_kill(game_manager_fixture):
     expected_points = ENEMY_POINTS.get(tank_type, 0)
 
     player = first_player(gm)
-    player.x = float(enemy.x)
-    player.y = float(enemy.y + TILE_SIZE + 10)
-    player.rect.topleft = (round(player.x), round(player.y))
+    place_player_at(gm, float(enemy.x), float(enemy.y + TILE_SIZE + 10), player=player)
     player.direction = Direction.UP
 
     bullet = player.shoot()

--- a/tests/integration/test_ice_slide.py
+++ b/tests/integration/test_ice_slide.py
@@ -12,7 +12,7 @@ from src.utils.constants import (
     ICE_SLIDE_DISTANCE,
     SUB_TILE_SIZE,
 )
-from tests.integration.conftest import first_player
+from tests.integration.conftest import first_player, place_player_at, tick
 
 _DIRECTION_TO_KEY = {direction: key for key, direction in KEY_TO_DIRECTION.items()}
 
@@ -24,15 +24,6 @@ def _place_ice_patch(game, grid_x, grid_y, width=4, height=4):
             tile = game.map.get_tile_at(grid_x + dx, grid_y + dy)
             if tile is not None:
                 game.map.set_tile_type(tile, TileType.ICE)
-
-
-def _move_player_to(game, px, py):
-    """Teleport the player tank to a pixel position."""
-    first_player(game).x = float(px)
-    first_player(game).y = float(py)
-    first_player(game).prev_x = float(px)
-    first_player(game).prev_y = float(py)
-    first_player(game).rect.topleft = (round(px), round(py))
 
 
 def _set_input(game, direction):
@@ -51,12 +42,6 @@ def _clear_input(game):
     _set_input(game, None)
 
 
-def _tick(game, n=1):
-    """Run n update frames."""
-    for _ in range(n):
-        game.update()
-
-
 class TestPlayerIceSlide:
     """Integration tests for player ice sliding."""
 
@@ -72,7 +57,7 @@ class TestPlayerIceSlide:
     def ice_game(self, game):
         """Game with player on a large ice patch."""
         _place_ice_patch(game, 4, 4, width=8, height=8)
-        _move_player_to(game, 6 * SUB_TILE_SIZE, 6 * SUB_TILE_SIZE)
+        place_player_at(game, 6 * SUB_TILE_SIZE, 6 * SUB_TILE_SIZE)
         first_player(game).direction = Direction.UP
         return game
 
@@ -81,16 +66,16 @@ class TestPlayerIceSlide:
         game = ice_game
 
         _set_input(game, Direction.UP)
-        _tick(game, 5)
+        tick(game, 5)
         assert first_player(game).direction == Direction.UP
 
         _clear_input(game)
-        _tick(game, 1)
+        tick(game)
         assert first_player(game).is_sliding is True
         assert first_player(game)._slide_direction == Direction.UP
 
         pos_before = first_player(game).y
-        _tick(game, 1)
+        tick(game)
         assert first_player(game).y < pos_before, "Tank should slide UP (decreasing y)"
 
     def test_slide_on_perpendicular_direction_change(self, ice_game):
@@ -98,10 +83,10 @@ class TestPlayerIceSlide:
         game = ice_game
 
         _set_input(game, Direction.UP)
-        _tick(game, 5)
+        tick(game, 5)
 
         _set_input(game, Direction.LEFT)
-        _tick(game, 1)
+        tick(game)
         assert first_player(game).is_sliding is True, (
             "Tank should start sliding on perpendicular direction change"
         )
@@ -110,7 +95,7 @@ class TestPlayerIceSlide:
         )
 
         pos_before_y = first_player(game).y
-        _tick(game, 1)
+        tick(game)
         assert first_player(game).y < pos_before_y, (
             "Tank should continue moving UP during slide"
         )
@@ -121,14 +106,14 @@ class TestPlayerIceSlide:
 
         first_player(game).direction = Direction.RIGHT
         _set_input(game, Direction.RIGHT)
-        _tick(game, 5)
+        tick(game, 5)
 
         _clear_input(game)
-        _tick(game, 1)
+        tick(game)
         pos_before = first_player(game).x
 
         for _ in range(120):
-            _tick(game, 1)
+            tick(game)
             if not first_player(game).is_sliding:
                 break
 
@@ -140,9 +125,9 @@ class TestPlayerIceSlide:
     def test_no_slide_when_not_on_ice(self, game):
         """Player does NOT slide on normal tiles."""
         _set_input(game, Direction.RIGHT)
-        _tick(game, 5)
+        tick(game, 5)
         _clear_input(game)
-        _tick(game, 1)
+        tick(game)
 
         assert first_player(game).is_sliding is False
 
@@ -161,11 +146,11 @@ class TestPlayerIceSlide:
 
         first_player(game).direction = Direction.RIGHT
         _set_input(game, Direction.RIGHT)
-        _tick(game, 3)
+        tick(game, 3)
         _clear_input(game)
 
         for _ in range(60):
-            _tick(game, 1)
+            tick(game)
             if not first_player(game).is_sliding:
                 break
 
@@ -178,14 +163,14 @@ class TestPlayerIceSlide:
         game = ice_game
 
         _set_input(game, Direction.UP)
-        _tick(game, 5)
+        tick(game, 5)
 
         _set_input(game, Direction.DOWN)
-        _tick(game, 1)
+        tick(game)
         assert first_player(game).is_sliding is True, (
             "Tank should slide when pressing opposite direction"
         )
 
         pos_before = first_player(game).y
-        _tick(game, 1)
+        tick(game)
         assert first_player(game).y < pos_before, "Tank should continue sliding UP"

--- a/tests/integration/test_player_integration.py
+++ b/tests/integration/test_player_integration.py
@@ -11,7 +11,7 @@ from src.utils.constants import (
     BULLET_HEIGHT,
 )
 from src.core.tile import Tile, TileType
-from tests.integration.conftest import first_player
+from tests.integration.conftest import first_player, send_event, tick_for
 
 
 @pytest.mark.parametrize(
@@ -49,20 +49,10 @@ def test_player_movement(key, axis, direction_sign, expected_direction):
     player_tank.prev_x, player_tank.prev_y = new_x, new_y
 
     initial_pos = player_tank.get_position()
-    dt = 1.0 / FPS
-    update_duration = 0.2
-    num_updates = int(update_duration / dt)
 
-    key_down_event = pygame.event.Event(pygame.KEYDOWN, key=key)
-    game_manager.input_handler.handle_event(key_down_event)
-    game_manager.player_manager.handle_event(key_down_event)
-
-    for _ in range(num_updates):
-        game_manager.update()
-
-    key_up_event = pygame.event.Event(pygame.KEYUP, key=key)
-    game_manager.input_handler.handle_event(key_up_event)
-    game_manager.player_manager.handle_event(key_up_event)
+    send_event(game_manager, pygame.event.Event(pygame.KEYDOWN, key=key))
+    tick_for(game_manager, 0.2)
+    send_event(game_manager, pygame.event.Event(pygame.KEYUP, key=key))
 
     final_pos = player_tank.get_position()
 
@@ -160,20 +150,9 @@ def test_player_movement_blocked_by_tile(
         round(start_x), round(start_y), player_tank.width, player_tank.height
     )
 
-    dt = 1.0 / FPS
-    update_duration = 0.2
-    num_updates = int(update_duration / dt)
-
-    key_down_event = pygame.event.Event(pygame.KEYDOWN, key=key)
-    game_manager.input_handler.handle_event(key_down_event)
-    game_manager.player_manager.handle_event(key_down_event)
-
-    for _ in range(num_updates):
-        game_manager.update()
-
-    key_up_event = pygame.event.Event(pygame.KEYUP, key=key)
-    game_manager.input_handler.handle_event(key_up_event)
-    game_manager.player_manager.handle_event(key_up_event)
+    send_event(game_manager, pygame.event.Event(pygame.KEYDOWN, key=key))
+    tick_for(game_manager, 0.2)
+    send_event(game_manager, pygame.event.Event(pygame.KEYUP, key=key))
 
     final_player_rect = player_tank.rect
     colliding_tile_rect = pygame.Rect(
@@ -292,12 +271,7 @@ def test_player_bullet_movement(direction_str, axis_index, direction_sign):
 
     initial_pos = bullet.get_position()
 
-    dt = 1.0 / FPS
-    update_duration = 0.1
-    num_updates = int(update_duration / dt)
-
-    for _ in range(num_updates):
-        game_manager.update()
+    tick_for(game_manager, 0.1)
 
     final_pos = bullet.get_position()
 


### PR DESCRIPTION
## Summary

Closes #189.

Move common setup patterns from individual integration test files into `tests/integration/conftest.py`:

- `clear_tiles(game_map, positions)`
- `spawn_enemy_at(game, grid_x, grid_y, tank_type, direction, replace, **enemy_kwargs)` — returns the EnemyTank so callers can tweak speed/shoot/etc.
- `fire_bullet_from(game, tank) -> Bullet`
- `place_player_at(game, x, y, player=None)` — syncs set_position + prev_x/prev_y + rect.topleft
- `clear_enemies(game, reset_total=True)` — resets enemy_tanks, _pending_spawns, optionally total_enemy_spawns
- `tick(game, n=1)` and `tick_for(game, seconds)` — for unconditional tick loops (loops with break conditions stay as-is)
- `send_event(game, event)` — dispatches to input_handler and player_manager

Migrations:
- `test_collision_integration.py` — drop local `_clear_tiles`; migrate EnemyTank construction, bullet firing, and player placement.
- `test_enemy_integration.py` — migrate enemy construction and enemy-state reset (clear_enemies).
- `test_gamestate_integration.py` — migrate enemy construction, player placement, and bullet firing.
- `test_player_integration.py` — migrate event dispatch and unconditional tick loops.
- `test_ice_slide.py` — drop local `_move_player_to` / `_tick` in favor of shared versions.
- `test_controller.py` — drop local `_send_event` in favor of shared `send_event`.

Based on the #188 narration-strip branch (per the issue's ordering note) to avoid merge churn.

Net diff: +211 / -336 in test files. No behavior change.

## Test plan

- [x] `pytest tests/integration/` — 98 passed
- [x] `pytest` (full suite) — 881 passed
- [x] `ruff check` + `ruff format --check` clean