### PR TITLE
chore(typing): enable ruff UP rules and modernize annotations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ build = [
 line-length = 88
 
 [tool.ruff.lint]
-select = ["E", "F"]
+select = ["E", "F", "UP"]
 ignore = []
 
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"

--- a/src/core/bullet.py
+++ b/src/core/bullet.py
@@ -1,5 +1,4 @@
 import pygame
-from typing import Optional, Tuple
 from loguru import logger
 from .game_object import GameObject
 from src.utils.constants import (
@@ -20,7 +19,7 @@ class Bullet(GameObject):
         y: float,
         direction: Direction,
         owner,
-        sprite: Optional[pygame.Surface] = None,
+        sprite: pygame.Surface | None = None,
         speed: float = BULLET_SPEED,
         power_bullet: bool = False,
     ) -> None:
@@ -39,7 +38,7 @@ class Bullet(GameObject):
         self.direction: Direction = direction
         self.speed: float = speed
         self.active: bool = True
-        self.color: Tuple[int, int, int] = WHITE
+        self.color: tuple[int, int, int] = WHITE
         self.prev_x: float = x
         self.prev_y: float = y
         self.owner = owner

--- a/src/core/effect.py
+++ b/src/core/effect.py
@@ -1,5 +1,4 @@
 import pygame
-from typing import List
 
 
 class Effect:
@@ -13,7 +12,7 @@ class Effect:
         self,
         x: float,
         y: float,
-        frames: List[pygame.Surface],
+        frames: list[pygame.Surface],
         frame_duration: float,
     ) -> None:
         """Initialize the effect.

--- a/src/core/game_object.py
+++ b/src/core/game_object.py
@@ -2,7 +2,6 @@
 Base GameObject class for all game entities.
 """
 
-from typing import Tuple, Optional
 import pygame
 from loguru import logger
 
@@ -16,7 +15,7 @@ class GameObject:
         y: float,
         width: int,
         height: int,
