### PR TITLE
refactor(paths): simplify with pathlib and platformdirs

### DIFF
--- a/installer/linux/com.battlecity.BattleCity.yml
+++ b/installer/linux/com.battlecity.BattleCity.yml
@@ -18,7 +18,7 @@ modules:
   #   uv run --python 3.13 --with requirements-parser --with packaging \
   #     tools/flatpak-pip-generator --runtime org.freedesktop.Sdk//25.08 \
   #     --prefer-wheels pygame,pyinstaller \
-  #     --yaml --output python-deps pyinstaller pygame loguru pytmx
+  #     --yaml --output python-deps pyinstaller pygame loguru pytmx platformdirs
   - python-deps.yaml
 
   - name: battle-city

--- a/installer/linux/python-deps.yaml
+++ b/installer/linux/python-deps.yaml
@@ -1,4 +1,4 @@
-# Generated with flatpak-pip-generator --runtime org.freedesktop.Sdk//25.08 --prefer-wheels pygame,pyinstaller --yaml --output python-deps pyinstaller pygame loguru pytmx
+# Generated with flatpak-pip-generator --runtime org.freedesktop.Sdk//25.08 --prefer-wheels pygame,pyinstaller --yaml --output python-deps pyinstaller pygame loguru pytmx platformdirs
 name: python-deps
 buildsystem: simple
 build-commands: []
@@ -59,3 +59,12 @@ modules:
       - type: file
         url: https://files.pythonhosted.org/packages/35/e0/fd0a2d2b93599dec876158fe7fccb8c3e8096844a5a4110dd5bc67377128/PyTMX-3.32-py3-none-any.whl
         sha256: 4da4c01133dfcb2746cb4e7f46ea1aef21d56119ab044f8f77b9906dea5fbccb
+  - name: python3-platformdirs
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "platformdirs" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl
+        sha256: e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "pygame",
     "loguru",
     "pytmx",
+    "platformdirs",
 ]
 
 [project.optional-dependencies]

--- a/src/utils/paths.py
+++ b/src/utils/paths.py
@@ -1,18 +1,16 @@
 """Path helpers for frozen (PyInstaller) and development builds."""
 
-import os
 import sys
+from pathlib import Path
+
+from platformdirs import user_log_dir
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _is_frozen() -> bool:
     """Return True if running inside a PyInstaller bundle."""
     return hasattr(sys, "_MEIPASS")
-
-
-def _project_root() -> str:
-    """Return the project root directory (for development mode)."""
-    # src/utils/paths.py -> go up 3 levels to reach project root
-    return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 def resource_path(relative_path: str) -> str:
@@ -29,16 +27,16 @@ def resource_path(relative_path: str) -> str:
         Absolute path to the resource.
     """
     if _is_frozen():
-        base = sys._MEIPASS  # type: ignore[attr-defined]
+        base = Path(sys._MEIPASS)  # type: ignore[attr-defined]
     else:
-        base = _project_root()
-    return os.path.join(base, relative_path)
+        base = _PROJECT_ROOT
+    return str(base / relative_path)
 
 
 def get_log_path() -> str:
     """Return the path for the game log file.
 
-    In frozen builds, writes to a platform-appropriate user data directory.
+    In frozen builds, writes to a platform-appropriate user log directory.
     In development, writes to the current directory.
 
     Returns:
@@ -47,13 +45,6 @@ def get_log_path() -> str:
     if not _is_frozen():
         return "game.log"
 
-    if sys.platform == "win32":
-        base = os.environ.get("APPDATA", os.path.expanduser("~"))
-    else:
-        base = os.environ.get(
-            "XDG_DATA_HOME", os.path.join(os.path.expanduser("~"), ".local", "share")
-        )
-
-    log_dir = os.path.join(base, "BattleCity")
-    os.makedirs(log_dir, exist_ok=True)
-    return os.path.join(log_dir, "game.log")
+    log_dir = Path(user_log_dir("BattleCity", appauthor=False))
+    log_dir.mkdir(parents=True, exist_ok=True)
+    return str(log_dir / "game.log")

--- a/tests/unit/utils/test_paths.py
+++ b/tests/unit/utils/test_paths.py
@@ -1,28 +1,22 @@
 import os
 import sys
+from pathlib import Path
 from unittest.mock import patch
 
 
 class TestResourcePath:
     """Tests for resource_path() helper."""
 
-    def test_returns_relative_path_in_dev_mode(self):
+    def test_returns_project_root_path_in_dev_mode(self):
         """In non-frozen mode, resource_path returns path relative to project root."""
         from src.utils.paths import resource_path
 
-        # Ensure sys._MEIPASS is not set (normal dev mode)
         if hasattr(sys, "_MEIPASS"):
             delattr(sys, "_MEIPASS")
 
         result = resource_path("assets/sprites/sprites.png")
