### PR TITLE
build(installer): run PyInstaller inside the Flatpak SDK

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,23 +57,21 @@ jobs:
         uses: astral-sh/setup-uv@v4
 
       - name: Install dependencies
-        run: uv pip install -e ".[dev,build]" --system
+        run: uv pip install -e ".[dev]" --system
 
       - name: Run tests
         run: pytest
-
-      - name: Build with PyInstaller
-        run: pyinstaller battle-city.spec --noconfirm
 
       - name: Install Flatpak tools
         run: |
           sudo apt-get update
           sudo apt-get install -y flatpak flatpak-builder
           flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-          flatpak install --user -y flathub org.freedesktop.Platform//23.08 org.freedesktop.Sdk//23.08
+          flatpak install --user -y flathub org.freedesktop.Platform//24.08 org.freedesktop.Sdk//24.08
 
       - name: Build Flatpak
         run: |
+          mkdir -p dist
           cd installer/linux
           flatpak-builder --user --force-clean --repo=repo build com.battlecity.BattleCity.yml
           flatpak build-bundle repo BattleCity-${GITHUB_REF_NAME}.flatpak com.battlecity.BattleCity

--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,9 @@ settings.json
 .claude/
 .superpowers/
 .vscode/
+
+# Flatpak build artifacts
+installer/linux/.flatpak-builder/
+installer/linux/build/
+installer/linux/repo/
+installer/linux/tools/

--- a/installer/linux/com.battlecity.BattleCity.yml
+++ b/installer/linux/com.battlecity.BattleCity.yml
@@ -13,13 +13,25 @@ finish-args:
   - --filesystem=xdg-data/BattleCity:create
 
 modules:
+  # Pinned Python wheels (pyinstaller + runtime deps).
+  # Regenerate with:
+  #   uv run --python 3.12 --with requirements-parser --with packaging \
+  #     tools/flatpak-pip-generator --runtime org.freedesktop.Sdk//24.08 \
+  #     --yaml --output python-deps pyinstaller pygame loguru pytmx
+  - python-deps.yaml
+
   - name: battle-city
     buildsystem: simple
+    build-options:
+      env:
+        PYTHONPATH: /app/lib/python3.12/site-packages
     build-commands:
-      - install -d /app/bin
+      # Freeze the game with PyInstaller inside the SDK so bundled shared libs
+      # are ABI-matched to the runtime (fixes host glibc vs runtime glibc drift).
+      - pyinstaller battle-city.spec --noconfirm --workpath build --distpath dist
       - install -d /app/lib/battle-city