-        sprite: Optional[pygame.Surface] = None,
+        sprite: pygame.Surface | None = None,
     ) -> None:
         """
         Initialize a game object.
@@ -58,7 +57,7 @@ class GameObject:
         else:
             pygame.draw.rect(surface, (255, 0, 0), self.rect)  # Debug red rectangle
 
-    def get_position(self) -> Tuple[float, float]:
+    def get_position(self) -> tuple[float, float]:
         """Get the current position of the object."""
         return (self.x, self.y)
 

--- a/src/core/map.py
+++ b/src/core/map.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Iterable, List, Optional, Tuple
+from collections.abc import Iterable
 import pygame
 import pytmx
 from pytmx.util_pygame import load_pygame
@@ -20,9 +20,9 @@ from src.utils.constants import (
 class SpawnPoints:
     """Spawn-point layout parsed from a TMX map."""
 
-    player_spawn: Tuple[int, int]
-    player_spawn_2: Optional[Tuple[int, int]] = None
-    enemy_spawns: List[Tuple[int, int]] = field(default_factory=list)
+    player_spawn: tuple[int, int]
+    player_spawn_2: tuple[int, int] | None = None
+    enemy_spawns: list[tuple[int, int]] = field(default_factory=list)
 
 
 def load_spawn_points(
@@ -42,9 +42,9 @@ def load_spawn_points(
         logger.warning("No 'spawn_points' object layer found in TMX")
         return SpawnPoints(player_spawn=(map_width // 2 - 1, map_height - 2))
 
-    player_spawn: Optional[Tuple[int, int]] = None
-    player_spawn_2: Optional[Tuple[int, int]] = None
-    enemy_spawns: List[Tuple[int, int]] = []
+    player_spawn: tuple[int, int] | None = None
+    player_spawn_2: tuple[int, int] | None = None
+    enemy_spawns: list[tuple[int, int]] = []
     tmx_tw = tiled_map.tilewidth
     tmx_th = tiled_map.tileheight
     for obj in spawn_layer:
@@ -93,18 +93,18 @@ class Map:
     def __init__(self, map_file: str, texture_manager: TextureManager) -> None:
         self.tile_size = SUB_TILE_SIZE
         self.texture_manager = texture_manager
-        self.tiles: List[List[Optional[Tile]]] = []
-        self.spawn_points: List[Tuple[int, int]] = []
-        self.player_spawn: Tuple[int, int] = (0, 0)
-        self.player_spawn_2: Optional[tuple[int, int]] = None
-        self._animated_tiles: List[Tile] = []
-        self._drawable_tiles: List[Tile] = []
+        self.tiles: list[list[Tile | None]] = []
+        self.spawn_points: list[tuple[int, int]] = []
+        self.player_spawn: tuple[int, int] = (0, 0)
+        self.player_spawn_2: tuple[int, int] | None = None
+        self._animated_tiles: list[Tile] = []
+        self._drawable_tiles: list[Tile] = []
         self._tile_cache_dirty: bool = True
         self._cached_tiles_by_type: dict = {}
-        self._cached_collidable_rects: List[pygame.Rect] = []
-        self._cached_blocking_tiles: List[Tile] = []
-        self._cached_bullet_blocking_tiles: List[Tile] = []
-        self._cached_base: Optional[Tile] = None
+        self._cached_collidable_rects: list[pygame.Rect] = []
+        self._cached_blocking_tiles: list[Tile] = []
+        self._cached_bullet_blocking_tiles: list[Tile] = []
+        self._cached_base: Tile | None = None
 
         self._load_from_tmx(map_file)
         self._build_derived_tile_lists()
@@ -319,7 +319,7 @@ class Map:
         diff_str = props.get("difficulty")
         if diff_str is not None:
             try:
-                self.difficulty_override: Optional[Difficulty] = Difficulty(
+                self.difficulty_override: Difficulty | None = Difficulty(
                     str(diff_str).strip()
                 )
             except ValueError:
@@ -372,16 +372,16 @@ class Map:
         return self.height * self.tile_size
 
     @property
-    def drawable_tiles(self) -> List[Tile]:
+    def drawable_tiles(self) -> list[Tile]:
         """Tiles that are drawn below tanks and bullets."""
         return self._drawable_tiles
 
     @property
-    def overlay_tiles(self) -> List[Tile]:
+    def overlay_tiles(self) -> list[Tile]:
         """Tiles that are drawn above tanks and bullets (e.g. bushes)."""
         return self._overlay_tiles
 
-    def grid_to_pixels(self, grid_x: int, grid_y: int) -> Tuple[int, int]:
+    def grid_to_pixels(self, grid_x: int, grid_y: int) -> tuple[int, int]:
         """Convert grid coordinates to pixel coordinates."""
         return grid_x * self.tile_size, grid_y * self.tile_size
 
@@ -400,7 +400,7 @@ class Map:
         for tile in self._overlay_tiles:
             tile.draw(surface, self.texture_manager)
 
-    def get_tile_at(self, x: int, y: int) -> Optional[Tile]:
+    def get_tile_at(self, x: int, y: int) -> Tile | None:
         """Get the tile at the specified grid coordinates."""
         if 0 <= y < self.height and 0 <= x < self.width:
             return self.tiles[y][x]
@@ -533,8 +533,8 @@ class Map:
         """Rebuild all cached tile lists from the grid."""
         self._cached_tiles_by_type = {}
         collidable_rects = []
-        blocking_tiles: List[Tile] = []
-        bullet_blocking_tiles: List[Tile] = []
+        blocking_tiles: list[Tile] = []
+        bullet_blocking_tiles: list[Tile] = []
         base = None
 
         for row in self.tiles:
@@ -564,7 +564,7 @@ class Map:
         if self._tile_cache_dirty:
             self._rebuild_tile_caches()
 
-    def get_tiles_by_type(self, types: Iterable[TileType]) -> List[Tile]:
+    def get_tiles_by_type(self, types: Iterable[TileType]) -> list[Tile]:
         """Get a list of tiles matching the specified types."""
         self._ensure_cache()
         result = []
@@ -593,27 +593,27 @@ class Map:
         tile = self.get_tile_at(grid_x, grid_y)
         return tile is not None and tile.is_slidable
 
-    def get_base(self) -> Optional[Tile]:
+    def get_base(self) -> Tile | None:
         """Find and return a player base tile, if it exists."""
         self._ensure_cache()
         return self._cached_base
 
-    def get_collidable_tiles(self) -> List[pygame.Rect]:
+    def get_collidable_tiles(self) -> list[pygame.Rect]:
         """Get a list of rectangles for all collidable tiles."""
         self._ensure_cache()
         return self._cached_collidable_rects
 
-    def get_blocking_tiles(self) -> List[Tile]:
+    def get_blocking_tiles(self) -> list[Tile]:
         """Get all tiles that block tank movement."""
         self._ensure_cache()
         return self._cached_blocking_tiles
 
-    def get_bullet_blocking_tiles(self) -> List[Tile]:
+    def get_bullet_blocking_tiles(self) -> list[Tile]:
         """Get all tiles that block bullets."""
         self._ensure_cache()
         return self._cached_bullet_blocking_tiles
 
-    def get_base_surrounding_tiles(self, include_empty: bool = False) -> List[Tile]:
+    def get_base_surrounding_tiles(self, include_empty: bool = False) -> list[Tile]:
         """Return tiles in the ring around the base.
 
         Finds all BASE tiles to determine the base bounds, then returns

--- a/src/core/tank.py
+++ b/src/core/tank.py
@@ -1,5 +1,4 @@
 import pygame
-from typing import Optional
 from loguru import logger
 from .game_object import GameObject
 from .bullet import Bullet
@@ -28,7 +27,7 @@ class Tank(GameObject):
         y: float,
         texture_manager: TextureManager,
         tile_size: int = TILE_SIZE,
-        sprite: Optional[pygame.Surface] = None,
+        sprite: pygame.Surface | None = None,
         health: int = 1,
         lives: int = 1,
         speed: float = TANK_SPEED,
@@ -141,17 +140,15 @@ class Tank(GameObject):
         logger.debug(f"Tank {self.owner_type} health now {self.health}.")
         return False
 
-    def shoot(self) -> Optional[Bullet]:
+    def shoot(self) -> Bullet | None:
         """Create and return a new bullet.
 
         Returns:
             A new Bullet instance, or None if creation fails.
         """
         logger.debug(
-            (
-                f"Tank {self.owner_type} at ({self.x}, {self.y}) shooting "
-                f"in direction {self.direction}."
-            )
+            f"Tank {self.owner_type} at ({self.x}, {self.y}) shooting "
+            f"in direction {self.direction}."
         )
         bullet_x = self.x + self.width // 2 - BULLET_SIZE // 2
         bullet_y = self.y + self.height // 2 - BULLET_SIZE // 2
