### PR TITLE
polish: game_manager hot-path cleanup (#241, #242, #244)

### DIFF
--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -387,14 +387,24 @@ class GameManager:
         active_players = self.player_manager.get_active_players()
 
         if not self.spawn_manager.enemies_frozen:
+            # When 0 or 1 active players, the AI target is the same for every
+            # enemy and can be hoisted out of the per-enemy loop. Only 2P mode
+            # needs the per-enemy min() to pick the nearest player.
+            num_players = len(active_players)
+            shared_pos: tuple[float, float] | None = None
+            if num_players == 1:
+                p = active_players[0]
+                shared_pos = (p.x, p.y)
+
             for enemy in self.spawn_manager.enemy_tanks:
-                closest_pos = None
-                if active_players:
+                if num_players >= 2:
                     closest = min(
                         active_players,
                         key=lambda p: abs(p.x - enemy.x) + abs(p.y - enemy.y),
                     )
-                    closest_pos = (closest.x, closest.y)
+                    closest_pos: tuple[float, float] | None = (closest.x, closest.y)
+                else:
+                    closest_pos = shared_pos
                 enemy.update(dt, player_position=closest_pos)
                 enemy.on_ice = self.map.is_tile_slidable(
                     enemy.x, enemy.y, enemy.width, enemy.height

--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -577,12 +577,12 @@ class GameManager:
                 1.0, self._state_timer / GAME_OVER_RISE_DURATION
             )
 
-        all_bullets = self.player_manager.get_all_bullets() + self.bullets
         self.renderer.render(
             self.map,
             self.player_manager.get_active_players(),
             self.spawn_manager.enemy_tanks,
-            all_bullets,
+            self.player_manager.get_all_bullets(),
+            self.bullets,
             self.effect_manager,
             self.state,
             self.player_manager.scores,

--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -424,7 +424,7 @@ class GameManager:
 
         player_bullets = self.player_manager.get_all_bullets()
 
-        active_power_ups = self.power_up_manager.get_power_ups()
+        active_power_ups = self.power_up_manager.active_power_ups
 
         self.collision_manager.check_collisions(
             player_tanks=active_players,
@@ -576,7 +576,7 @@ class GameManager:
             self.effect_manager,
             self.state,
             self.player_manager.scores,
-            power_ups=self.power_up_manager.get_power_ups(),
+            power_ups=self.power_up_manager.active_power_ups,
             game_over_rise_progress=game_over_rise_progress,
         )
 

--- a/src/managers/player_manager.py
+++ b/src/managers/player_manager.py
@@ -185,10 +185,9 @@ class PlayerManager:
     def get_all_bullets(self) -> list[Bullet]:
         """Return all player bullets (pruned to active-only by update()).
 
-        Returns:
-            Shallow copy of the internal bullet list.
+        Read-only: callers must not mutate the returned list.
         """
-        return list(self._bullets)
+        return self._bullets
 
     def get_active_players(self) -> list[PlayerTank]:
         """Return players that are still alive (health > 0).

--- a/src/managers/power_up_manager.py
+++ b/src/managers/power_up_manager.py
@@ -176,10 +176,6 @@ class PowerUpManager:
                         target = TileType.STEEL if should_show_steel else orig_type
                         self._game_map.set_tile_type(tile, target)
 
-    def get_power_ups(self) -> list[PowerUp]:
-        """Return the list of active power-ups for collision checking and rendering."""
-        return self.active_power_ups
-
     def collect_power_up(self, power_up: PowerUp) -> PowerUpType | None:
         """Collect a specific power-up. Returns its type, or None if not found."""
         if power_up not in self.active_power_ups:

--- a/src/managers/renderer.py
+++ b/src/managers/renderer.py
@@ -76,7 +76,8 @@ class Renderer:
         game_map,
         player_tanks: list,
         enemy_tanks: list,
-        bullets: list,
+        player_bullets: Sequence,
+        enemy_bullets: Sequence,
         effect_manager,
         state: GameState,
         scores: dict[int, int] | None = None,
@@ -89,7 +90,8 @@ class Renderer:
             game_map: The game map to draw.
             player_tanks: List of player tanks.
             enemy_tanks: List of enemy tanks.
-            bullets: List of bullets.
+            player_bullets: Player-fired bullets.
+            enemy_bullets: Enemy-fired bullets.
             state: Current game state.
             scores: Per-player scores dict {player_id: score}.
             power_ups: Active power-ups to draw.
@@ -105,7 +107,10 @@ class Renderer:
             enemy.draw(self.map_surface)
         for power_up in power_ups:
             power_up.draw(self.map_surface)
-        for bullet in bullets:
+        for bullet in player_bullets:
+            if bullet.active:
+                bullet.draw(self.map_surface)
+        for bullet in enemy_bullets:
             if bullet.active:
                 bullet.draw(self.map_surface)
 

--- a/tests/integration/test_sound_integration.py
+++ b/tests/integration/test_sound_integration.py
@@ -73,5 +73,5 @@ class TestPowerupBlinkWiring:
         gm.power_up_manager.spawn_power_up(
             first_player(gm), gm.spawn_manager.enemy_tanks
         )
-        assert len(gm.power_up_manager.get_power_ups()) > 0
+        assert len(gm.power_up_manager.active_power_ups) > 0
         gm.update()

--- a/tests/unit/managers/test_power_up_manager.py
+++ b/tests/unit/managers/test_power_up_manager.py
@@ -58,15 +58,6 @@ class TestPowerUpManager:
         assert pu.y == 96
         assert pu.power_up_type == PowerUpType.STAR
 
-    def test_get_power_ups_returns_list(self, manager, mock_player_tank):
-        manager.spawn_power_up(mock_player_tank, [])
-        result = manager.get_power_ups()
-        assert isinstance(result, list)
-        assert len(result) == 1
-
-    def test_get_power_ups_returns_empty_when_none(self, manager):
-        assert manager.get_power_ups() == []
-
     def test_collect_specific_power_up(self, manager, mock_player_tank):
         manager.spawn_power_up(mock_player_tank, [], power_up_type=PowerUpType.CLOCK)
         pu = manager.active_power_ups[0]

--- a/tests/unit/managers/test_renderer.py
+++ b/tests/unit/managers/test_renderer.py
@@ -77,6 +77,7 @@ class TestRendererRender:
                 [mock_player],
                 [mock_enemy1, mock_enemy2],
                 [mock_bullet1, mock_bullet2],
+                [],
                 mock_effect_manager,
                 GameState.RUNNING,
             )
@@ -102,7 +103,9 @@ class TestRendererRender:
         ):
             mock_scale.return_value = MagicMock()
             mock_em = MagicMock()
-            renderer.render(mock_map, mock_player, [], [], mock_em, GameState.VICTORY)
+            renderer.render(
+                mock_map, mock_player, [], [], [], mock_em, GameState.VICTORY
+            )
 
         mock_draw_v.assert_called_once()
 
@@ -120,7 +123,9 @@ class TestRendererRender:
         ):
             mock_scale.return_value = MagicMock()
             mock_em = MagicMock()
-            renderer.render(mock_map, mock_player, [], [], mock_em, GameState.RUNNING)
+            renderer.render(
+                mock_map, mock_player, [], [], [], mock_em, GameState.RUNNING
+            )
 
         mock_draw_v.assert_not_called()
 
@@ -138,7 +143,9 @@ class TestRendererRender:
         ):
             mock_scale.return_value = mock_scaled
             mock_em = MagicMock()
-            renderer.render(mock_map, mock_player, [], [], mock_em, GameState.RUNNING)
+            renderer.render(
+                mock_map, mock_player, [], [], [], mock_em, GameState.RUNNING
+            )
 
         mock_scale.assert_called_once_with(
             renderer.game_surface, (1024, 1024), renderer.screen
@@ -164,7 +171,9 @@ class TestRendererHUD:
         ):
             mock_scale.return_value = MagicMock()
             mock_em = MagicMock()
-            renderer.render(mock_map, mock_player, [], [], mock_em, GameState.RUNNING)
+            renderer.render(
+                mock_map, mock_player, [], [], [], mock_em, GameState.RUNNING
+            )
 
         # small_font.render: lives + score only (no invincibility)
         assert renderer.small_font.render.call_count == 2


### PR DESCRIPTION
## Summary

Three related micro-optimizations bundled into one PR because they all touch `GameManager`'s update/render hot paths:

- **#241** — Drop `PowerUpManager.get_power_ups()` pass-through wrapper (1 commit)
- **#242** — Hoist closest-player `min()` out of the enemy loop when there are 0 or 1 active players (1 commit)
- **#244** — Split `bullets` into `player_bullets` / `enemy_bullets` in `Renderer.render()` to drop per-frame list concat; also drop the defensive `list(...)` copy in `PlayerManager.get_all_bullets()` (1 commit)

Closes #241, #242, #244.

## Why bundle

Each fix is a tiny, mechanical change on its own, and all three touch `game_manager.py` (either `update()` or `render()`). Separate PRs would cause three-way back-and-forth on near-identical files. Each commit is isolated, so the history still reads commit-by-commit.

## Test plan

- [x] `pytest` — 877 pass
- [x] `ruff check src/ tests/` — clean
- [ ] Play a 1P stage: verify enemies still move and target base + player
- [ ] Play a 2P stage: verify enemies appear to track nearest player
- [ ] Verify bullets render correctly (player bullets and enemy bullets both visible)