### PR TITLE
polish(installer): Linux Flatpak + desktop entry fixes

### DIFF
--- a/installer/linux/com.battlecity.BattleCity.desktop
+++ b/installer/linux/com.battlecity.BattleCity.desktop
@@ -7,3 +7,4 @@ Icon=com.battlecity.BattleCity
 Terminal=false
 Categories=Game;ArcadeGame;
 Keywords=battle;city;tank;arcade;nes;
+StartupWMClass=BattleCity

--- a/installer/linux/com.battlecity.BattleCity.yml
+++ b/installer/linux/com.battlecity.BattleCity.yml
@@ -1,6 +1,6 @@
 app-id: com.battlecity.BattleCity
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 command: battle-city
 
@@ -8,7 +8,8 @@ finish-args:
   - --socket=x11
   - --socket=wayland
   - --socket=pulseaudio
-  - --device=all
+  - --device=dri
+  - --device=input
   - --filesystem=xdg-data/BattleCity:create
 
 modules:


### PR DESCRIPTION
## Summary

Three fixes to the Linux installer:

- **#203** (`com.battlecity.BattleCity.yml`): Bump \`runtime-version\` from \`'23.08'\` (EOL) to \`'24.08'\`.
- **#204** (`com.battlecity.BattleCity.yml`): Replace \`--device=all\` with \`--device=dri\` (GPU for pygame rendering) + \`--device=input\` (controller support — joystick handling lives in \`src/managers/input_handler.py\`, \`player_input.py\`, \`player_manager.py\`, \`game_manager.py\`, and \`src/core/player_tank.py\`, so \`input\` is **not** optional).
- **#206** (`com.battlecity.BattleCity.desktop`): Add \`StartupWMClass=BattleCity\` so desktop environments can associate the running pygame window with the launcher (taskbar grouping, pinning, icon attribution).

**Not included:** #205 (LD_LIBRARY_PATH wrapper investigation) — that's an investigative task requiring a local \`flatpak-builder\` run and runtime library-resolution verification, which is out of scope for a config-tweak PR.

Closes #203, closes #204, closes #206.

## Test plan

- [ ] Run \`flatpak-builder --force-clean build-dir installer/linux/com.battlecity.BattleCity.yml\` and confirm the build succeeds against the 24.08 runtime.
- [ ] Launch the resulting Flatpak and confirm the game starts (no missing SDL/GL symbols).
- [ ] Confirm keyboard input works (rendering + input devices reachable).
- [ ] Plug in a controller and confirm joystick input still works (validates \`--device=input\` is sufficient and \`--device=all\` wasn't masking a wider need).
- [ ] Run \`xprop WM_CLASS\` on the running window and confirm it matches \`BattleCity\`; adjust the \`StartupWMClass\` value if not.
- [ ] Confirm the launcher entry groups with the running window in the taskbar (GNOME/KDE).