@@ -323,7 +320,7 @@ class Tank(GameObject):
         self._moving_this_frame = True
         return True  # Movement was attempted
 
-    def revert_move(self, obstacle_rect: Optional[pygame.Rect] = None) -> None:
+    def revert_move(self, obstacle_rect: pygame.Rect | None = None) -> None:
         """
         Reverts the tank to its previous position or snaps it to an obstacle.
         If obstacle_rect is provided, snaps to it based on self.direction.

--- a/src/core/tile.py
+++ b/src/core/tile.py
@@ -1,5 +1,5 @@
-from enum import Enum, auto
-from typing import List, NamedTuple, Optional, Tuple
+from enum import Enum, StrEnum, auto
+from typing import NamedTuple
 import pygame
 from loguru import logger
 from src.managers.texture_manager import TextureManager
@@ -19,7 +19,7 @@ class TileType(Enum):
     BASE_DESTROYED = auto()
 
 
-class BrickVariant(str, Enum):
+class BrickVariant(StrEnum):
     """Brick tile variants matching Tiled BrickVariant property type."""
 
     FULL = "full"
@@ -27,9 +27,6 @@ class BrickVariant(str, Enum):
     BOTTOM = "bottom"
     LEFT = "left"
     TOP = "top"
-
-    def __str__(self) -> str:
-        return self.value
 
 
 class TileDefaults(NamedTuple):
@@ -62,7 +59,7 @@ class Tile:
         x: int,
         y: int,
         size: int = SUB_TILE_SIZE,
-        tmx_sprite: Optional[pygame.Surface] = None,
+        tmx_sprite: pygame.Surface | None = None,
         brick_variant: "BrickVariant" = BrickVariant.FULL,
         blocks_tanks: bool = False,
         blocks_bullets: bool = False,
@@ -83,18 +80,18 @@ class Tile:
         self.is_slidable = is_slidable
 
         # TMX sprite: the actual tile image from the map editor
-        self.tmx_sprite: Optional[pygame.Surface] = tmx_sprite
+        self.tmx_sprite: pygame.Surface | None = tmx_sprite
 
         self.brick_variant: BrickVariant = brick_variant
 
         # Animation attributes
         self.is_animated: bool = False
-        self.animation_sprites: List[pygame.Surface] = []
-        self._frame_durations: List[float] = []
+        self.animation_sprites: list[pygame.Surface] = []
+        self._frame_durations: list[float] = []
         self.current_frame_index: int = 0
         self.animation_timer: float = 0.0
 
-    def set_animation_frames(self, frames: List[Tuple[pygame.Surface, float]]) -> None:
+    def set_animation_frames(self, frames: list[tuple[pygame.Surface, float]]) -> None:
         """Set animation frames with per-frame durations.
 
         Args:

--- a/src/managers/collision_manager.py
+++ b/src/managers/collision_manager.py
@@ -1,5 +1,6 @@
 import pygame
-from typing import List, Tuple, Optional, Protocol, runtime_checkable, Sequence
+from typing import Protocol, runtime_checkable
+from collections.abc import Sequence
 
 
 # Define a protocol for objects that have a rect attribute
@@ -14,7 +15,7 @@ class CollisionManager:
     def __init__(self) -> None:
         """Initializes the CollisionManager."""
         # Stores pairs of objects that have collided
