### PR TITLE
build(installer): replace LD_LIBRARY_PATH wrapper with symlink

### DIFF
--- a/installer/linux/com.battlecity.BattleCity.yml
+++ b/installer/linux/com.battlecity.BattleCity.yml
@@ -30,16 +30,9 @@ modules:
       # Freeze the game with PyInstaller inside the SDK so bundled shared libs
       # are ABI-matched to the runtime (fixes host glibc vs runtime glibc drift).
       - pyinstaller battle-city.spec --noconfirm --workpath build --distpath dist
-      - install -d /app/lib/battle-city
+      - install -d /app/lib/battle-city /app/bin
       - cp -r dist/BattleCity/. /app/lib/battle-city/
-      # Wrapper script: see issue #205 for whether this is still needed.
-      - |
-        cat > /app/bin/battle-city << 'WRAPPER'
-        #!/bin/bash
-        export LD_LIBRARY_PATH="/app/lib/battle-city:${LD_LIBRARY_PATH}"
-        exec /app/lib/battle-city/BattleCity "$@"
-        WRAPPER
-      - chmod +x /app/bin/battle-city
+      - ln -s /app/lib/battle-city/BattleCity /app/bin/battle-city
       - install -Dm644 com.battlecity.BattleCity.desktop /app/share/applications/com.battlecity.BattleCity.desktop
       - install -Dm644 assets/icons/battle-city-64.png /app/share/icons/hicolor/64x64/apps/com.battlecity.BattleCity.png
       - install -Dm644 assets/icons/battle-city-128.png /app/share/icons/hicolor/128x128/apps/com.battlecity.BattleCity.png


### PR DESCRIPTION
## Summary
- Replaces the inline bash wrapper in the Flatpak manifest with a symlink from `/app/bin/battle-city` to `/app/lib/battle-city/BattleCity`.
- PyInstaller's onedir bootloader already sets up the library search path at runtime, so the `LD_LIBRARY_PATH` override was redundant.
- Drops a shell process from the launch path and simplifies the manifest.

Closes #205.

## Test plan
- [x] `flatpak-builder --user --force-clean --install build com.battlecity.BattleCity.yml` succeeds.
- [x] `flatpak run com.battlecity.BattleCity` launches: pygame loads SDL 2.28.4, sound mixer loads all 12 sounds, main loop runs, clean shutdown on quit.
- [ ] CI Flatpak build passes.