### PR TITLE
build(ci): fix build-linux by moving to flatpak-github-actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           name: windows-installer
           path: dist/BattleCitySetup-*.exe
 
-  build-linux:
+  test-linux:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -62,26 +62,29 @@ jobs:
       - name: Run tests
         run: pytest
 
-      - name: Install Flatpak tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y flatpak flatpak-builder
-          flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-          flatpak install --user -y flathub org.freedesktop.Platform//25.08 org.freedesktop.Sdk//25.08
+  build-linux:
+    needs: test-linux
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-25.08
+      options: --privileged
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Build Flatpak
-        run: |
-          mkdir -p dist
-          cd installer/linux
-          flatpak-builder --user --force-clean --repo=repo build com.battlecity.BattleCity.yml
-          flatpak build-bundle repo BattleCity-${GITHUB_REF_NAME}.flatpak com.battlecity.BattleCity
-          mv BattleCity-${GITHUB_REF_NAME}.flatpak ../../dist/
+        uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        with:
+          bundle: BattleCity-${{ github.ref_name }}.flatpak
+          manifest-path: installer/linux/com.battlecity.BattleCity.yml
+          cache-key: flatpak-builder-${{ github.sha }}
+          upload-artifact: false
 
       - name: Upload Flatpak bundle
         uses: actions/upload-artifact@v4
         with:
           name: linux-flatpak
-          path: dist/BattleCity-*.flatpak
+          path: BattleCity-*.flatpak
 
   release:
     needs: [build-windows, build-linux]


### PR DESCRIPTION
Closes #217.

## Summary

- Ubuntu runners ship Flatpak 1.14.6 from apt, which rejects `--device=input` (that finish-arg requires Flatpak 1.15.4+).
- Switch the Linux build to `flatpak/flatpak-github-actions/flatpak-builder@v6` running inside `ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-25.08`, which ships a recent Flatpak and the runtime preinstalled.
- Split the old `build-linux` job into `test-linux` (pytest on the Ubuntu host) and `build-linux` (flatpak-builder action in the container) so Linux test coverage is preserved.
- Keep the existing `linux-flatpak` artifact name via `upload-artifact: false` on the action plus an explicit `actions/upload-artifact@v4` step, so the `release` job needs no changes.

## Test plan

- [ ] Re-tag a release (or push a test tag) and confirm `build-linux` builds the Flatpak bundle without the `Unknown device type input` error.
- [ ] Confirm the release asset still shows up as `BattleCity-<tag>.flatpak` in the GitHub release.
- [ ] Confirm `test-linux` still runs and gates `build-linux`.