-        assert result == os.path.join(
-            os.path.dirname(
-                os.path.dirname(
-                    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-                )
-            ),
-            "assets/sprites/sprites.png",
-        )
+        expected_root = Path(__file__).resolve().parents[3]
+        assert result == str(expected_root / "assets/sprites/sprites.png")
 
     def test_returns_meipass_path_in_frozen_mode(self):
         """In frozen mode, resource_path returns path relative to _MEIPASS."""
@@ -47,50 +41,19 @@ class TestGetLogPath:
         result = get_log_path()
         assert result == "game.log"
 
-    def test_returns_platform_path_in_frozen_mode_linux(self):
-        """In frozen mode on Linux, uses XDG_DATA_HOME."""
-        from src.utils.paths import get_log_path
+    def test_uses_platformdirs_in_frozen_mode(self):
+        """In frozen mode, delegates to platformdirs.user_log_dir."""
+        from src.utils import paths
 
         fake_meipass = "/tmp/fake_meipass"
+        fake_log_dir = "/tmp/fake_log_dir/BattleCity"
         with (
             patch.object(sys, "_MEIPASS", fake_meipass, create=True),
-            patch("sys.platform", "linux"),
-            patch.dict(os.environ, {"XDG_DATA_HOME": "/tmp/xdg_data"}, clear=False),
-            patch("src.utils.paths.os.makedirs"),
+            patch.object(paths, "user_log_dir", return_value=fake_log_dir) as mock_dir,
+            patch("pathlib.Path.mkdir") as mock_mkdir,
         ):
-            result = get_log_path()
-            assert result == os.path.join("/tmp/xdg_data", "BattleCity", "game.log")
+            result = paths.get_log_path()
 
-    def test_returns_platform_path_in_frozen_mode_windows(self):
-        """In frozen mode on Windows, uses APPDATA."""
-        from src.utils.paths import get_log_path
-
-        fake_meipass = "/tmp/fake_meipass"
-        appdata = "C:\\Users\\Test\\AppData\\Roaming"
-        with (
-            patch.object(sys, "_MEIPASS", fake_meipass, create=True),
-            patch("sys.platform", "win32"),
-            patch.dict(os.environ, {"APPDATA": appdata}, clear=False),
-            patch("src.utils.paths.os.makedirs"),
-        ):
-            result = get_log_path()
-            assert result == os.path.join(appdata, "BattleCity", "game.log")
-
-    def test_frozen_linux_defaults_xdg_when_env_missing(self):
-        """Falls back to ~/.local/share when XDG_DATA_HOME is not set."""
-        from src.utils.paths import get_log_path
-
-        fake_meipass = "/tmp/fake_meipass"
-        env = os.environ.copy()
-        env.pop("XDG_DATA_HOME", None)
-        with (
-            patch.object(sys, "_MEIPASS", fake_meipass, create=True),
-            patch("sys.platform", "linux"),
-            patch.dict(os.environ, env, clear=True),
-            patch("src.utils.paths.os.makedirs"),
-        ):
-            result = get_log_path()
-            expected = os.path.join(
-                os.path.expanduser("~"), ".local", "share", "BattleCity", "game.log"
-            )
-            assert result == expected
+        mock_dir.assert_called_once_with("BattleCity", appauthor=False)
+        mock_mkdir.assert_called_once_with(parents=True, exist_ok=True)
+        assert result == os.path.join(fake_log_dir, "game.log")

--- a/uv.lock
+++ b/uv.lock
@@ -34,10 +34,11 @@ wheels = [
 
 [[package]]
 name = "battle-city-clone"
-version = "1.0.1"
+version = "1.0.3"
 source = { virtual = "." }
 dependencies = [
     { name = "loguru" },
+    { name = "platformdirs" },
     { name = "pygame" },
     { name = "pytmx" },
 ]
@@ -61,6 +62,7 @@ requires-dist = [
     { name = "bump-my-version", marker = "extra == 'build'" },
     { name = "loguru" },
     { name = "mypy", marker = "extra == 'dev'" },
+    { name = "platformdirs" },
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "pygame" },
     { name = "pyinstaller", marker = "extra == 'build'" },


### PR DESCRIPTION
## Summary

- Replace triple-nested \`os.path.dirname\` with \`Path(__file__).resolve().parents[2]\`, cached at module import so the project root isn't recomputed on every \`resource_path()\` call.
- Swap the hand-rolled XDG/APPDATA branches in \`get_log_path\` for \`platformdirs.user_log_dir\`. Also fixes a latent macOS bug — logs previously landed under \`~/.local/share/BattleCity\` instead of \`~/Library/Logs/BattleCity\`.
- Regenerate Flatpak \`python-deps.yaml\` to bundle \`platformdirs\` for the frozen build.

Closes #221. Closes #222.

## Test plan

- [x] \`pytest tests/unit/utils/test_paths.py\` — 4 passed
- [x] \`pytest\` full suite — 879 passed
- [x] \`ruff check\` + \`ruff format --check\` — clean
- [ ] CI Flatpak build succeeds with new \`platformdirs\` entry