-        self._collision_events: List[Tuple[Collidable, Collidable]] = []
+        self._collision_events: list[tuple[Collidable, Collidable]] = []
         self._seen_pairs: set[tuple[int, int]] = set()
 
     def check_collisions(
@@ -25,7 +26,7 @@ class CollisionManager:
         enemy_bullets: Sequence[Collidable],
         tank_blocking_tiles: Sequence[Collidable],
         bullet_blocking_tiles: Sequence[Collidable],
-        player_base: Optional[Collidable],
+        player_base: Collidable | None,
         power_ups: Sequence[Collidable] = (),
     ) -> None:
         """
@@ -45,7 +46,7 @@ class CollisionManager:
         self._seen_pairs.clear()
 
         # Combine tanks
-        all_tanks: List[Collidable] = list(player_tanks)
+        all_tanks: list[Collidable] = list(player_tanks)
         all_tanks.extend(enemy_tanks)
 
         # Bullet collisions
@@ -135,6 +136,6 @@ class CollisionManager:
         self._seen_pairs.add(pair_key)
         self._collision_events.append((obj_a, obj_b))
 
-    def get_collision_events(self) -> List[Tuple[Collidable, Collidable]]:
+    def get_collision_events(self) -> list[tuple[Collidable, Collidable]]:
         """Returns the list of detected collision events for this frame."""
         return self._collision_events

--- a/src/managers/collision_response_handler.py
+++ b/src/managers/collision_response_handler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Type
+from typing import TYPE_CHECKING, Any
+from collections.abc import Callable
 
 if TYPE_CHECKING:
     from src.managers.power_up_manager import PowerUpManager
@@ -33,9 +34,9 @@ class CollisionResponseHandler:
         set_game_state: Callable[[GameState], None],
         effect_manager: EffectManager,
         add_score: Callable[..., None] = lambda *args, **kwargs: None,
-        power_up_manager: Optional[PowerUpManager] = None,
-        sound_manager: Optional[SoundManager] = None,
-        on_player_death: Optional[Callable[[PlayerTank], bool]] = None,
+        power_up_manager: PowerUpManager | None = None,
+        sound_manager: SoundManager | None = None,
+        on_player_death: Callable[[PlayerTank], bool] | None = None,
     ) -> None:
         self._map = game_map
         self._set_game_state = set_game_state
@@ -44,10 +45,10 @@ class CollisionResponseHandler:
         self._power_up_manager = power_up_manager
         self._sound_manager = sound_manager
         self._on_player_death = on_player_death
-        self._collected_power_up_type: Optional[PowerUpType] = None
-        self._collected_power_up_player: Optional[PlayerTank] = None
+        self._collected_power_up_type: PowerUpType | None = None
+        self._collected_power_up_player: PlayerTank | None = None
 
-        self._handlers: Dict[Tuple[Type, Type], Callable[[Any, Any, List], bool]] = {
+        self._handlers: dict[tuple[type, type], Callable[[Any, Any, list], bool]] = {
             (Bullet, EnemyTank): self._handle_bullet_vs_enemy,
             (Bullet, PlayerTank): self._handle_bullet_vs_player,
             (Bullet, Tile): self._handle_bullet_vs_tile,
@@ -64,14 +65,14 @@ class CollisionResponseHandler:
         if self._sound_manager is not None:
             self._sound_manager.play(name)
 
-    def process_collisions(self, events: List[Tuple[Any, Any]]) -> List[EnemyTank]:
+    def process_collisions(self, events: list[tuple[Any, Any]]) -> list[EnemyTank]:
         """Process collision events and return list of enemies to remove."""
         if not events:
             return []
 
         processed_bullets: set = set()
         reverted_tanks: set = set()
-        enemies_to_remove: List[EnemyTank] = []
+        enemies_to_remove: list[EnemyTank] = []
 
         for obj_a, obj_b in events:
             handler, a, b = self._lookup(obj_a, obj_b)
@@ -121,7 +122,7 @@ class CollisionResponseHandler:
 
         return enemies_to_remove
 
-    def _lookup(self, obj_a: Any, obj_b: Any) -> Tuple[Any, Any, Any]:
+    def _lookup(self, obj_a: Any, obj_b: Any) -> tuple[Any, Any, Any]:
         """Look up handler for type pair, trying both orderings.
 
         All participating types are concrete leaves (PlayerTank, EnemyTank,
@@ -145,7 +146,7 @@ class CollisionResponseHandler:
         self,
         bullet: Bullet,
         enemy: EnemyTank,
-        enemies_to_remove: List[EnemyTank],
+        enemies_to_remove: list[EnemyTank],
     ) -> bool:
         if not bullet.active:
             return False
@@ -173,7 +174,7 @@ class CollisionResponseHandler:
         self,
         bullet: Bullet,
         player: PlayerTank,
-        enemies_to_remove: List[EnemyTank],
+        enemies_to_remove: list[EnemyTank],
     ) -> bool:
         if not bullet.active:
             return False
@@ -215,7 +216,7 @@ class CollisionResponseHandler:
         self,
         bullet: Bullet,
         tile: Tile,
-        enemies_to_remove: List[EnemyTank],
+        enemies_to_remove: list[EnemyTank],
     ) -> bool:
         if not bullet.active:
             return False
@@ -250,7 +251,7 @@ class CollisionResponseHandler:
         self,
         bullet_a: Bullet,
         bullet_b: Bullet,
-        enemies_to_remove: List[EnemyTank],
+        enemies_to_remove: list[EnemyTank],
     ) -> bool:
         if not bullet_a.active or not bullet_b.active:
             return False
@@ -264,7 +265,7 @@ class CollisionResponseHandler:
         self,
         player: PlayerTank,
         power_up: PowerUp,
-        enemies_to_remove: List[EnemyTank],
+        enemies_to_remove: list[EnemyTank],
     ) -> bool:
         if self._power_up_manager is None:
             return False
@@ -279,7 +280,7 @@ class CollisionResponseHandler:
 
     def consume_collected_power_up(
         self,
-    ) -> tuple[Optional[PowerUpType], Optional[PlayerTank]]:
+    ) -> tuple[PowerUpType | None, PlayerTank | None]:
         """Return and clear the collected power-up type and player (one-shot read).
 
         Returns:
@@ -306,7 +307,7 @@ class CollisionResponseHandler:
         self,
         tank_a: Tank,
         tank_b: Tank,
-        enemies_to_remove: List[EnemyTank],
+        enemies_to_remove: list[EnemyTank],
     ) -> bool:
         a_caused = self._caused_collision(tank_a, tank_b)
         b_caused = self._caused_collision(tank_b, tank_a)
@@ -329,7 +330,7 @@ class CollisionResponseHandler:
         self,
         tank: Tank,
         tile: Tile,
-        enemies_to_remove: List[EnemyTank],
+        enemies_to_remove: list[EnemyTank],
     ) -> bool:
         if tile.blocks_tanks:
             tank.revert_move(tile.rect)

--- a/src/managers/effect_manager.py
+++ b/src/managers/effect_manager.py
@@ -1,5 +1,4 @@
 import pygame
-from typing import Dict, List, Tuple
 from loguru import logger
 from src.core.effect import Effect
 from src.managers.texture_manager import TextureManager
@@ -22,8 +21,8 @@ class EffectManager:
         Args:
             texture_manager: TextureManager for loading sprites.
         """
