### PR TITLE
refactor(constants): remove unused aliases and derived constants

### DIFF
--- a/src/core/bullet.py
+++ b/src/core/bullet.py
@@ -5,9 +5,8 @@ from .game_object import GameObject
 from src.utils.constants import (
     Direction,
     OwnerType,
+    BULLET_SIZE,
     BULLET_SPEED,
-    BULLET_WIDTH,
-    BULLET_HEIGHT,
     WHITE,
 )
 
@@ -36,7 +35,7 @@ class Bullet(GameObject):
             sprite: Optional sprite surface
             speed: Speed of the bullet in pixels per second
         """
-        super().__init__(x, y, BULLET_WIDTH, BULLET_HEIGHT, sprite)
+        super().__init__(x, y, BULLET_SIZE, BULLET_SIZE, sprite)
         self.direction: Direction = direction
         self.speed: float = speed
         self.active: bool = True

--- a/src/core/enemy_tank.py
+++ b/src/core/enemy_tank.py
@@ -4,7 +4,7 @@ from loguru import logger
 from .tank import Tank
 from typing import TypedDict
 from src.utils.constants import (
-    CARRIER_BLINK_CYCLE,
+    CARRIER_BLINK_INTERVAL,
     Difficulty,
     Direction,
     DIRECTION_CHANGE_RANDOM_OFFSET,
@@ -139,8 +139,8 @@ class EnemyTank(Tank):
         """Update sprite using type-specific prefix and carrier red variant."""
         if (
             self.is_carrier
-            and self.carrier_blink_timer % CARRIER_BLINK_CYCLE
-            >= CARRIER_BLINK_CYCLE / 2
+            and self.carrier_blink_timer % (CARRIER_BLINK_INTERVAL * 2)
+            >= CARRIER_BLINK_INTERVAL
         ):
             sprite_name = (
                 f"{self._sprite_prefix}_red_{self.direction}_{self.animation_frame}"

--- a/src/core/power_up.py
+++ b/src/core/power_up.py
@@ -5,7 +5,6 @@ import pygame
 from src.core.game_object import GameObject
 from src.managers.texture_manager import TextureManager
 from src.utils.constants import (
-    POWERUP_BLINK_CYCLE,
     POWERUP_BLINK_INTERVAL,
     POWERUP_TIMEOUT,
     TILE_SIZE,
@@ -44,7 +43,7 @@ class PowerUp(GameObject):
         """Draw the power-up with blinking effect."""
         if not self.active:
             return
-        if self.blink_timer % POWERUP_BLINK_CYCLE < POWERUP_BLINK_INTERVAL:
+        if self.blink_timer % (POWERUP_BLINK_INTERVAL * 2) < POWERUP_BLINK_INTERVAL:
             super().draw(surface)
 
     def collect(self) -> PowerUpType:

--- a/src/core/tank.py
+++ b/src/core/tank.py
@@ -10,13 +10,10 @@ from src.utils.constants import (
     TILE_SIZE,
     SUB_TILE_SIZE,
     TANK_SPEED,
-    TANK_WIDTH,
-    TANK_HEIGHT,
     TANK_ANIMATION_DISTANCE,
     TANK_ALIGN_THRESHOLD,
     TANK_BLINK_INTERVAL,
-    BULLET_WIDTH,
-    BULLET_HEIGHT,
+    BULLET_SIZE,
     BULLET_SPEED,
     ICE_SLIDE_DISTANCE,
 )
@@ -62,7 +59,7 @@ class Tank(GameObject):
         x = round(x / tile_size) * tile_size
         y = round(y / tile_size) * tile_size
         logger.debug(f"Creating Tank at ({x}, {y})")
-        super().__init__(x, y, TANK_WIDTH, TANK_HEIGHT, sprite)
+        super().__init__(x, y, TILE_SIZE, TILE_SIZE, sprite)
         self.texture_manager = texture_manager
         self.speed = speed
         self.bullet_speed = bullet_speed
@@ -156,8 +153,8 @@ class Tank(GameObject):
                 f"in direction {self.direction}."
             )
         )
-        bullet_x = self.x + self.width // 2 - BULLET_WIDTH // 2
-        bullet_y = self.y + self.height // 2 - BULLET_HEIGHT // 2
+        bullet_x = self.x + self.width // 2 - BULLET_SIZE // 2
+        bullet_y = self.y + self.height // 2 - BULLET_SIZE // 2
         try:
             bullet_sprite = self.texture_manager.get_sprite(f"bullet_{self.direction}")
         except KeyError:

--- a/src/managers/power_up_manager.py
+++ b/src/managers/power_up_manager.py
@@ -20,7 +20,6 @@ from src.utils.constants import (
     HELMET_INVINCIBILITY_DURATION,
     PowerUpType,
     SHOVEL_DURATION,
-    SHOVEL_FLASH_CYCLE,
     SHOVEL_FLASH_INTERVAL,
     SHOVEL_WARNING_DURATION,
     TILE_SIZE,
@@ -166,7 +165,8 @@ class PowerUpManager:
         if self.shovel_timer <= SHOVEL_WARNING_DURATION:
             self._shovel_flash_timer += dt
             should_show_steel = (
-                self._shovel_flash_timer % SHOVEL_FLASH_CYCLE < SHOVEL_FLASH_INTERVAL
+                self._shovel_flash_timer % (SHOVEL_FLASH_INTERVAL * 2)
+                < SHOVEL_FLASH_INTERVAL
             )
             if should_show_steel != self._shovel_flash_showing_steel:
                 self._shovel_flash_showing_steel = should_show_steel

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -130,11 +130,6 @@ VICTORY_PAUSE_DURATION: float = 1.0
 GAME_OVER_RISE_DURATION: float = 2.0
 GAME_OVER_HOLD_DURATION: float = 1.0
 
-# Pre-computed blink/flash cycles (2x the interval)
-POWERUP_BLINK_CYCLE: float = POWERUP_BLINK_INTERVAL * 2
-CARRIER_BLINK_CYCLE: float = CARRIER_BLINK_INTERVAL * 2
-SHOVEL_FLASH_CYCLE: float = SHOVEL_FLASH_INTERVAL * 2
-
 
 # Window settings
 WINDOW_WIDTH: int = 1024  # Logical width (16*32) * 2
@@ -158,12 +153,9 @@ GRAY: Tuple[int, int, int] = (128, 128, 128)
 WHITE: Tuple[int, int, int] = (255, 255, 255)
 RED: Tuple[int, int, int] = (255, 0, 0)
 GREEN: Tuple[int, int, int] = (0, 255, 0)
-YELLOW: Tuple[int, int, int] = (255, 255, 0)
 
 # Tank settings
 TANK_SPEED: float = 80  # pixels per second (was 12 px/step)
-TANK_WIDTH: int = TILE_SIZE
-TANK_HEIGHT: int = TILE_SIZE
 TANK_ANIMATION_DISTANCE: float = 4  # pixels traveled between animation frame toggles
 TANK_ALIGN_THRESHOLD: float = 4.0  # max px offset for steering assist
 TANK_BLINK_INTERVAL: float = 0.2  # blink interval during invincibility
@@ -177,8 +169,6 @@ ATLAS_BG_COLOR: tuple[int, int, int] = (0, 0, 1)
 # Bullet settings
 BULLET_SPEED: float = 180  # pixels per second (was 3, multiplied by FPS internally)
 BULLET_SIZE: int = 4  # Visual size of bullet sprites after extraction
-BULLET_WIDTH: int = BULLET_SIZE
-BULLET_HEIGHT: int = BULLET_SIZE
 
 # Enemy AI settings
 ENEMY_SPAWN_INTERVAL: float = 5.0

--- a/tests/integration/test_player_integration.py
+++ b/tests/integration/test_player_integration.py
@@ -6,8 +6,7 @@ from src.utils.constants import (
     FPS,
     OwnerType,
     SUB_TILE_SIZE,
-    BULLET_WIDTH,
-    BULLET_HEIGHT,
+    BULLET_SIZE,
 )
 from src.core.tile import Tile, TileType
 from tests.integration.conftest import first_player, send_event, tick_for
@@ -227,8 +226,8 @@ def test_player_shooting(game_manager_fixture):
     assert bullet.owner_type == OwnerType.PLAYER, "Bullet owner type is incorrect."
     assert bullet.owner is player_tank, "Bullet owner should be the player tank."
 
-    expected_x = player_tank.x + player_tank.width // 2 - BULLET_WIDTH // 2
-    expected_y = player_tank.y + player_tank.height // 2 - BULLET_HEIGHT // 2
+    expected_x = player_tank.x + player_tank.width // 2 - BULLET_SIZE // 2
+    expected_y = player_tank.y + player_tank.height // 2 - BULLET_SIZE // 2
     actual_pos = bullet.get_position()
     assert actual_pos == (expected_x, expected_y), (
         f"Bullet spawn position incorrect. Expected ({expected_x}, {expected_y}), "

--- a/tests/unit/core/test_bullet.py
+++ b/tests/unit/core/test_bullet.py
@@ -4,9 +4,8 @@ from unittest.mock import MagicMock, patch
 from src.core.bullet import Bullet
 from src.utils.constants import (
     Direction,
+    BULLET_SIZE,
     BULLET_SPEED,
-    BULLET_WIDTH,
-    BULLET_HEIGHT,
     TILE_SIZE,
 )
 
@@ -32,8 +31,8 @@ class TestBullet:
         assert bullet.active
         assert bullet.owner.owner_type == "test"
         assert bullet.owner_type == "test"
-        assert bullet.width == BULLET_WIDTH
-        assert bullet.height == BULLET_HEIGHT
+        assert bullet.width == BULLET_SIZE
+        assert bullet.height == BULLET_SIZE
 
     @pytest.mark.parametrize(
         "direction,expected_x,expected_y",

--- a/tests/unit/core/test_tank.py
+++ b/tests/unit/core/test_tank.py
@@ -7,8 +7,7 @@ from src.utils.constants import (
     SUB_TILE_SIZE,
     TANK_SPEED,
     TANK_ALIGN_THRESHOLD,
-    BULLET_WIDTH,
-    BULLET_HEIGHT,
+    BULLET_SIZE,
     FPS,
     ICE_SLIDE_DISTANCE,
 )
@@ -97,8 +96,8 @@ class TestTank:
         assert isinstance(bullet, Bullet)
         assert bullet.active
 
-        expected_x = tank.x + tank.width // 2 - BULLET_WIDTH // 2
-        expected_y = tank.y + tank.height // 2 - BULLET_HEIGHT // 2
+        expected_x = tank.x + tank.width // 2 - BULLET_SIZE // 2
+        expected_y = tank.y + tank.height // 2 - BULLET_SIZE // 2
         assert bullet.x == expected_x
         assert bullet.y == expected_y
 


### PR DESCRIPTION
## Summary

Three small cleanups in \`src/utils/constants.py\`:

- **Remove unused \`YELLOW\`** color constant (no callers).
- **Inline \`*_CYCLE\` constants** (\`POWERUP_BLINK_CYCLE\`, \`CARRIER_BLINK_CYCLE\`, \`SHOVEL_FLASH_CYCLE\`). Each is just \`INTERVAL * 2\` used in a single modulo expression. Call sites now write \`timer % (INTERVAL * 2)\` directly, which is no less clear and drops 4 lines of boilerplate from constants.
- **Collapse \`TANK_WIDTH\`/\`TANK_HEIGHT\` and \`BULLET_WIDTH\`/\`BULLET_HEIGHT\` aliases**. They were always equal to \`TILE_SIZE\` / \`BULLET_SIZE\` — two names per dimension invited drift bugs. Call sites (\`tank.py\`, \`bullet.py\`, and tests) use the single canonical constant now.

Closes #225. Closes #226. Closes #227.

## Test plan

- [x] \`pytest\` full suite — 881 passed
- [x] \`ruff check\` + \`ruff format --check\` — clean