### PR TITLE
polish(installer): Windows Inno Setup fixes (AppId, lzma2, excludes)

### DIFF
--- a/installer/windows/battle-city.iss
+++ b/installer/windows/battle-city.iss
@@ -6,7 +6,7 @@
 #define MyAppExeName "BattleCity.exe"
 
 [Setup]
-AppId={{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
+AppId={{1EE01768-3762-4299-A5D0-BFCAF23FE9C5}
 AppName={#MyAppName}
 AppVersion={#MyAppVersion}
 AppPublisher={#MyAppPublisher}
@@ -16,7 +16,8 @@ AllowNoIcons=yes
 OutputDir=..\..\dist
 OutputBaseFilename=BattleCitySetup-{#MyAppVersion}
 SetupIconFile=..\..\assets\icons\battle-city.ico
-Compression=lzma
+Compression=lzma2/max
+LZMACompressionThreads=auto
 SolidCompression=yes
 WizardStyle=modern
 PrivilegesRequired=lowest
@@ -28,7 +29,7 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: "..\..\dist\BattleCity\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "..\..\dist\BattleCity\*"; DestDir: "{app}"; Excludes: "*.pdb,*.pyc,__pycache__\*"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 [Icons]
 Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; IconFilename: "{app}\_internal\assets\icons\battle-city.ico"


### PR DESCRIPTION
## Summary

Three fixes to `installer/windows/battle-city.iss`:

- **Critical (#202)**: Replace placeholder `A1B2C3D4-...` AppId GUID with a generated unique GUID (`1EE01768-3762-4299-A5D0-BFCAF23FE9C5`). Prevents upgrade/uninstall collisions with unrelated installers built from the same template. Inno Setup's double-brace escape preserved.
- **Polish (#207)**: Switch \`Compression=lzma\` → \`Compression=lzma2/max\` and add \`LZMACompressionThreads=auto\`. Faster builds on multi-core, ratio equal-or-better. \`SolidCompression=yes\` kept.
- **Polish (#208)**: Add \`Excludes: \"*.pdb,*.pyc,__pycache__\\*\"\` to the Source glob. Regenerable bytecode and stray debug symbols don't ship.

Closes #202, closes #207, closes #208.

## Test plan

Can't build Inno Setup on Linux, so verification is deferred to the Windows release build:

- [ ] Build the installer on Windows via the usual release pipeline.
- [ ] Confirm it compiles cleanly (no rejection of \`lzma2/max\`, \`LZMACompressionThreads\`, or the \`Excludes\` param).
- [ ] Install into a fresh VM; confirm the game launches.
- [ ] Verify no \`__pycache__\` / \`.pyc\` files in the installed tree.
- [ ] Upgrade flow: install the previous (old-GUID) build, then this one — new-GUID install should be treated as a separate app (expected, one-time migration cost).