### PR TITLE
refactor(tank): derive revert_move snap offset from Direction.delta

### DIFF
--- a/src/core/tank.py
+++ b/src/core/tank.py
@@ -336,13 +336,14 @@ class Tank(GameObject):
             # Start with current (collided) position as a basis for snapping
             snapped_x, snapped_y = self.x, self.y
 
-            if self.direction == Direction.RIGHT:
+            dx, dy = self.direction.delta
+            if dx > 0:
                 snapped_x = float(obstacle_rect.left - self.width)
-            elif self.direction == Direction.LEFT:
+            elif dx < 0:
                 snapped_x = float(obstacle_rect.right)
-            elif self.direction == Direction.DOWN:
+            elif dy > 0:
                 snapped_y = float(obstacle_rect.top - self.height)
-            elif self.direction == Direction.UP:
+            elif dy < 0:
                 snapped_y = float(obstacle_rect.bottom)
 
             self.x = snapped_x


### PR DESCRIPTION
## Summary

\`Tank.revert_move\` was the last site comparing \`self.direction\` against \`Direction.UP/DOWN/LEFT/RIGHT\` with explicit equality:

\`\`\`python
if self.direction == Direction.RIGHT:
    snapped_x = float(obstacle_rect.left - self.width)
elif self.direction == Direction.LEFT:
    ...
\`\`\`

Every other direction-dependent site (\`Bullet.update\`, \`EnemyTank\` AI, \`Tank._move\` ice sliding, player input, player manager) uses the \`Direction.delta\` unit vector. Replace the enum-equality ladder with a \`(dx, dy)\` branch to keep the invariant consistent across the codebase.

\`\`\`python
dx, dy = self.direction.delta
if dx > 0:
    snapped_x = float(obstacle_rect.left - self.width)
elif dx < 0:
    snapped_x = float(obstacle_rect.right)
elif dy > 0:
    snapped_y = float(obstacle_rect.top - self.height)
elif dy < 0:
    snapped_y = float(obstacle_rect.bottom)
\`\`\`

No behavior change — the branches map 1:1. The only visible improvement is that future \`Direction\` additions wire up automatically as long as their delta is set.

Closes #230.

## Test plan

- [x] \`pytest\` — 881 passed (includes \`test_revert_move\` and the player movement integration tests that cover each direction + obstacle combination)
- [x] \`ruff check\` + \`ruff format --check\` — clean