-        self.effects: List[Effect] = []
-        self._effect_data: Dict[EffectType, Tuple[List[pygame.Surface], float]] = {}
+        self.effects: list[Effect] = []
+        self._effect_data: dict[EffectType, tuple[list[pygame.Surface], float]] = {}
         self._build_frame_cache(texture_manager)
 
     @staticmethod

--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -1,6 +1,6 @@
 import os
 import pygame
-from typing import Callable, List, Optional
+from collections.abc import Callable
 from loguru import logger
 from src.core.map import Map
 from src.core.player_tank import PlayerTank
@@ -244,7 +244,7 @@ class GameManager:
             powerup_carrier_indices=self.map.powerup_carrier_indices,
         )
 
-        self.bullets: List[Bullet] = []
+        self.bullets: list[Bullet] = []
 
         # Restore player progress
         self.player_manager.restore_state()
@@ -284,7 +284,7 @@ class GameManager:
                 logger.info("Returning to title screen.")
                 self._return_to_title()
 
-    def _active_menu(self) -> Optional[MenuController]:
+    def _active_menu(self) -> MenuController | None:
         if self.state == GameState.TITLE_SCREEN:
             return self._title_menu
         if self.state == GameState.PAUSED:
@@ -418,9 +418,9 @@ class GameManager:
 
         # --- Prepare data for Collision Manager ---
         # Built AFTER updates so newly fired bullets are included
-        tank_blocking_tiles: List[Tile] = self.map.get_blocking_tiles()
-        bullet_blocking_tiles: List[Tile] = self.map.get_bullet_blocking_tiles()
-        player_base: Optional[Tile] = self.map.get_base()
+        tank_blocking_tiles: list[Tile] = self.map.get_blocking_tiles()
+        bullet_blocking_tiles: list[Tile] = self.map.get_bullet_blocking_tiles()
+        player_base: Tile | None = self.map.get_base()
 
         player_bullets = self.player_manager.get_all_bullets()
 
@@ -520,7 +520,7 @@ class GameManager:
         self.state = state
 
     def _apply_power_up(
-        self, power_up_type: PowerUpType, player: Optional[PlayerTank] = None
+        self, power_up_type: PowerUpType, player: PlayerTank | None = None
     ) -> None:
         """Resolve the recipient and forward to PowerUpManager.apply."""
         if self.state != GameState.RUNNING:

--- a/src/managers/input_handler.py
+++ b/src/managers/input_handler.py
@@ -1,7 +1,5 @@
 """Menu and system input, backed by the SDL GameController API."""
 
-from typing import Optional
-
 import pygame
 from loguru import logger
 
@@ -38,10 +36,10 @@ class InputHandler:
     """Menu and system input. Gameplay input lives in PlayerInput/PlayerManager."""
 
     def __init__(self) -> None:
-        self._controllers: dict[int, "sdl_controller.Controller"] = {}
+        self._controllers: dict[int, sdl_controller.Controller] = {}
         self._menu_actions: list[MenuAction] = []
-        self._axis_menu_h: Optional[MenuAction] = None
-        self._axis_menu_v: Optional[MenuAction] = None
+        self._axis_menu_h: MenuAction | None = None
+        self._axis_menu_v: MenuAction | None = None
         self._init_controllers()
 
     def _init_controllers(self) -> None:
@@ -137,7 +135,7 @@ class InputHandler:
         pos_action: MenuAction,
     ) -> None:
         state = classify_axis(raw_value)
-        new_state: Optional[MenuAction]
+        new_state: MenuAction | None
         if state is AxisState.NEGATIVE:
             new_state = neg_action
         elif state is AxisState.POSITIVE:

--- a/src/managers/menu_controller.py
+++ b/src/managers/menu_controller.py
@@ -1,7 +1,7 @@
 """Declarative menu navigation: items + callbacks, no per-screen handler boilerplate."""
 
 from dataclasses import dataclass
-from typing import Callable, List, Optional
+from collections.abc import Callable
 
 from src.utils.constants import MenuAction
 
@@ -9,9 +9,9 @@ from src.utils.constants import MenuAction
 @dataclass(frozen=True)
 class MenuItem:
     label: str
-    on_confirm: Optional[Callable[[], None]] = None
-    on_left: Optional[Callable[[], None]] = None
-    on_right: Optional[Callable[[], None]] = None
+    on_confirm: Callable[[], None] | None = None
+    on_left: Callable[[], None] | None = None
+    on_right: Callable[[], None] | None = None
 
 
 class MenuController:
@@ -19,9 +19,9 @@ class MenuController:
 
     def __init__(
         self,
-        items: List[MenuItem],
-        on_select: Optional[Callable[[], None]] = None,
-        on_back: Optional[Callable[[], None]] = None,
+        items: list[MenuItem],
+        on_select: Callable[[], None] | None = None,
+        on_back: Callable[[], None] | None = None,
     ) -> None:
         if not items:
             raise ValueError("MenuController requires at least one MenuItem")
