### PR TITLE
refactor(animation): extract is_blink_visible helper (#238)

### DIFF
--- a/src/core/enemy_tank.py
+++ b/src/core/enemy_tank.py
@@ -3,6 +3,7 @@ import random
 from loguru import logger
 from .tank import Tank
 from typing import TypedDict
+from src.utils.animation import is_blink_visible
 from src.utils.constants import (
     CARRIER_BLINK_INTERVAL,
     Difficulty,
@@ -136,10 +137,8 @@ class EnemyTank(Tank):
 
     def _update_sprite(self) -> None:
         """Update sprite using type-specific prefix and carrier red variant."""
-        if (
-            self.is_carrier
-            and self.carrier_blink_timer % (CARRIER_BLINK_INTERVAL * 2)
-            >= CARRIER_BLINK_INTERVAL
+        if self.is_carrier and not is_blink_visible(
+            self.carrier_blink_timer, CARRIER_BLINK_INTERVAL
         ):
             sprite_name = (
                 f"{self._sprite_prefix}_red_{self.direction}_{self.animation_frame}"

--- a/src/core/player_tank.py
+++ b/src/core/player_tank.py
@@ -2,6 +2,7 @@ import pygame
 from loguru import logger
 from .tank import Tank
 from src.managers.texture_manager import TextureManager
+from src.utils.animation import is_blink_visible
 from src.utils.constants import (
     Direction,
     INITIAL_PLAYER_LIVES,
@@ -190,7 +191,7 @@ class PlayerTank(Tank):
             if self.sprite:
                 surface.blit(self.sprite, self.rect)
             interval = self.shield_flicker_interval
-            frame_idx = int(self.invincibility_timer % (interval * 2) >= interval)
+            frame_idx = 0 if is_blink_visible(self.invincibility_timer, interval) else 1
             surface.blit(self._shield_frames[frame_idx], self.rect)
         else:
             super().draw(surface)

--- a/src/core/power_up.py
+++ b/src/core/power_up.py
@@ -4,6 +4,7 @@ import pygame
 
 from src.core.game_object import GameObject
 from src.managers.texture_manager import TextureManager
+from src.utils.animation import is_blink_visible
 from src.utils.constants import (
     POWERUP_BLINK_INTERVAL,
     POWERUP_TIMEOUT,
@@ -43,7 +44,7 @@ class PowerUp(GameObject):
         """Draw the power-up with blinking effect."""
         if not self.active:
             return
-        if self.blink_timer % (POWERUP_BLINK_INTERVAL * 2) < POWERUP_BLINK_INTERVAL:
+        if is_blink_visible(self.blink_timer, POWERUP_BLINK_INTERVAL):
             super().draw(surface)
 
     def collect(self) -> PowerUpType:

--- a/src/core/tank.py
+++ b/src/core/tank.py
@@ -3,6 +3,7 @@ from loguru import logger
 from .game_object import GameObject
 from .bullet import Bullet
 from src.managers.texture_manager import TextureManager
+from src.utils.animation import is_blink_visible
 from src.utils.constants import (
     Direction,
     OwnerType,
@@ -348,9 +349,8 @@ class Tank(GameObject):
             surface: Surface to draw on
         """
         # Only draw if not invincible or during visible phase of blinking
-        if (
-            not self.is_invincible
-            or self.blink_timer % (self.blink_interval * 2) < self.blink_interval
+        if not self.is_invincible or is_blink_visible(
+            self.blink_timer, self.blink_interval
         ):
             if self.sprite:
                 surface.blit(self.sprite, self.rect)

--- a/src/managers/power_up_manager.py
+++ b/src/managers/power_up_manager.py
@@ -13,6 +13,7 @@ from src.core.player_tank import PlayerTank
 from src.core.power_up import PowerUp
 from src.core.map import Map
 from src.managers.texture_manager import TextureManager
+from src.utils.animation import is_blink_visible
 from src.utils.constants import (
     CLOCK_FREEZE_DURATION,
     EffectType,
@@ -165,9 +166,8 @@ class PowerUpManager:
             return
         if self.shovel_timer <= SHOVEL_WARNING_DURATION:
             self._shovel_flash_timer += dt
-            should_show_steel = (
-                self._shovel_flash_timer % (SHOVEL_FLASH_INTERVAL * 2)
-                < SHOVEL_FLASH_INTERVAL
+            should_show_steel = is_blink_visible(
+                self._shovel_flash_timer, SHOVEL_FLASH_INTERVAL
             )
             if should_show_steel != self._shovel_flash_showing_steel:
                 self._shovel_flash_showing_steel = should_show_steel

--- a/src/utils/animation.py
+++ b/src/utils/animation.py
@@ -1,0 +1,10 @@
+"""Animation timing helpers."""
+
+
+def is_blink_visible(timer: float, interval: float) -> bool:
+    """Return True during the 'on' phase of a 2*interval blink cycle.
+
+    A blink cycle is 2*interval long: the first half is visible,
+    the second half is hidden.
+    """
+    return timer % (interval * 2) < interval

--- a/tests/unit/utils/test_animation.py
+++ b/tests/unit/utils/test_animation.py
@@ -1,0 +1,22 @@
+from src.utils.animation import is_blink_visible
+
+
+class TestIsBlinkVisible:
+    def test_first_half_is_visible(self):
+        assert is_blink_visible(0.0, 1.0)
+        assert is_blink_visible(0.5, 1.0)
+
+    def test_second_half_is_hidden(self):
+        assert not is_blink_visible(1.0, 1.0)
+        assert not is_blink_visible(1.5, 1.0)
+
+    def test_cycle_wraps(self):
+        # second cycle, first half
+        assert is_blink_visible(2.0, 1.0)
+        assert is_blink_visible(2.5, 1.0)
+        # second cycle, second half
+        assert not is_blink_visible(3.5, 1.0)
+
+    def test_interval_boundary_is_hidden(self):
+        # exactly at interval → start of hidden phase
+        assert not is_blink_visible(1.0, 1.0)


### PR DESCRIPTION
## Summary

- Add `src/utils/animation.py` with `is_blink_visible(timer, interval)` helper
- Replace five call sites that hand-rolled `timer % (interval * 2) < interval` (or the inverted `>=` form)
- Add unit tests for the helper

Closes #238.

## Call sites updated

- `src/core/power_up.py` — powerup on-ground blink
- `src/core/tank.py` — invincibility blink
- `src/core/player_tank.py` — shield flicker frame selection
- `src/core/enemy_tank.py` — carrier red-blink (inverted branch)
- `src/managers/power_up_manager.py` — shovel flash warning

## Test plan

- [x] `pytest` — 883 pass (4 new)
- [x] `ruff check src/ tests/` — clean
- [ ] Play through a stage and confirm: invincibility blink, carrier red flash, powerup blink, shovel warning flash all look unchanged