### PR TITLE
refactor(effect-manager): add spawn_at_rect helper (#240)

### DIFF
--- a/src/managers/collision_response_handler.py
+++ b/src/managers/collision_response_handler.py
@@ -162,11 +162,7 @@ class CollisionResponseHandler:
                 ENEMY_POINTS.get(enemy.tank_type, 0),
                 player_id=bullet.owner.player_id,
             )
-            self._effect_manager.spawn(
-                EffectType.LARGE_EXPLOSION,
-                float(enemy.rect.centerx),
-                float(enemy.rect.centery),
-            )
+            self._effect_manager.spawn_at_rect(EffectType.LARGE_EXPLOSION, enemy.rect)
             self._play("explosion")
         return True
 
@@ -197,10 +193,8 @@ class CollisionResponseHandler:
             destroyed = player.take_damage()
             if destroyed:
                 logger.info("Player tank destroyed.")
-                self._effect_manager.spawn(
-                    EffectType.LARGE_EXPLOSION,
-                    float(player.rect.centerx),
-                    float(player.rect.centery),
+                self._effect_manager.spawn_at_rect(
+                    EffectType.LARGE_EXPLOSION, player.rect
                 )
                 self._play("explosion")
                 if self._on_player_death is not None:
@@ -225,11 +219,7 @@ class CollisionResponseHandler:
 
         logger.debug(f"Bullet hit {tile.type.name} tile at ({tile.x}, {tile.y})")
         bullet.active = False
-        self._effect_manager.spawn(
-            EffectType.SMALL_EXPLOSION,
-            float(bullet.rect.centerx),
-            float(bullet.rect.centery),
-        )
+        self._effect_manager.spawn_at_rect(EffectType.SMALL_EXPLOSION, bullet.rect)
         if tile.type == TileType.BASE:
             self._play("explosion")
         else:

--- a/src/managers/effect_manager.py
+++ b/src/managers/effect_manager.py
@@ -98,6 +98,10 @@ class EffectManager:
         logger.trace(f"Spawned {effect_type.name} at ({x:.1f}, {y:.1f})")
         return effect
 
+    def spawn_at_rect(self, effect_type: EffectType, rect: pygame.Rect) -> Effect:
+        """Spawn an effect centered on a rect."""
+        return self.spawn(effect_type, float(rect.centerx), float(rect.centery))
+
     def update(self, dt: float) -> None:
         """Update all effects and remove inactive ones.
 

--- a/src/managers/power_up_manager.py
+++ b/src/managers/power_up_manager.py
@@ -121,11 +121,7 @@ class PowerUpManager:
         spawn_manager: SpawnManager, effect_manager: EffectManager
     ) -> None:
         for enemy in list(spawn_manager.enemy_tanks):
-            effect_manager.spawn(
-                EffectType.LARGE_EXPLOSION,
-                float(enemy.rect.centerx),
-                float(enemy.rect.centery),
-            )
+            effect_manager.spawn_at_rect(EffectType.LARGE_EXPLOSION, enemy.rect)
             spawn_manager.remove_enemy(enemy)
 
     def apply_shovel(self) -> None:

--- a/tests/unit/managers/test_collision_response_handler.py
+++ b/tests/unit/managers/test_collision_response_handler.py
@@ -448,8 +448,8 @@ class TestExplosionEffects:
         mock_map.get_tile_at.return_value = Tile(TileType.EMPTY, 4, 5)
         bullet = make_bullet(direction=Direction.RIGHT, rect=pygame.Rect(64, 66, 2, 2))
         handler.process_collisions([(bullet, tile)])
-        mock_effect_manager.spawn.assert_called_once_with(
-            EffectType.SMALL_EXPLOSION, 65.0, 67.0
+        mock_effect_manager.spawn_at_rect.assert_called_once_with(
+            EffectType.SMALL_EXPLOSION, bullet.rect
         )
 
     def test_bullet_vs_steel_spawns_small_explosion(
@@ -462,8 +462,8 @@ class TestExplosionEffects:
         tile.is_destructible = False
         tile.x, tile.y = 0, 0
         handler.process_collisions([(bullet, tile)])
-        mock_effect_manager.spawn.assert_called_once_with(
-            EffectType.SMALL_EXPLOSION, 51.0, 51.0
+        mock_effect_manager.spawn_at_rect.assert_called_once_with(
+            EffectType.SMALL_EXPLOSION, bullet.rect
         )
 
     def test_bullet_vs_base_spawns_small_explosion(
@@ -476,8 +476,8 @@ class TestExplosionEffects:
         tile.is_destructible = False
         tile.x, tile.y = 0, 0
         handler.process_collisions([(bullet, tile)])
-        mock_effect_manager.spawn.assert_called_once_with(
-            EffectType.SMALL_EXPLOSION, 51.0, 51.0
+        mock_effect_manager.spawn_at_rect.assert_called_once_with(
+            EffectType.SMALL_EXPLOSION, bullet.rect
         )
 
     def test_enemy_destroyed_spawns_large_explosion(
@@ -490,8 +490,8 @@ class TestExplosionEffects:
         enemy.take_damage = MagicMock(return_value=True)
         enemy.rect = pygame.Rect(100, 100, 32, 32)
         handler.process_collisions([(bullet, enemy)])
-        mock_effect_manager.spawn.assert_called_once_with(
-            EffectType.LARGE_EXPLOSION, 116.0, 116.0
+        mock_effect_manager.spawn_at_rect.assert_called_once_with(
+            EffectType.LARGE_EXPLOSION, enemy.rect
         )
 
     def test_bullet_vs_bullet_no_explosion(
@@ -501,6 +501,7 @@ class TestExplosionEffects:
         b2 = make_bullet(rect=pygame.Rect(52, 50, 2, 2))
         handler.process_collisions([(b1, b2)])
         mock_effect_manager.spawn.assert_not_called()
+        mock_effect_manager.spawn_at_rect.assert_not_called()
 
     def test_player_destroyed_spawns_large_explosion(
         self, handler, make_bullet, mock_player, mock_effect_manager
@@ -509,8 +510,8 @@ class TestExplosionEffects:
         mock_player.take_damage.return_value = True
         mock_player.rect = pygame.Rect(100, 100, 32, 32)
         handler.process_collisions([(bullet, mock_player)])
-        mock_effect_manager.spawn.assert_called_once_with(
-            EffectType.LARGE_EXPLOSION, 116.0, 116.0
+        mock_effect_manager.spawn_at_rect.assert_called_once_with(
+            EffectType.LARGE_EXPLOSION, mock_player.rect
         )
 
 

--- a/tests/unit/managers/test_effect_manager.py
+++ b/tests/unit/managers/test_effect_manager.py
@@ -75,3 +75,11 @@ class TestEffectManager:
         surface = pygame.Surface((256, 256))
         effect_manager.spawn(EffectType.SMALL_EXPLOSION, 100, 100)
         effect_manager.draw(surface)
+
+    def test_spawn_at_rect_centers_on_rect(self, effect_manager):
+        rect = pygame.Rect(100, 200, 32, 32)
+        effect_manager.spawn_at_rect(EffectType.SMALL_EXPLOSION, rect)
+        assert len(effect_manager.effects) == 1
+        effect = effect_manager.effects[0]
+        assert effect.x == 116.0  # centerx of (100, 200, 32, 32)
+        assert effect.y == 216.0  # centery

--- a/tests/unit/managers/test_game_manager_powerups.py
+++ b/tests/unit/managers/test_game_manager_powerups.py
@@ -81,10 +81,8 @@ class TestPowerUpManagerApply:
         enemy.rect = pygame.Rect(100, 100, TILE_SIZE, TILE_SIZE)
         spawn_manager.enemy_tanks = [enemy]
         manager.apply(PowerUpType.BOMB, player, spawn_manager, effect_manager)
-        effect_manager.spawn.assert_called_once_with(
-            EffectType.LARGE_EXPLOSION,
-            float(enemy.rect.centerx),
-            float(enemy.rect.centery),
+        effect_manager.spawn_at_rect.assert_called_once_with(
+            EffectType.LARGE_EXPLOSION, enemy.rect
         )
 
     def test_bomb_does_not_trigger_carrier_powerup(


### PR DESCRIPTION
## Summary

- Add `EffectManager.spawn_at_rect(effect_type, rect)` that centers on a rect
- Replace four hand-rolled `float(rect.centerx), float(rect.centery)` call sites in `CollisionResponseHandler` (3 sites) and `PowerUpManager` (1 site)
- Update corresponding unit tests to assert on the new API

Closes #240.

The `spawn_manager.py:87-88` site (setting `EnemyTank.base_position`) uses the same float-tuple shape for AI targeting, not effect spawning — left as-is since it's now a single, isolated use.

## Test plan

- [x] `pytest` — 880 pass (1 new)
- [x] `ruff check src/ tests/` — clean
- [ ] Trigger tank explosions (player, enemy), bullet-vs-tile hit, and BOMB power-up, confirm effects still spawn centered