@@ -31,7 +31,7 @@ class MenuController:
         self.selection: int = 0
 
     @property
-    def labels(self) -> List[str]:
+    def labels(self) -> list[str]:
         """Return the ordered labels of this menu's items."""
         return [item.label for item in self._items]
 

--- a/src/managers/player_manager.py
+++ b/src/managers/player_manager.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 import pygame
 from loguru import logger
@@ -34,7 +34,7 @@ class PlayerManager:
     """
 
     def __init__(
-        self, texture_manager: "TextureManager", sound_manager: "SoundManager"
+        self, texture_manager: TextureManager, sound_manager: SoundManager
     ) -> None:
         """Initialize PlayerManager.
 
@@ -52,7 +52,7 @@ class PlayerManager:
 
     def create_players(
         self,
-        game_map: "Map",
+        game_map: Map,
         controller_instance_ids: list[int],
         two_player_mode: bool = False,
     ) -> None:
@@ -122,7 +122,7 @@ class PlayerManager:
         for pi in self._player_inputs:
             pi.clear_pending_shoot()
 
-    def update(self, dt: float, game_map: "Map") -> None:
+    def update(self, dt: float, game_map: Map) -> None:
         """Process input, move players, and handle ice sliding.
 
         For each live player:
@@ -177,7 +177,7 @@ class PlayerManager:
                     1 for b in self._bullets if b.owner is player and b.active
                 )
                 if active_count < player.max_bullets:
-                    bullet: Optional[Bullet] = player.shoot()
+                    bullet: Bullet | None = player.shoot()
                     if bullet is not None:
                         self._bullets.append(bullet)
                         self._sound_manager.play("shoot")

--- a/src/managers/power_up_manager.py
+++ b/src/managers/power_up_manager.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import random
-from typing import TYPE_CHECKING, List, Optional, Tuple
+from typing import TYPE_CHECKING
 
 import pygame
 from loguru import logger
@@ -40,18 +40,18 @@ class PowerUpManager:
     ) -> None:
         self._texture_manager = texture_manager
         self._game_map = game_map
-        self.active_power_ups: List[PowerUp] = []
+        self.active_power_ups: list[PowerUp] = []
         self.shovel_timer: float = 0.0
-        self._shovel_original_tiles: List[Tuple[Tile, TileType]] = []
+        self._shovel_original_tiles: list[tuple[Tile, TileType]] = []
         self._shovel_flash_timer: float = 0.0
         self._shovel_flash_showing_steel: bool = True
 
     def spawn_power_up(
         self,
-        player_tank: Optional[PlayerTank] = None,
-        enemy_tanks: Optional[List[EnemyTank]] = None,
-        power_up_type: Optional[PowerUpType] = None,
-        position: Optional[tuple[int, int]] = None,
+        player_tank: PlayerTank | None = None,
+        enemy_tanks: list[EnemyTank] | None = None,
+        power_up_type: PowerUpType | None = None,
+        position: tuple[int, int] | None = None,
     ) -> None:
         """Spawn a power-up, appending it to the active list.
 
@@ -87,8 +87,8 @@ class PowerUpManager:
         self,
         power_up_type: PowerUpType,
         player: PlayerTank,
-        spawn_manager: "SpawnManager",
-        effect_manager: "EffectManager",
+        spawn_manager: SpawnManager,
+        effect_manager: EffectManager,
     ) -> None:
         """Dispatch a power-up effect.
 
@@ -118,7 +118,7 @@ class PowerUpManager:
 
     @staticmethod
     def _detonate_bomb(
-        spawn_manager: "SpawnManager", effect_manager: "EffectManager"
+        spawn_manager: SpawnManager, effect_manager: EffectManager
     ) -> None:
         for enemy in list(spawn_manager.enemy_tanks):
             effect_manager.spawn(
@@ -176,11 +176,11 @@ class PowerUpManager:
                         target = TileType.STEEL if should_show_steel else orig_type
                         self._game_map.set_tile_type(tile, target)
 
-    def get_power_ups(self) -> List[PowerUp]:
+    def get_power_ups(self) -> list[PowerUp]:
         """Return the list of active power-ups for collision checking and rendering."""
         return self.active_power_ups
 
-    def collect_power_up(self, power_up: PowerUp) -> Optional[PowerUpType]:
+    def collect_power_up(self, power_up: PowerUp) -> PowerUpType | None:
         """Collect a specific power-up. Returns its type, or None if not found."""
         if power_up not in self.active_power_ups:
             return None
@@ -190,9 +190,9 @@ class PowerUpManager:
 
     def _find_spawn_position(
         self,
-        player_tank: Optional[PlayerTank],
-        enemy_tanks: List[EnemyTank],
-    ) -> Optional[tuple[int, int]]:
+        player_tank: PlayerTank | None,
+        enemy_tanks: list[EnemyTank],
+    ) -> tuple[int, int] | None:
         """Find a random walkable tile position not occupied by any tank."""
         walkable = []
         grid = self._game_map.tiles

--- a/src/managers/renderer.py
+++ b/src/managers/renderer.py
@@ -1,5 +1,5 @@
 import pygame
-from typing import Dict, List, Optional, Sequence, Tuple
+from collections.abc import Sequence
 from src.states.game_state import GameState
 from src.utils.constants import (
     WHITE,
@@ -59,7 +59,7 @@ class Renderer:
         self.map_surface: pygame.Surface = pygame.Surface((map_width_px, map_height_px))
 
         # Cached text surface for game over animation (set on first use)
-        self._game_over_text: Optional[pygame.Surface] = None
+        self._game_over_text: pygame.Surface | None = None
 
         # Reusable overlay surfaces for pause/game-over screens
         self._pause_overlay: pygame.Surface = pygame.Surface(
@@ -74,14 +74,14 @@ class Renderer:
     def render(
         self,
         game_map,
-        player_tanks: List,
-        enemy_tanks: List,
-        bullets: List,
+        player_tanks: list,
+        enemy_tanks: list,
+        bullets: list,
         effect_manager,
         state: GameState,
-        scores: Optional[Dict[int, int]] = None,
+        scores: dict[int, int] | None = None,
         power_ups: Sequence = (),
-        game_over_rise_progress: Optional[float] = None,
+        game_over_rise_progress: float | None = None,
     ) -> None:
         """Render the complete game frame.
 