-      - cp -r BattleCity/* /app/lib/battle-city/
-      # Wrapper script that sets LD_LIBRARY_PATH to prioritize bundled libs
+      - cp -r dist/BattleCity/. /app/lib/battle-city/
+      # Wrapper script: see issue #205 for whether this is still needed.
       - |
         cat > /app/bin/battle-city << 'WRAPPER'
         #!/bin/bash
@@ -28,15 +40,19 @@ modules:
         WRAPPER
       - chmod +x /app/bin/battle-city
       - install -Dm644 com.battlecity.BattleCity.desktop /app/share/applications/com.battlecity.BattleCity.desktop
-      - install -Dm644 icons/battle-city-64.png /app/share/icons/hicolor/64x64/apps/com.battlecity.BattleCity.png
-      - install -Dm644 icons/battle-city-128.png /app/share/icons/hicolor/128x128/apps/com.battlecity.BattleCity.png
-      - install -Dm644 icons/battle-city-256.png /app/share/icons/hicolor/256x256/apps/com.battlecity.BattleCity.png
+      - install -Dm644 assets/icons/battle-city-64.png /app/share/icons/hicolor/64x64/apps/com.battlecity.BattleCity.png
+      - install -Dm644 assets/icons/battle-city-128.png /app/share/icons/hicolor/128x128/apps/com.battlecity.BattleCity.png
+      - install -Dm644 assets/icons/battle-city-256.png /app/share/icons/hicolor/256x256/apps/com.battlecity.BattleCity.png
     sources:
+      - type: file
+        path: ../../main.py
+      - type: file
+        path: ../../battle-city.spec
       - type: dir
-        path: ../../dist/BattleCity
-        dest: BattleCity
+        path: ../../src
+        dest: src
+      - type: dir
+        path: ../../assets
+        dest: assets
       - type: file
         path: com.battlecity.BattleCity.desktop
-      - type: dir
-        path: ../../assets/icons
-        dest: icons

--- a/installer/linux/python-deps.yaml
+++ b/installer/linux/python-deps.yaml
@@ -1,0 +1,61 @@
+# Generated with flatpak-pip-generator --runtime org.freedesktop.Sdk//24.08 --prefer-wheels pygame,pyinstaller --yaml --output python-deps pyinstaller pygame loguru pytmx
+name: python-deps
+buildsystem: simple
+build-commands: []
+modules:
+  - name: python3-pyinstaller
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "pyinstaller" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/a9/ba/000a1996d4308bc65120167c21241a3b205464a2e0b58deda26ae8ac21d1/altgraph-0.17.5-py2.py3-none-any.whl
+        sha256: f3a22400bce1b0c701683820ac4f3b159cd301acab067c51c653e06961600597
+      - type: file
+        url: https://files.pythonhosted.org/packages/53/60/b8db5f1a4b0fb228175f2ea0aa33f949adcc097fbe981cc524f9faf85777/pyinstaller-6.19.0-py3-none-manylinux2014_x86_64.whl
+        sha256: a0fc5f6b3c55aa54353f0c74ffa59b1115433c1850c6f655d62b461a2ed6cbbe
+        only-arches:
+          - x86_64
+      - type: file
+        url: https://files.pythonhosted.org/packages/cd/7e/dfd724b0b533f5aaec0ee5df406fe2319987ed6964480a706f85478b12ea/pyinstaller-6.19.0-py3-none-manylinux2014_aarch64.whl
+        sha256: 8bd68abd812d8a6ba33b9f1810e91fee0f325969733721b78151f0065319ca11
+        only-arches:
+          - aarch64
+      - type: file
+        url: https://files.pythonhosted.org/packages/88/f4/035fb8c06deff827f540a9a4ed9122c54e5376fca3e42eddf0c263730775/pyinstaller_hooks_contrib-2026.4-py3-none-any.whl
+        sha256: 1de1a5e49a878122010b88c7e295502bc69776c157c4a4dc78741a4e6178b00f
+  - name: python3-pygame
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "pygame" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/b9/f2/d31e6ad42d657af07be2ffd779190353f759a07b51232b9e1d724f2cda46/pygame-2.6.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+        sha256: 1206125f14cae22c44565c9d333607f1d9f59487b1f1432945dfc809aeaa3e88
+        only-arches:
+          - x86_64
+      - type: file
+        url: https://files.pythonhosted.org/packages/06/be/3ed337583f010696c3b3435e89a74fb29d0c74d0931e8f33c0a4246307a9/pygame-2.6.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+        sha256: c47a6938de93fa610accd4969e638c2aebcb29b2fca518a84c3a39d91ab47116
+        only-arches:
+          - aarch64
+  - name: python3-loguru
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "loguru" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
+        sha256: 31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c
+  - name: python3-pytmx
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "pytmx" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/35/e0/fd0a2d2b93599dec876158fe7fccb8c3e8096844a5a4110dd5bc67377128/PyTMX-3.32-py3-none-any.whl
+        sha256: 4da4c01133dfcb2746cb4e7f46ea1aef21d56119ab044f8f77b9906dea5fbccb


### PR DESCRIPTION
## Summary

- Moves the Linux PyInstaller step inside `org.freedesktop.Sdk//24.08` so bundled libs are ABI-matched to the runtime by construction. Fixes contributors on newer host distros (e.g. Fedora 43) hitting `GLIBC_ABI_GNU2_TLS not found` when the mixer initialises.
- Pins Python deps as vendored wheels in `installer/linux/python-deps.yaml` (sha256). Regeneration command is documented in the main manifest header.
- Drops the stale `org.freedesktop.Platform//23.08` install step from the release workflow (manifest pins 24.08) and the host-side PyInstaller step (freezing is now hermetic inside the sandbox).

Closes #212. Does not address #205 (the `LD_LIBRARY_PATH` wrapper question) — that's easier to answer cleanly on top of this.

## Test plan

- [x] `pytest` still green on host (881 passed)
- [x] `flatpak-builder --user --force-clean --install` succeeds locally on Fedora 43
- [x] `flatpak run com.battlecity.BattleCity` launches; `SoundManager loaded 12/12 sounds` — previously the failure point — now logs successfully
- [x] Bundled `/app/lib/battle-city/_internal/libstdc++.so.6` no longer exposes `GLIBC_ABI_GNU2_TLS`, confirming it came from the SDK, not the host
- [ ] CI green against the updated manifest (the Linux job no longer runs PyInstaller on the Ubuntu runner; `flatpak-builder` does it inside the SDK)