### PR TITLE
Drop build-only Python deps from Flatpak bundle

### DIFF
--- a/installer/linux/com.battlecity.BattleCity.yml
+++ b/installer/linux/com.battlecity.BattleCity.yml
@@ -32,6 +32,11 @@ modules:
       - pyinstaller battle-city.spec --noconfirm --workpath build --distpath dist
       - install -d /app/lib/battle-city /app/bin
       - cp -r dist/BattleCity/. /app/lib/battle-city/
+      # Drop the build-time Python deps: the frozen dist vendors its own
+      # ABI-matched pygame and libpython, so site-packages, pygame headers,
+      # and PyInstaller entry points are dead weight at runtime (~10MB in
+      # the bundle).
+      - rm -rf /app/lib/python3.13 /app/include/python3.13 /app/bin/pyinstaller /app/bin/pyi-*
       - ln -s /app/lib/battle-city/BattleCity /app/bin/battle-city
       - install -Dm644 com.battlecity.BattleCity.desktop /app/share/applications/com.battlecity.BattleCity.desktop
       - install -Dm644 assets/icons/battle-city-64.png /app/share/icons/hicolor/64x64/apps/com.battlecity.BattleCity.png


### PR DESCRIPTION
Closes #219.

## Summary

- Remove `/app/lib/python3.13`, `/app/include/python3.13`, and PyInstaller entry-point scripts from the Flatpak after the freeze step. These wheels were vendored in so PyInstaller could freeze the app inside the SDK, but the frozen dist in `/app/lib/battle-city/` ships its own ABI-matched copies, so the originals are dead weight at runtime.

## Result

Locally rebuilt bundle size:

| Version | Bundle size |
|---|---|
| v0.11.0 (pre-hermetic-freeze) | 14.1 MB |
| v1.0.2 (current) | 23.7 MB |
| This branch | 18.2 MB |

The remaining gap vs v0.11.0 comes from ABI-matched shared libs (libcrypto, libpython, libstdc++, libSDL2) that PyInstaller now bundles because it runs inside the SDK — which is the intended trade-off from #212.

## Test plan

- [x] `flatpak-builder` succeeds locally against the 25.08 runtime.
- [x] Built `.flatpak` bundle size is 18.2 MB (down from 23.7 MB).
- [x] Installed bundle launches, pygame/SDL initialize, GameManager and SoundManager come up, main loop enters.
- [ ] CI `build-linux` job produces a similar-sized bundle on tag release.