@@ -138,7 +138,7 @@ class Renderer:
         self,
         text: str,
         font: pygame.font.Font,
-        color: Tuple[int, int, int],
+        color: tuple[int, int, int],
         y: int,
     ) -> None:
         """Render text centered horizontally at the given y position."""
@@ -147,7 +147,7 @@ class Renderer:
         self.game_surface.blit(surface, rect)
 
     def _draw_hud(
-        self, player_tanks: List, scores: Optional[Dict[int, int]] = None
+        self, player_tanks: list, scores: dict[int, int] | None = None
     ) -> None:
         """Draw the heads-up display.
 
@@ -182,8 +182,8 @@ class Renderer:
     def _draw_hud_slot(
         self,
         label: str,
-        score_text: Optional[str],
-        color: Tuple[int, int, int],
+        score_text: str | None,
+        color: tuple[int, int, int],
         align: str,
     ) -> None:
         """Render a HUD label and optional score line at the given edge."""
@@ -220,7 +220,7 @@ class Renderer:
         """Draw the victory screen."""
         self._draw_overlay_screen("VICTORY!", GREEN, "Next Stage...")
 
-    def render_curtain(self, progress: float, stage: Optional[int]) -> None:
+    def render_curtain(self, progress: float, stage: int | None) -> None:
         """Render the stage curtain animation.
 
         Args:
@@ -252,7 +252,7 @@ class Renderer:
     def _draw_overlay_screen(
         self,
         title: str,
-        title_color: Tuple[int, int, int],
+        title_color: tuple[int, int, int],
         subtitle: str,
     ) -> None:
         """Draw a semi-transparent overlay with centered title and subtitle."""
@@ -262,12 +262,12 @@ class Renderer:
 
     def _draw_menu(
         self,
-        options: List[str],
+        options: list[str],
         selection: int,
         start_y: int,
         spacing: int = 30,
-        colors: Optional[List[Tuple[int, int, int]]] = None,
-    ) -> List[pygame.Rect]:
+        colors: list[tuple[int, int, int]] | None = None,
+    ) -> list[pygame.Rect]:
         """Draw a vertical list of options with a cursor. Returns option rects."""
         rects = []
         for i, label in enumerate(options):

--- a/src/managers/spawn_manager.py
+++ b/src/managers/spawn_manager.py
@@ -1,6 +1,5 @@
 import random
 from dataclasses import dataclass
-from typing import List, Optional
 
 import pygame
 from loguru import logger
@@ -42,10 +41,10 @@ class SpawnManager:
         game_map: Map,
         enemy_composition: dict[TankType, int],
         spawn_interval: float,
-        player_tanks: List[PlayerTank],
-        effect_manager: Optional[EffectManager] = None,
+        player_tanks: list[PlayerTank],
+        effect_manager: EffectManager | None = None,
         difficulty: Difficulty = Difficulty.NORMAL,
-        powerup_carrier_indices: Optional[tuple[int, ...]] = None,
+        powerup_carrier_indices: tuple[int, ...] | None = None,
     ) -> None:
         """Initialize the SpawnManager.
 
@@ -64,12 +63,12 @@ class SpawnManager:
         self._difficulty = difficulty
         self.texture_manager = texture_manager
         self.spawn_points = game_map.spawn_points
-        self._spawn_queue: List[TankType] = self._build_spawn_queue(enemy_composition)
+        self._spawn_queue: list[TankType] = self._build_spawn_queue(enemy_composition)
         self.max_enemy_spawns: int = len(self._spawn_queue)
         self.spawn_interval = spawn_interval
         self.map_width_px = game_map.width_px
         self.map_height_px = game_map.height_px
-        self.enemy_tanks: List[EnemyTank] = []
+        self.enemy_tanks: list[EnemyTank] = []
         self.total_enemy_spawns: int = 0
         self.spawn_timer: float = 0.0
         self._freeze_timer: float = 0.0
@@ -79,7 +78,7 @@ class SpawnManager:
             if powerup_carrier_indices is not None
             else POWERUP_CARRIER_INDICES
         )
-        self._pending_spawns: List[_PendingSpawn] = []
+        self._pending_spawns: list[_PendingSpawn] = []
 
         # Set class-level base position for AI targeting
         base_tile = game_map.get_base()
@@ -94,7 +93,7 @@ class SpawnManager:
 
     def _build_spawn_queue(
         self, enemy_composition: dict[TankType, int]
-    ) -> List[TankType]:
+    ) -> list[TankType]:
         """Build a shuffled list of enemy types from the composition dict.
 
         Args:
@@ -103,7 +102,7 @@ class SpawnManager:
         Returns:
             Shuffled list of TankType enum members.
         """
-        queue: List[TankType] = [
+        queue: list[TankType] = [
             tank_type
             for tank_type, count in enemy_composition.items()
             for _ in range(count)
@@ -114,7 +113,7 @@ class SpawnManager:
     def _is_spawn_blocked(
         self,
         rect: pygame.Rect,
-        player_tanks: List[PlayerTank],
+        player_tanks: list[PlayerTank],
         game_map: Map,
     ) -> bool:
         """Check if a spawn rect overlaps any obstacle."""
@@ -132,7 +131,7 @@ class SpawnManager:
                 return True
         return False
 
-    def spawn_enemy(self, player_tanks: List[PlayerTank], game_map: Map) -> bool:
+    def spawn_enemy(self, player_tanks: list[PlayerTank], game_map: Map) -> bool:
         """Spawn a new enemy tank at a random spawn point if under the spawn limit.
 
         If an EffectManager is available, plays a spawn animation first and
@@ -217,7 +216,7 @@ class SpawnManager:
         """Whether enemy AI updates are currently suppressed."""
         return self._freeze_timer > 0
 
-    def update(self, dt: float, player_tanks: List[PlayerTank], game_map: Map) -> None:
+    def update(self, dt: float, player_tanks: list[PlayerTank], game_map: Map) -> None:
         """Update spawn timer and attempt to spawn enemies.
 
         Also checks pending spawns and materializes tanks whose

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -3,7 +3,6 @@ Game constants and configuration values.
 """
 
 from enum import Enum, StrEnum, auto
-from typing import Tuple
 
 
 class Direction(StrEnum):
@@ -122,11 +121,11 @@ LOGICAL_WIDTH: int = 512
 LOGICAL_HEIGHT: int = 512
 
 # Colors
-BLACK: Tuple[int, int, int] = (0, 0, 0)
-GRAY: Tuple[int, int, int] = (128, 128, 128)
-WHITE: Tuple[int, int, int] = (255, 255, 255)
-RED: Tuple[int, int, int] = (255, 0, 0)
-GREEN: Tuple[int, int, int] = (0, 255, 0)
+BLACK: tuple[int, int, int] = (0, 0, 0)
+GRAY: tuple[int, int, int] = (128, 128, 128)
+WHITE: tuple[int, int, int] = (255, 255, 255)
+RED: tuple[int, int, int] = (255, 0, 0)
+GREEN: tuple[int, int, int] = (0, 255, 0)
 
 # Tank settings
 TANK_SPEED: float = 80  # pixels per second (was 12 px/step)

--- a/tests/unit/core/test_map.py
+++ b/tests/unit/core/test_map.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import pytest
 from unittest.mock import MagicMock
 from src.core.map import Map, load_spawn_points
@@ -557,7 +555,7 @@ class TestGetBaseSurroundingTiles:
             assert tile.type != TileType.EMPTY
 
 
-def _mock_spawn_obj(name: str, x: int, y: int, properties: Optional[dict] = None):
+def _mock_spawn_obj(name: str, x: int, y: int, properties: dict | None = None):
     """Build a minimal TMX-like spawn object for load_spawn_points tests."""
     obj = MagicMock()
     obj.name = name


### PR DESCRIPTION
## Summary

Enable ruff's \`UP\` (pyupgrade) rule set and let it auto-fix the codebase. Brings every annotation onto the PEP 585 / PEP 604 style, which is a no-op at runtime on 3.13 but removes the legacy \`typing.Tuple\`/\`List\`/\`Dict\`/\`Optional\` imports and verbose \`Optional[X]\` forms.

Also migrates the last str-enum holdout (\`BrickVariant\` in \`src/core/tile.py\`) to \`enum.StrEnum\`, following the pattern established in #233. After this, the full \`UP\` rule set is enabled with an empty ignore list.

## What ruff fixed automatically

- \`Tuple[...]\` → \`tuple[...]\`, \`List[...]\` → \`list[...]\`, \`Dict[...]\` → \`dict[...]\` (UP006)
- \`Optional[X]\` → \`X | None\` (UP045)
- Pruned unused \`typing\` imports

## Manually applied

- \`BrickVariant(str, Enum)\` + \`__str__\` → \`BrickVariant(StrEnum)\` in \`src/core/tile.py\` (UP042)

Rebased onto \`main\` after #231, #232, #233, #235, #236 merged.

Closes #224.

## Test plan

- [x] \`pytest\` — 879 passed
- [x] \`ruff check src/ tests/\` — clean (full \`UP\` rule set, no ignores)
- [x] \`ruff format --check src/ tests/\` — clean