### PR TITLE
Add 1 Player + AI co-op mode

### DIFF
--- a/assets/config/ai_teammate.json
+++ b/assets/config/ai_teammate.json
@@ -1,0 +1,10 @@
+{
+  "direction_change_interval": 0.5,
+  "shoot_interval": 0.8,
+  "aligned_shoot_multiplier": 0.3,
+  "defender_base_radius_tiles": 6,
+  "hunter_target_bias": 2.0,
+  "defender_base_bias": 3.0,
+  "defender_enemy_bias": 1.0,
+  "friendly_fire_check_tiles": 5
+}

--- a/src/core/ai_geometry.py
+++ b/src/core/ai_geometry.py
@@ -2,6 +2,29 @@
 
 from src.utils.constants import Direction
 
+_ALL_DIRECTIONS = list(Direction)
+
+
+def manhattan(a: tuple[float, float], b: tuple[float, float]) -> float:
+    """L1 distance between two points."""
+    return abs(a[0] - b[0]) + abs(a[1] - b[1])
+
+
+def filter_candidate_directions(
+    current: Direction, blocked: set[Direction]
+) -> list[Direction]:
+    """Directions the tank may pick next.
+
+    Prefers directions that are neither blocked nor the reverse of `current`.
+    Falls back to allowing the reverse when every other non-blocked direction
+    is gone, and returns an empty list only when every direction is blocked.
+    """
+    opposite = current.opposite
+    filtered = [d for d in _ALL_DIRECTIONS if d not in blocked and d != opposite]
+    if filtered:
+        return filtered
+    return [d for d in _ALL_DIRECTIONS if d not in blocked]
+
 
 def direction_moves_toward(
     pos: tuple[float, float],

--- a/src/core/ai_geometry.py
+++ b/src/core/ai_geometry.py
@@ -1,0 +1,36 @@
+"""Pure geometry helpers shared by tank AI implementations."""
+
+from src.utils.constants import Direction
+
+
+def direction_moves_toward(
+    pos: tuple[float, float],
+    direction: Direction,
+    target: tuple[float, float],
+) -> bool:
+    """True if moving from pos along direction reduces distance to target."""
+    dx, dy = direction.delta
+    x, y = pos
+    tx, ty = target
+    if dx != 0:
+        return (dx > 0 and tx > x) or (dx < 0 and tx < x)
+    return (dy > 0 and ty > y) or (dy < 0 and ty < y)
+
+
+def is_aligned_with(
+    pos: tuple[float, float],
+    direction: Direction,
+    tile_size: int,
+    target: tuple[float, float],
+) -> bool:
+    """True if facing direction and within one tile on the perpendicular axis."""
+    x, y = pos
+    tx, ty = target
+    dx, dy = direction.delta
+    if dx != 0:
+        if abs(y - ty) > tile_size:
+            return False
+    else:
+        if abs(x - tx) > tile_size:
+            return False
+    return direction_moves_toward(pos, direction, target)

--- a/src/core/enemy_tank.py
+++ b/src/core/enemy_tank.py
@@ -3,6 +3,7 @@ import random
 from loguru import logger
 from .tank import Tank
 from typing import TypedDict
+from src.core.ai_geometry import direction_moves_toward, is_aligned_with
 from src.utils.animation import is_blink_visible
 from src.utils.constants import (
     CARRIER_BLINK_INTERVAL,
@@ -158,11 +159,7 @@ class EnemyTank(Tank):
         self, direction: Direction, target: tuple[float, float]
     ) -> bool:
         """Check if moving in direction reduces distance to target."""
-        dx, dy = direction.delta
-        tx, ty = target
-        if dx != 0:
-            return (dx > 0 and tx > self.x) or (dx < 0 and tx < self.x)
-        return (dy > 0 and ty > self.y) or (dy < 0 and ty < self.y)
+        return direction_moves_toward((self.x, self.y), direction, target)
 
     def _change_direction(
         self,
@@ -219,16 +216,7 @@ class EnemyTank(Tank):
 
     def _is_aligned_with(self, target: tuple[float, float]) -> bool:
         """Check if the tank is facing toward and aligned with a target position."""
-        tx, ty = target
-        dx, dy = self.direction.delta
-        tile = self.tile_size
-        if dx != 0:
-            if abs(self.y - ty) > tile:
-                return False
-        else:
-            if abs(self.x - tx) > tile:
-                return False
-        return self._direction_moves_toward(self.direction, target)
+        return is_aligned_with((self.x, self.y), self.direction, self.tile_size, target)
 
     def consume_shoot(self) -> bool:
         """Check if the tank wants to shoot and clear the flag."""

--- a/src/core/enemy_tank.py
+++ b/src/core/enemy_tank.py
@@ -3,7 +3,11 @@ import random
 from loguru import logger
 from .tank import Tank
 from typing import TypedDict
-from src.core.ai_geometry import direction_moves_toward, is_aligned_with
+from src.core.ai_geometry import (
+    direction_moves_toward,
+    filter_candidate_directions,
+    is_aligned_with,
+)
 from src.utils.animation import is_blink_visible
 from src.utils.constants import (
     CARRIER_BLINK_INTERVAL,
@@ -134,8 +138,6 @@ class EnemyTank(Tank):
             f"shoot_interval={self.shoot_interval:.2f}"
         )
 
-    _ALL_DIRECTIONS = list(Direction)
-
     def _update_sprite(self) -> None:
         """Update sprite using type-specific prefix and carrier red variant."""
         if self.is_carrier and not is_blink_visible(
@@ -169,18 +171,9 @@ class EnemyTank(Tank):
         """Change the tank's direction, weighted by AI biases when applicable."""
         old_direction = self.direction
 
-        # Prefer unblocked directions, excluding opposite to avoid reversing
-        opposite = old_direction.opposite
-        candidates = [
-            d
-            for d in self._ALL_DIRECTIONS
-            if d not in self._blocked_directions and d != opposite
-        ]
-        # Fall back to unblocked only (allow opposite)
-        if not candidates:
-            candidates = [
-                d for d in self._ALL_DIRECTIONS if d not in self._blocked_directions
-            ]
+        candidates = filter_candidate_directions(
+            old_direction, self._blocked_directions
+        )
         # All directions blocked — stay put and wait for one to open
         if not candidates:
             return

--- a/src/managers/ai_player_input.py
+++ b/src/managers/ai_player_input.py
@@ -87,4 +87,15 @@ class AIPlayerInput:
         teammate: PlayerTank | None,
     ) -> None:
         """Advance AI state by one frame. Filled in over subsequent tasks."""
-        return
+        self._direction_timer += dt
+        self._shoot_timer += dt
+
+        moved = (self._tank.x != self._tank.prev_x) or (
+            self._tank.y != self._tank.prev_y
+        )
+        requested_movement = self._dx != 0 or self._dy != 0
+        if moved:
+            self._blocked_directions.clear()
+        elif requested_movement and not self._tank.is_frozen:
+            self._blocked_directions.add(self._tank.direction)
+            self._direction_timer = 0.0

--- a/src/managers/ai_player_input.py
+++ b/src/managers/ai_player_input.py
@@ -9,9 +9,10 @@ from typing import TYPE_CHECKING
 
 import pygame
 
-from src.core.ai_geometry import direction_moves_toward
+from src.core.ai_geometry import direction_moves_toward, is_aligned_with
 from src.utils.constants import (
     DIRECTION_CHANGE_RANDOM_OFFSET,
+    SHOOT_RANDOM_OFFSET,
     TILE_SIZE,
     Direction,
 )
@@ -110,7 +111,35 @@ class AIPlayerInput:
             self._replan(enemies)
             self._direction_timer = random.uniform(0, DIRECTION_CHANGE_RANDOM_OFFSET)
 
+        self._maybe_shoot(enemies, teammate)
+
     _ALL_DIRECTIONS = list(Direction)
+
+    def _maybe_shoot(
+        self,
+        enemies: list[EnemyTank],
+        teammate: PlayerTank | None,
+    ) -> None:
+        if self._shoot_timer < self._shoot_interval * self._aligned_shoot_multiplier:
+            return
+
+        if self._shoot_timer < self._shoot_interval:
+            if not enemies:
+                return
+            nearest = min(
+                enemies,
+                key=lambda e: abs(e.x - self._tank.x) + abs(e.y - self._tank.y),
+            )
+            if not is_aligned_with(
+                (self._tank.x, self._tank.y),
+                self._tank.direction,
+                self._tank.tile_size,
+                (nearest.x, nearest.y),
+            ):
+                return
+
+        self._wants_shoot = True
+        self._shoot_timer = random.uniform(0, SHOOT_RANDOM_OFFSET)
 
     def _replan(self, enemies: list[EnemyTank]) -> None:
         from src.core.enemy_tank import EnemyTank

--- a/src/managers/ai_player_input.py
+++ b/src/managers/ai_player_input.py
@@ -116,13 +116,14 @@ class AIPlayerInput:
             self._tank.y != self._tank.prev_y
         )
         requested_movement = self._dx != 0 or self._dy != 0
+        replan_now = False
         if moved:
             self._blocked_directions.clear()
         elif requested_movement and not self._tank.is_frozen:
             self._blocked_directions.add(self._tank.direction)
-            self._direction_timer = 0.0
+            replan_now = True
 
-        if self._direction_timer >= self._direction_change_interval:
+        if replan_now or self._direction_timer >= self._direction_change_interval:
             self._replan(enemies)
             self._direction_timer = random.uniform(0, DIRECTION_CHANGE_RANDOM_OFFSET)
 

--- a/src/managers/ai_player_input.py
+++ b/src/managers/ai_player_input.py
@@ -138,8 +138,25 @@ class AIPlayerInput:
             ):
                 return
 
+        if self._teammate_in_line_of_fire(teammate):
+            return
+
         self._wants_shoot = True
         self._shoot_timer = random.uniform(0, SHOOT_RANDOM_OFFSET)
+
+    def _teammate_in_line_of_fire(self, teammate: PlayerTank | None) -> bool:
+        if teammate is None:
+            return False
+        dx, dy = self._tank.direction.delta
+        ox = teammate.x - self._tank.x
+        oy = teammate.y - self._tank.y
+        if dx != 0:
+            along = ox * dx
+            perp = abs(oy)
+        else:
+            along = oy * dy
+            perp = abs(ox)
+        return 0 < along <= self._friendly_fire_check_px and perp <= TILE_SIZE
 
     def _replan(self, enemies: list[EnemyTank]) -> None:
         from src.core.enemy_tank import EnemyTank

--- a/src/managers/ai_player_input.py
+++ b/src/managers/ai_player_input.py
@@ -86,6 +86,18 @@ class AIPlayerInput:
     def clear_pending_shoot(self) -> None:
         self._wants_shoot = False
 
+    def reset(self) -> None:
+        """Clear all transient AI state. Called on the teammate's respawn so
+        stale timers, pending shots, and block-memory from the previous life
+        don't leak into the new one.
+        """
+        self._dx = 0
+        self._dy = 0
+        self._wants_shoot = False
+        self._direction_timer = 0.0
+        self._shoot_timer = 0.0
+        self._blocked_directions.clear()
+
     # AI-specific, called by PlayerManager via isinstance branch ---------------
     def update(
         self,

--- a/src/managers/ai_player_input.py
+++ b/src/managers/ai_player_input.py
@@ -9,7 +9,13 @@ from typing import TYPE_CHECKING
 
 import pygame
 
-from src.core.ai_geometry import direction_moves_toward, is_aligned_with
+from src.core.ai_geometry import (
+    direction_moves_toward,
+    filter_candidate_directions,
+    is_aligned_with,
+    manhattan,
+)
+from src.core.enemy_tank import EnemyTank
 from src.utils.constants import (
     DIRECTION_CHANGE_RANDOM_OFFSET,
     SHOOT_RANDOM_OFFSET,
@@ -18,7 +24,6 @@ from src.utils.constants import (
 )
 
 if TYPE_CHECKING:
-    from src.core.enemy_tank import EnemyTank
     from src.core.player_tank import PlayerTank
 
 
@@ -72,7 +77,6 @@ class AIPlayerInput:
         self._shoot_timer: float = 0.0
         self._blocked_directions: set[Direction] = set()
 
-    # PlayerInput protocol -----------------------------------------------------
     def handle_event(self, event: pygame.event.Event) -> None:
         pass
 
@@ -98,7 +102,6 @@ class AIPlayerInput:
         self._shoot_timer = 0.0
         self._blocked_directions.clear()
 
-    # AI-specific, called by PlayerManager via isinstance branch ---------------
     def update(
         self,
         dt: float,
@@ -125,8 +128,6 @@ class AIPlayerInput:
 
         self._maybe_shoot(enemies, teammate)
 
-    _ALL_DIRECTIONS = list(Direction)
-
     def _maybe_shoot(
         self,
         enemies: list[EnemyTank],
@@ -138,10 +139,8 @@ class AIPlayerInput:
         if self._shoot_timer < self._shoot_interval:
             if not enemies:
                 return
-            nearest = min(
-                enemies,
-                key=lambda e: abs(e.x - self._tank.x) + abs(e.y - self._tank.y),
-            )
+            pos = (self._tank.x, self._tank.y)
+            nearest = min(enemies, key=lambda e: manhattan((e.x, e.y), pos))
             if not is_aligned_with(
                 (self._tank.x, self._tank.y),
                 self._tank.direction,
@@ -171,13 +170,13 @@ class AIPlayerInput:
         return 0 < along <= self._friendly_fire_check_px and perp <= TILE_SIZE
 
     def _replan(self, enemies: list[EnemyTank]) -> None:
-        from src.core.enemy_tank import EnemyTank
-
         base_position = EnemyTank.base_position
         role = self._select_role(enemies, base_position)
         target_pos = self._select_target(enemies, base_position, role)
 
-        candidates = self._candidate_directions()
+        candidates = filter_candidate_directions(
+            self._tank.direction, self._blocked_directions
+        )
         if not candidates:
             self._dx, self._dy = 0, 0
             return
@@ -196,9 +195,8 @@ class AIPlayerInput:
     ) -> AIRole:
         if base_position is None:
             return AIRole.HUNTER
-        bx, by = base_position
         for e in enemies:
-            if abs(e.x - bx) + abs(e.y - by) <= self._defender_base_radius:
+            if manhattan((e.x, e.y), base_position) <= self._defender_base_radius:
                 return AIRole.DEFENDER
         return AIRole.HUNTER
 
@@ -211,25 +209,11 @@ class AIPlayerInput:
         if not enemies:
             return None
         if role == AIRole.DEFENDER and base_position is not None:
-            bx, by = base_position
-            nearest = min(enemies, key=lambda e: abs(e.x - bx) + abs(e.y - by))
+            anchor = base_position
         else:
-            nearest = min(
-                enemies,
-                key=lambda e: abs(e.x - self._tank.x) + abs(e.y - self._tank.y),
-            )
+            anchor = (self._tank.x, self._tank.y)
+        nearest = min(enemies, key=lambda e: manhattan((e.x, e.y), anchor))
         return (nearest.x, nearest.y)
-
-    def _candidate_directions(self) -> list[Direction]:
-        opposite = self._tank.direction.opposite
-        filtered = [
-            d
-            for d in self._ALL_DIRECTIONS
-            if d not in self._blocked_directions and d != opposite
-        ]
-        if filtered:
-            return filtered
-        return [d for d in self._ALL_DIRECTIONS if d not in self._blocked_directions]
 
     def _compute_weights(
         self,

--- a/src/managers/ai_player_input.py
+++ b/src/managers/ai_player_input.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 import json
+import random
 from enum import Enum, auto
 from typing import TYPE_CHECKING
 
 import pygame
 
-from src.utils.constants import TILE_SIZE, Direction
+from src.core.ai_geometry import direction_moves_toward
+from src.utils.constants import (
+    DIRECTION_CHANGE_RANDOM_OFFSET,
+    TILE_SIZE,
+    Direction,
+)
 
 if TYPE_CHECKING:
     from src.core.enemy_tank import EnemyTank
@@ -86,7 +92,7 @@ class AIPlayerInput:
         enemies: list[EnemyTank],
         teammate: PlayerTank | None,
     ) -> None:
-        """Advance AI state by one frame. Filled in over subsequent tasks."""
+        """Advance AI state by one frame."""
         self._direction_timer += dt
         self._shoot_timer += dt
 
@@ -99,3 +105,93 @@ class AIPlayerInput:
         elif requested_movement and not self._tank.is_frozen:
             self._blocked_directions.add(self._tank.direction)
             self._direction_timer = 0.0
+
+        if self._direction_timer >= self._direction_change_interval:
+            self._replan(enemies)
+            self._direction_timer = random.uniform(0, DIRECTION_CHANGE_RANDOM_OFFSET)
+
+    _ALL_DIRECTIONS = list(Direction)
+
+    def _replan(self, enemies: list[EnemyTank]) -> None:
+        from src.core.enemy_tank import EnemyTank
+
+        base_position = EnemyTank.base_position
+        role = self._select_role(enemies, base_position)
+        target_pos = self._select_target(enemies, base_position, role)
+
+        candidates = self._candidate_directions()
+        if not candidates:
+            self._dx, self._dy = 0, 0
+            return
+
+        pos = (self._tank.x, self._tank.y)
+        weights = self._compute_weights(
+            candidates, pos, role, target_pos, base_position
+        )
+        new_direction = random.choices(candidates, weights)[0]
+        self._dx, self._dy = new_direction.delta
+
+    def _select_role(
+        self,
+        enemies: list[EnemyTank],
+        base_position: tuple[float, float] | None,
+    ) -> AIRole:
+        if base_position is None:
+            return AIRole.HUNTER
+        bx, by = base_position
+        for e in enemies:
+            if abs(e.x - bx) + abs(e.y - by) <= self._defender_base_radius:
+                return AIRole.DEFENDER
+        return AIRole.HUNTER
+
+    def _select_target(
+        self,
+        enemies: list[EnemyTank],
+        base_position: tuple[float, float] | None,
+        role: AIRole,
+    ) -> tuple[float, float] | None:
+        if not enemies:
+            return None
+        if role == AIRole.DEFENDER and base_position is not None:
+            bx, by = base_position
+            nearest = min(enemies, key=lambda e: abs(e.x - bx) + abs(e.y - by))
+        else:
+            nearest = min(
+                enemies,
+                key=lambda e: abs(e.x - self._tank.x) + abs(e.y - self._tank.y),
+            )
+        return (nearest.x, nearest.y)
+
+    def _candidate_directions(self) -> list[Direction]:
+        opposite = self._tank.direction.opposite
+        filtered = [
+            d
+            for d in self._ALL_DIRECTIONS
+            if d not in self._blocked_directions and d != opposite
+        ]
+        if filtered:
+            return filtered
+        return [d for d in self._ALL_DIRECTIONS if d not in self._blocked_directions]
+
+    def _compute_weights(
+        self,
+        candidates: list[Direction],
+        pos: tuple[float, float],
+        role: AIRole,
+        target_pos: tuple[float, float] | None,
+        base_position: tuple[float, float] | None,
+    ) -> list[float]:
+        weights = [1.0] * len(candidates)
+        if role == AIRole.DEFENDER and base_position is not None:
+            for i, d in enumerate(candidates):
+                if direction_moves_toward(pos, d, base_position):
+                    weights[i] += self._defender_base_bias
+                if target_pos is not None and direction_moves_toward(
+                    pos, d, target_pos
+                ):
+                    weights[i] += self._defender_enemy_bias
+        elif role == AIRole.HUNTER and target_pos is not None:
+            for i, d in enumerate(candidates):
+                if direction_moves_toward(pos, d, target_pos):
+                    weights[i] += self._hunter_target_bias
+        return weights

--- a/src/managers/ai_player_input.py
+++ b/src/managers/ai_player_input.py
@@ -1,0 +1,90 @@
+"""AI implementation of the PlayerInput protocol for the AI co-op teammate."""
+
+from __future__ import annotations
+
+import json
+from enum import Enum, auto
+from typing import TYPE_CHECKING
+
+import pygame
+
+from src.utils.constants import TILE_SIZE, Direction
+
+if TYPE_CHECKING:
+    from src.core.enemy_tank import EnemyTank
+    from src.core.player_tank import PlayerTank
+
+
+_AI_TEAMMATE_CONFIG_PATH = "assets/config/ai_teammate.json"
+_ai_teammate_config: dict | None = None
+
+
+def _get_ai_teammate_config() -> dict:
+    global _ai_teammate_config
+    if _ai_teammate_config is None:
+        from src.utils.paths import resource_path
+
+        with open(resource_path(_AI_TEAMMATE_CONFIG_PATH)) as f:
+            _ai_teammate_config = json.load(f)
+    return _ai_teammate_config
+
+
+def _reset_ai_teammate_config() -> None:
+    global _ai_teammate_config
+    _ai_teammate_config = None
+
+
+class AIRole(Enum):
+    HUNTER = auto()
+    DEFENDER = auto()
+
+
+class AIPlayerInput:
+    """PlayerInput implementation that steers a PlayerTank via a role-aware AI."""
+
+    def __init__(self, tank: PlayerTank) -> None:
+        cfg = _get_ai_teammate_config()
+        self._tank = tank
+        self._direction_change_interval: float = cfg["direction_change_interval"]
+        self._shoot_interval: float = cfg["shoot_interval"]
+        self._aligned_shoot_multiplier: float = cfg["aligned_shoot_multiplier"]
+        self._defender_base_radius: float = (
+            cfg["defender_base_radius_tiles"] * TILE_SIZE
+        )
+        self._hunter_target_bias: float = cfg["hunter_target_bias"]
+        self._defender_base_bias: float = cfg["defender_base_bias"]
+        self._defender_enemy_bias: float = cfg["defender_enemy_bias"]
+        self._friendly_fire_check_px: float = (
+            cfg["friendly_fire_check_tiles"] * TILE_SIZE
+        )
+
+        self._dx: int = 0
+        self._dy: int = 0
+        self._wants_shoot: bool = False
+        self._direction_timer: float = 0.0
+        self._shoot_timer: float = 0.0
+        self._blocked_directions: set[Direction] = set()
+
+    # PlayerInput protocol -----------------------------------------------------
+    def handle_event(self, event: pygame.event.Event) -> None:
+        pass
+
+    def get_movement_direction(self) -> tuple[int, int]:
+        return (self._dx, self._dy)
+
+    def consume_shoot(self) -> bool:
+        flag, self._wants_shoot = self._wants_shoot, False
+        return flag
+
+    def clear_pending_shoot(self) -> None:
+        self._wants_shoot = False
+
+    # AI-specific, called by PlayerManager via isinstance branch ---------------
+    def update(
+        self,
+        dt: float,
+        enemies: list[EnemyTank],
+        teammate: PlayerTank | None,
+    ) -> None:
+        """Advance AI state by one frame. Filled in over subsequent tasks."""
+        return

--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -75,7 +75,7 @@ class GameManager:
         self.state: GameState = GameState.TITLE_SCREEN
         self._options_from_pause: bool = False
         self._state_timer: float = 0.0
-        self._two_player_mode: bool = False
+        self._game_mode: GameMode = GameMode.ONE_PLAYER
         self._post_curtain_state: GameState = GameState.RUNNING
 
         self._title_menu, self._pause_menu, self._options_menu = self._build_menus()
@@ -115,8 +115,18 @@ class GameManager:
 
         title = MenuController(
             items=[
-                MenuItem("1 Player", on_confirm=lambda: self._start_game(False)),
-                MenuItem("2 Players", on_confirm=lambda: self._start_game(True)),
+                MenuItem(
+                    "1 Player",
+                    on_confirm=lambda: self._start_game(GameMode.ONE_PLAYER),
+                ),
+                MenuItem(
+                    "2 Players",
+                    on_confirm=lambda: self._start_game(GameMode.TWO_PLAYER),
+                ),
+                MenuItem(
+                    "1 Player + AI",
+                    on_confirm=lambda: self._start_game(GameMode.ONE_PLAYER_AI),
+                ),
                 MenuItem("Options", on_confirm=lambda: self._open_options(False)),
                 MenuItem("Quit", on_confirm=self._quit_game),
             ],
@@ -213,11 +223,10 @@ class GameManager:
             on_player_death=self.player_manager.handle_player_death,
         )
 
-        mode = GameMode.TWO_PLAYER if self._two_player_mode else GameMode.ONE_PLAYER
         self.player_manager.create_players(
             self.map,
             controller_instance_ids=self.input_handler.controller_instance_ids,
-            mode=mode,
+            mode=self._game_mode,
         )
 
         # Renderer (fixed logical surface with map centered inside)
@@ -333,11 +342,9 @@ class GameManager:
         else:
             self.state = GameState.TITLE_SCREEN
 
-    def _start_game(self, two_player: bool) -> None:
-        self._two_player_mode = two_player
-        logger.info(
-            f"{'2 Players' if two_player else '1 Player'} selected, starting game."
-        )
+    def _start_game(self, mode: GameMode) -> None:
+        self._game_mode = mode
+        logger.info(f"{mode.name} selected, starting game.")
         self._new_game()
         self.state = GameState.STAGE_CURTAIN_CLOSE
         self._state_timer = 0.0

--- a/src/managers/game_manager.py
+++ b/src/managers/game_manager.py
@@ -6,6 +6,7 @@ from src.core.map import Map
 from src.core.player_tank import PlayerTank
 from src.core.tile import Tile
 from src.core.bullet import Bullet
+from src.states.game_mode import GameMode
 from src.states.game_state import GameState
 from src.utils.constants import (
     VOLUME_ADJUSTMENT_STEP,
@@ -212,10 +213,11 @@ class GameManager:
             on_player_death=self.player_manager.handle_player_death,
         )
 
+        mode = GameMode.TWO_PLAYER if self._two_player_mode else GameMode.ONE_PLAYER
         self.player_manager.create_players(
             self.map,
             controller_instance_ids=self.input_handler.controller_instance_ids,
-            two_player_mode=self._two_player_mode,
+            mode=mode,
         )
 
         # Renderer (fixed logical surface with map centered inside)
@@ -381,7 +383,7 @@ class GameManager:
 
         self.map.update(dt)
         # Update player tanks via PlayerManager
-        self.player_manager.update(dt, self.map)
+        self.player_manager.update(dt, self.map, self.spawn_manager.enemy_tanks)
         self.player_manager.try_shoot()
 
         active_players = self.player_manager.get_active_players()

--- a/src/managers/player_manager.py
+++ b/src/managers/player_manager.py
@@ -9,14 +9,17 @@ from loguru import logger
 
 from src.core.bullet import Bullet
 from src.core.player_tank import PlayerTank
+from src.managers.ai_player_input import AIPlayerInput
 from src.managers.player_input import (
     CombinedInput,
     ControllerInput,
     KeyboardInput,
     PlayerInput,
 )
+from src.states.game_mode import GameMode
 
 if TYPE_CHECKING:
+    from src.core.enemy_tank import EnemyTank
     from src.core.map import Map
     from src.managers.sound_manager import SoundManager
     from src.managers.texture_manager import TextureManager
@@ -54,7 +57,7 @@ class PlayerManager:
         self,
         game_map: Map,
         controller_instance_ids: list[int],
-        two_player_mode: bool = False,
+        mode: GameMode = GameMode.ONE_PLAYER,
     ) -> None:
         # controller_instance_ids must come from InputHandler — it's the single
         # source of truth for which SDL game controllers are currently open.
@@ -79,15 +82,22 @@ class PlayerManager:
 
         self._players.append(make_player(game_map.player_spawn, 1))
 
-        if two_player_mode:
+        if mode == GameMode.ONE_PLAYER:
+            self._player_inputs.extend(self._one_player_inputs())
+        else:
             p2_spawn = game_map.player_spawn_2
             if p2_spawn is None:
                 px = game_map.player_spawn[0] + 8
                 p2_spawn = (px, game_map.player_spawn[1])
             self._players.append(make_player(p2_spawn, 2))
-            self._player_inputs.extend(self._two_player_inputs(controller_instance_ids))
-        else:
-            self._player_inputs.extend(self._one_player_inputs())
+
+            if mode == GameMode.ONE_PLAYER_AI:
+                self._player_inputs.extend(self._one_player_inputs())
+                self._player_inputs.append(AIPlayerInput(tank=self._players[1]))
+            else:  # GameMode.TWO_PLAYER
+                self._player_inputs.extend(
+                    self._two_player_inputs(controller_instance_ids)
+                )
 
         for player in self._players:
             if player.player_id not in self._scores:
@@ -122,14 +132,16 @@ class PlayerManager:
         for pi in self._player_inputs:
             pi.clear_pending_shoot()
 
-    def update(self, dt: float, game_map: Map) -> None:
+    def update(self, dt: float, game_map: Map, enemies: list[EnemyTank]) -> None:
         """Process input, move players, and handle ice sliding.
 
         For each live player:
-        1. Call player.update(dt) to advance timers.
-        2. Read movement direction from the paired PlayerInput.
-        3. Detect whether the player is on an ice tile and start sliding if needed.
-        4. Apply player.move() when there is valid (non-diagonal) input and the
+        1. If the input is an AIPlayerInput, advance its AI state with the
+           current enemy list and surviving teammate (if any).
+        2. Call player.update(dt) to advance timers.
+        3. Read movement direction from the paired PlayerInput.
+        4. Detect whether the player is on an ice tile and start sliding if needed.
+        5. Apply player.move() when there is valid (non-diagonal) input and the
            player is not currently sliding.
 
         Also advances all active bullets and prunes inactive ones.
@@ -137,10 +149,18 @@ class PlayerManager:
         Args:
             dt: Time step in seconds.
             game_map: Current map (used for ice tile detection).
+            enemies: Live enemy tanks; forwarded to AI inputs for targeting.
         """
         for player, player_input in zip(self._players, self._player_inputs):
             if player.health <= 0:
                 continue
+
+            if isinstance(player_input, AIPlayerInput):
+                teammate = next(
+                    (p for p in self._players if p is not player and p.health > 0),
+                    None,
+                )
+                player_input.update(dt, enemies, teammate)
 
             player.update(dt)
 

--- a/src/managers/player_manager.py
+++ b/src/managers/player_manager.py
@@ -279,6 +279,13 @@ class PlayerManager:
         """
         if player.lives > 0:
             player.respawn()
+            for p, pi in zip(self._players, self._player_inputs):
+                if p is player:
+                    if isinstance(pi, AIPlayerInput):
+                        pi.reset()
+                    else:
+                        pi.clear_pending_shoot()
+                    break
             return False
 
         return self.is_game_over()

--- a/src/states/game_mode.py
+++ b/src/states/game_mode.py
@@ -1,0 +1,9 @@
+"""Game mode: selected at the title screen, fixed for a run."""
+
+from enum import Enum, auto
+
+
+class GameMode(Enum):
+    ONE_PLAYER = auto()
+    TWO_PLAYER = auto()
+    ONE_PLAYER_AI = auto()

--- a/tests/integration/test_ai_coop_mode.py
+++ b/tests/integration/test_ai_coop_mode.py
@@ -1,0 +1,49 @@
+"""End-to-end tests for 1 Player + AI mode."""
+
+import pygame
+import pytest
+
+from src.managers.ai_player_input import AIPlayerInput
+from src.states.game_mode import GameMode
+from src.states.game_state import GameState
+
+
+@pytest.fixture
+def ai_coop_game(game_manager_fixture):
+    """Start the game in ONE_PLAYER_AI mode and run past stage-curtain animations."""
+    gm = game_manager_fixture
+    gm._start_game(GameMode.ONE_PLAYER_AI)
+    while gm.state != GameState.RUNNING:
+        pygame.event.clear()
+        gm.update()
+        if gm.state == GameState.EXIT:
+            pytest.fail("Game exited before reaching RUNNING")
+    return gm
+
+
+class TestAICoopRuntime:
+    def test_slot_2_has_ai_input(self, ai_coop_game):
+        pm = ai_coop_game.player_manager
+        assert len(pm.get_active_players()) == 2
+        assert isinstance(pm._player_inputs[1], AIPlayerInput)
+
+    def test_ai_tank_moves_from_spawn(self, ai_coop_game):
+        pm = ai_coop_game.player_manager
+        ai_tank = pm._players[1]
+        spawn_x, spawn_y = ai_tank.x, ai_tank.y
+        for _ in range(120):
+            pygame.event.clear()
+            ai_coop_game.update()
+        assert (ai_tank.x, ai_tank.y) != (spawn_x, spawn_y)
+
+    def test_ai_fires_a_bullet(self, ai_coop_game):
+        pm = ai_coop_game.player_manager
+        ai_tank = pm._players[1]
+        ai_fired = False
+        for _ in range(180):
+            pygame.event.clear()
+            ai_coop_game.update()
+            if any(b.owner is ai_tank for b in pm.get_all_bullets()):
+                ai_fired = True
+                break
+        assert ai_fired, "AI did not fire within 3 seconds"

--- a/tests/integration/test_ai_coop_mode.py
+++ b/tests/integration/test_ai_coop_mode.py
@@ -1,11 +1,26 @@
 """End-to-end tests for 1 Player + AI mode."""
 
+import random
+
 import pygame
 import pytest
 
-from src.managers.ai_player_input import AIPlayerInput
+from src.core.enemy_tank import EnemyTank
+from src.managers.ai_player_input import AIPlayerInput, AIRole
 from src.states.game_mode import GameMode
 from src.states.game_state import GameState
+from src.utils.constants import SUB_TILE_SIZE
+
+from tests.integration.conftest import clear_enemies, spawn_enemy_at
+
+
+@pytest.fixture(autouse=True)
+def seed_random():
+    """Seed the global `random` module so stochastic AI picks are deterministic."""
+    state = random.getstate()
+    random.seed(42)
+    yield
+    random.setstate(state)
 
 
 @pytest.fixture
@@ -38,12 +53,92 @@ class TestAICoopRuntime:
 
     def test_ai_fires_a_bullet(self, ai_coop_game):
         pm = ai_coop_game.player_manager
+        human = pm._players[0]
         ai_tank = pm._players[1]
+        # Move the human well off any axis shared with the AI so friendly-fire
+        # suppression never stalls the shoot timer during the observation window.
+        human.x = 4 * 32
+        human.y = 0.0
+        human.prev_x, human.prev_y = human.x, human.y
+        human.rect.topleft = (int(human.x), int(human.y))
+
         ai_fired = False
-        for _ in range(180):
+        for _ in range(300):
             pygame.event.clear()
             ai_coop_game.update()
             if any(b.owner is ai_tank for b in pm.get_all_bullets()):
                 ai_fired = True
                 break
-        assert ai_fired, "AI did not fire within 3 seconds"
+        assert ai_fired, "AI did not fire within 5 seconds"
+
+
+class TestAICoopDefenderMode:
+    def test_defender_role_triggers_when_enemy_near_base(
+        self, ai_coop_game, monkeypatch
+    ):
+        """With an enemy parked 2 tiles from the base, the AI should pick
+        DEFENDER on its next replan."""
+        pm = ai_coop_game.player_manager
+        ai_input = pm._player_inputs[1]
+
+        # Park a single enemy 2 tiles (64px) from the base along x.
+        assert EnemyTank.base_position is not None, (
+            "Base position must be set by SpawnManager"
+        )
+        bx, by = EnemyTank.base_position
+        clear_enemies(ai_coop_game)
+        # Use sub-tile grid (8px units) — 2 TILE_SIZE = 8 sub-tiles.
+        enemy_grid_x = int(bx / SUB_TILE_SIZE) + 8
+        enemy_grid_y = int(by / SUB_TILE_SIZE)
+        spawn_enemy_at(ai_coop_game, enemy_grid_x, enemy_grid_y)
+
+        captured_roles: list[AIRole] = []
+        original_select_role = ai_input._select_role
+
+        def spy(enemies, base_position):
+            role = original_select_role(enemies, base_position)
+            captured_roles.append(role)
+            return role
+
+        monkeypatch.setattr(ai_input, "_select_role", spy)
+
+        # Force a replan next frame.
+        ai_input._direction_timer = ai_input._direction_change_interval
+
+        for _ in range(5):
+            pygame.event.clear()
+            ai_coop_game.update()
+
+        assert AIRole.DEFENDER in captured_roles, (
+            f"Expected DEFENDER role when enemy is near base; captured={captured_roles}"
+        )
+
+
+class TestAICoopFriendlyFireSafety:
+    def test_player_bullet_hitting_ai_does_not_crash(self, ai_coop_game):
+        """Friendly fire on the AI tank must freeze it, not crash the AI."""
+        pm = ai_coop_game.player_manager
+        human = pm._players[0]
+        ai_tank = pm._players[1]
+
+        # Clear spawn invincibility so friendly-fire actually resolves.
+        ai_tank.is_invincible = False
+        ai_tank.invincibility_timer = 0.0
+        ai_tank.invincibility_duration = 0.0
+
+        # Fire a real player-owned bullet and reposition it on top of the AI
+        # tank so the next collision tick resolves friendly-fire immediately.
+        bullet = human.shoot()
+        assert bullet is not None
+        bullet.x = ai_tank.x
+        bullet.y = ai_tank.y
+        bullet.rect.topleft = (int(bullet.x), int(bullet.y))
+        pm._bullets.append(bullet)
+
+        # Step a few frames — must not raise, and the AI tank should freeze.
+        for _ in range(10):
+            pygame.event.clear()
+            ai_coop_game.update()
+
+        assert ai_tank.health > 0
+        assert ai_tank.is_frozen

--- a/tests/integration/test_two_player.py
+++ b/tests/integration/test_two_player.py
@@ -8,6 +8,7 @@ in the respective unit test files.
 import pytest
 import pygame
 from src.managers.game_manager import GameManager
+from src.states.game_mode import GameMode
 
 
 @pytest.fixture
@@ -15,7 +16,7 @@ def two_player_game():
     """GameManager in 2P mode with game running."""
     pygame.init()
     gm = GameManager()
-    gm._two_player_mode = True
+    gm._game_mode = GameMode.TWO_PLAYER
     gm._reset_game()
     return gm
 
@@ -72,7 +73,7 @@ class TestTwoPlayerStageTransition:
         gm.player_manager.create_players(
             gm.map,
             controller_instance_ids=gm.input_handler.controller_instance_ids,
-            two_player_mode=True,
+            mode=GameMode.TWO_PLAYER,
         )
         gm.player_manager.restore_state()
 

--- a/tests/unit/core/test_ai_geometry.py
+++ b/tests/unit/core/test_ai_geometry.py
@@ -1,0 +1,53 @@
+import pytest
+
+from src.core.ai_geometry import direction_moves_toward, is_aligned_with
+from src.utils.constants import TILE_SIZE, Direction
+
+
+class TestDirectionMovesToward:
+    @pytest.mark.parametrize(
+        "direction,target,expected",
+        [
+            (Direction.RIGHT, (100.0, 0.0), True),
+            (Direction.RIGHT, (-100.0, 0.0), False),
+            (Direction.LEFT, (-100.0, 0.0), True),
+            (Direction.LEFT, (100.0, 0.0), False),
+            (Direction.DOWN, (0.0, 100.0), True),
+            (Direction.DOWN, (0.0, -100.0), False),
+            (Direction.UP, (0.0, -100.0), True),
+            (Direction.UP, (0.0, 100.0), False),
+        ],
+    )
+    def test_cardinal_directions(self, direction, target, expected):
+        assert direction_moves_toward((0.0, 0.0), direction, target) is expected
+
+    def test_target_equals_position(self):
+        pos = (50.0, 50.0)
+        assert direction_moves_toward(pos, Direction.RIGHT, pos) is False
+        assert direction_moves_toward(pos, Direction.UP, pos) is False
+
+
+class TestIsAlignedWith:
+    def test_facing_and_on_axis(self):
+        result = is_aligned_with((0.0, 0.0), Direction.RIGHT, TILE_SIZE, (100.0, 0.0))
+        assert result is True
+
+    def test_facing_but_off_perpendicular_axis(self):
+        off_y = 2 * TILE_SIZE
+        result = is_aligned_with((0.0, 0.0), Direction.RIGHT, TILE_SIZE, (100.0, off_y))
+        assert result is False
+
+    def test_on_axis_but_facing_away(self):
+        result = is_aligned_with((0.0, 0.0), Direction.RIGHT, TILE_SIZE, (-100.0, 0.0))
+        assert result is False
+
+    def test_vertical_alignment(self):
+        pos = (0.0, 0.0)
+        assert is_aligned_with(pos, Direction.DOWN, TILE_SIZE, (0.0, 100.0)) is True
+        assert (
+            is_aligned_with(pos, Direction.DOWN, TILE_SIZE, (TILE_SIZE, 100.0)) is True
+        )
+        assert (
+            is_aligned_with(pos, Direction.DOWN, TILE_SIZE, (2 * TILE_SIZE, 100.0))
+            is False
+        )

--- a/tests/unit/managers/test_ai_player_input.py
+++ b/tests/unit/managers/test_ai_player_input.py
@@ -59,6 +59,22 @@ class TestProtocolMethods:
         assert ai.consume_shoot() is False
 
 
+class TestReset:
+    def test_reset_clears_transient_state(self, mock_player_tank):
+        ai = AIPlayerInput(tank=mock_player_tank)
+        ai._dx, ai._dy = 1, 0
+        ai._wants_shoot = True
+        ai._direction_timer = 0.42
+        ai._shoot_timer = 0.7
+        ai._blocked_directions = {Direction.UP, Direction.LEFT}
+        ai.reset()
+        assert (ai._dx, ai._dy) == (0, 0)
+        assert ai.consume_shoot() is False
+        assert ai._direction_timer == 0.0
+        assert ai._shoot_timer == 0.0
+        assert ai._blocked_directions == set()
+
+
 class TestConfigLoader:
     def test_loads_config_fields(self, mock_player_tank):
         ai = AIPlayerInput(tank=mock_player_tank)

--- a/tests/unit/managers/test_ai_player_input.py
+++ b/tests/unit/managers/test_ai_player_input.py
@@ -287,3 +287,62 @@ class TestDirectionPicking:
         )
         ai.update(dt=0.01, enemies=[], teammate=None)
         assert (ai._dx, ai._dy) == Direction.DOWN.delta
+
+
+class TestShooting:
+    def test_fires_when_timer_exceeds_interval(
+        self, mock_player_tank, mock_enemy_factory, monkeypatch
+    ):
+        ai = AIPlayerInput(tank=mock_player_tank)
+        ai._shoot_timer = ai._shoot_interval
+        mock_player_tank.direction = Direction.RIGHT
+        monkeypatch.setattr(EnemyTank, "base_position", None)
+        monkeypatch.setattr(
+            "src.managers.ai_player_input.random.uniform", lambda a, b: 0.0
+        )
+        ai.update(
+            dt=0.01,
+            enemies=[mock_enemy_factory(100.0, 0.0)],
+            teammate=None,
+        )
+        assert ai.consume_shoot() is True
+        assert ai._shoot_timer == 0.0
+
+    def test_does_not_fire_before_interval(
+        self, mock_player_tank, mock_enemy_factory, monkeypatch
+    ):
+        ai = AIPlayerInput(tank=mock_player_tank)
+        ai._shoot_timer = 0.0
+        mock_player_tank.direction = Direction.UP
+        monkeypatch.setattr(EnemyTank, "base_position", None)
+        ai.update(
+            dt=0.01,
+            enemies=[mock_enemy_factory(0.0, -100.0)],
+            teammate=None,
+        )
+        assert ai.consume_shoot() is False
+
+    def test_aligned_shoot_fires_early(
+        self, mock_player_tank, mock_enemy_factory, monkeypatch
+    ):
+        ai = AIPlayerInput(tank=mock_player_tank)
+        ai._shoot_timer = ai._shoot_interval * ai._aligned_shoot_multiplier + 0.01
+        mock_player_tank.direction = Direction.RIGHT
+        monkeypatch.setattr(EnemyTank, "base_position", None)
+        monkeypatch.setattr(
+            "src.managers.ai_player_input.random.uniform", lambda a, b: 0.0
+        )
+        aligned_enemy = mock_enemy_factory(5 * TILE_SIZE, 0.0)
+        ai.update(dt=0.01, enemies=[aligned_enemy], teammate=None)
+        assert ai.consume_shoot() is True
+
+    def test_aligned_shoot_misaligned_does_not_fire_early(
+        self, mock_player_tank, mock_enemy_factory, monkeypatch
+    ):
+        ai = AIPlayerInput(tank=mock_player_tank)
+        ai._shoot_timer = ai._shoot_interval * ai._aligned_shoot_multiplier + 0.01
+        mock_player_tank.direction = Direction.RIGHT
+        monkeypatch.setattr(EnemyTank, "base_position", None)
+        perp_enemy = mock_enemy_factory(0.0, 5 * TILE_SIZE)
+        ai.update(dt=0.01, enemies=[perp_enemy], teammate=None)
+        assert ai.consume_shoot() is False

--- a/tests/unit/managers/test_ai_player_input.py
+++ b/tests/unit/managers/test_ai_player_input.py
@@ -346,3 +346,90 @@ class TestShooting:
         perp_enemy = mock_enemy_factory(0.0, 5 * TILE_SIZE)
         ai.update(dt=0.01, enemies=[perp_enemy], teammate=None)
         assert ai.consume_shoot() is False
+
+
+class TestFriendlyFireSuppression:
+    def test_suppresses_when_teammate_in_line(
+        self, mock_player_tank, mock_enemy_factory, monkeypatch
+    ):
+        ai = AIPlayerInput(tank=mock_player_tank)
+        ai._shoot_timer = ai._shoot_interval
+        mock_player_tank.direction = Direction.RIGHT
+        monkeypatch.setattr(EnemyTank, "base_position", None)
+
+        teammate = MagicMock(spec=PlayerTank)
+        teammate.x = 2 * TILE_SIZE
+        teammate.y = 0.0
+        teammate.health = 1
+
+        pre_timer = ai._shoot_timer
+        ai.update(
+            dt=0.01,
+            enemies=[mock_enemy_factory(10 * TILE_SIZE, 0.0)],
+            teammate=teammate,
+        )
+        assert ai.consume_shoot() is False
+        assert ai._shoot_timer >= pre_timer
+
+    def test_fires_when_no_teammate(
+        self, mock_player_tank, mock_enemy_factory, monkeypatch
+    ):
+        ai = AIPlayerInput(tank=mock_player_tank)
+        ai._shoot_timer = ai._shoot_interval
+        mock_player_tank.direction = Direction.RIGHT
+        monkeypatch.setattr(EnemyTank, "base_position", None)
+        monkeypatch.setattr(
+            "src.managers.ai_player_input.random.uniform", lambda a, b: 0.0
+        )
+        ai.update(
+            dt=0.01,
+            enemies=[mock_enemy_factory(5 * TILE_SIZE, 0.0)],
+            teammate=None,
+        )
+        assert ai.consume_shoot() is True
+
+    def test_fires_when_teammate_perpendicular(
+        self, mock_player_tank, mock_enemy_factory, monkeypatch
+    ):
+        ai = AIPlayerInput(tank=mock_player_tank)
+        ai._shoot_timer = ai._shoot_interval
+        mock_player_tank.direction = Direction.RIGHT
+        monkeypatch.setattr(EnemyTank, "base_position", None)
+        monkeypatch.setattr(
+            "src.managers.ai_player_input.random.uniform", lambda a, b: 0.0
+        )
+
+        teammate = MagicMock(spec=PlayerTank)
+        teammate.x = 0.0
+        teammate.y = 5 * TILE_SIZE
+        teammate.health = 1
+
+        ai.update(
+            dt=0.01,
+            enemies=[mock_enemy_factory(10 * TILE_SIZE, 0.0)],
+            teammate=teammate,
+        )
+        assert ai.consume_shoot() is True
+
+    def test_fires_when_teammate_behind_ai(
+        self, mock_player_tank, mock_enemy_factory, monkeypatch
+    ):
+        ai = AIPlayerInput(tank=mock_player_tank)
+        ai._shoot_timer = ai._shoot_interval
+        mock_player_tank.direction = Direction.RIGHT
+        monkeypatch.setattr(EnemyTank, "base_position", None)
+        monkeypatch.setattr(
+            "src.managers.ai_player_input.random.uniform", lambda a, b: 0.0
+        )
+
+        teammate = MagicMock(spec=PlayerTank)
+        teammate.x = -2 * TILE_SIZE
+        teammate.y = 0.0
+        teammate.health = 1
+
+        ai.update(
+            dt=0.01,
+            enemies=[mock_enemy_factory(10 * TILE_SIZE, 0.0)],
+            teammate=teammate,
+        )
+        assert ai.consume_shoot() is True

--- a/tests/unit/managers/test_ai_player_input.py
+++ b/tests/unit/managers/test_ai_player_input.py
@@ -1,0 +1,72 @@
+from unittest.mock import MagicMock
+
+import pygame
+import pytest
+
+from src.core.player_tank import PlayerTank
+from src.managers.ai_player_input import (
+    AIPlayerInput,
+    _reset_ai_teammate_config,
+)
+from src.utils.constants import TILE_SIZE, Direction
+
+
+@pytest.fixture(autouse=True)
+def reset_config():
+    _reset_ai_teammate_config()
+    yield
+    _reset_ai_teammate_config()
+
+
+@pytest.fixture
+def mock_player_tank():
+    tank = MagicMock(spec=PlayerTank)
+    tank.x = 0.0
+    tank.y = 0.0
+    tank.prev_x = 0.0
+    tank.prev_y = 0.0
+    tank.is_frozen = False
+    tank.tile_size = TILE_SIZE
+    tank.direction = Direction.UP
+    return tank
+
+
+class TestProtocolMethods:
+    def test_handle_event_is_noop(self, mock_player_tank):
+        ai = AIPlayerInput(tank=mock_player_tank)
+        event = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_UP)
+        ai.handle_event(event)
+
+    def test_get_movement_direction_starts_zero(self, mock_player_tank):
+        ai = AIPlayerInput(tank=mock_player_tank)
+        assert ai.get_movement_direction() == (0, 0)
+
+    def test_consume_shoot_starts_false(self, mock_player_tank):
+        ai = AIPlayerInput(tank=mock_player_tank)
+        assert ai.consume_shoot() is False
+
+    def test_consume_shoot_drains_flag(self, mock_player_tank):
+        ai = AIPlayerInput(tank=mock_player_tank)
+        ai._wants_shoot = True
+        assert ai.consume_shoot() is True
+        assert ai.consume_shoot() is False
+
+    def test_clear_pending_shoot(self, mock_player_tank):
+        ai = AIPlayerInput(tank=mock_player_tank)
+        ai._wants_shoot = True
+        ai.clear_pending_shoot()
+        assert ai.consume_shoot() is False
+
+
+class TestConfigLoader:
+    def test_loads_config_fields(self, mock_player_tank):
+        ai = AIPlayerInput(tank=mock_player_tank)
+        assert ai._direction_change_interval == 0.5
+        assert ai._shoot_interval == 0.8
+        assert ai._aligned_shoot_multiplier == 0.3
+
+    def test_config_cached(self, mock_player_tank):
+        AIPlayerInput(tank=mock_player_tank)
+        from src.managers import ai_player_input as mod
+
+        assert mod._ai_teammate_config is not None

--- a/tests/unit/managers/test_ai_player_input.py
+++ b/tests/unit/managers/test_ai_player_input.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 import pygame
 import pytest
 
+from src.core.enemy_tank import EnemyTank
 from src.core.player_tank import PlayerTank
 from src.managers.ai_player_input import (
     AIPlayerInput,
@@ -127,3 +128,162 @@ class TestTimerAdvancement:
         ai = AIPlayerInput(tank=mock_player_tank)
         ai.update(dt=0.1, enemies=[], teammate=None)
         assert ai._shoot_timer == pytest.approx(0.1)
+
+
+@pytest.fixture
+def mock_enemy_factory():
+    def _make(x: float, y: float) -> MagicMock:
+        e = MagicMock(spec=EnemyTank)
+        e.x = x
+        e.y = y
+        return e
+
+    return _make
+
+
+class TestRoleSelection:
+    def test_hunter_when_no_enemies(self, mock_player_tank, monkeypatch):
+        ai = AIPlayerInput(tank=mock_player_tank)
+        ai._direction_timer = ai._direction_change_interval
+        captured = {}
+
+        def fake_choices(candidates, weights):
+            captured["weights"] = weights
+            return [candidates[0]]
+
+        monkeypatch.setattr("src.managers.ai_player_input.random.choices", fake_choices)
+        monkeypatch.setattr(EnemyTank, "base_position", (100.0, 100.0))
+        ai.update(dt=0.01, enemies=[], teammate=None)
+        assert all(w == 1.0 for w in captured["weights"])
+
+    def test_defender_when_enemy_near_base(
+        self, mock_player_tank, mock_enemy_factory, monkeypatch
+    ):
+        ai = AIPlayerInput(tank=mock_player_tank)
+        ai._direction_timer = ai._direction_change_interval
+        # Base at origin, tank 5 tiles to the right, enemy 1 tile from base.
+        monkeypatch.setattr(EnemyTank, "base_position", (0.0, 0.0))
+        mock_player_tank.x = 5 * TILE_SIZE
+        mock_player_tank.y = 0.0
+        # Face UP so LEFT (toward base) is not the excluded opposite.
+        mock_player_tank.direction = Direction.UP
+
+        close_enemy = mock_enemy_factory(TILE_SIZE, 0.0)
+
+        captured = {}
+
+        def fake_choices(candidates, weights):
+            captured["candidates"] = candidates
+            captured["weights"] = weights
+            return [candidates[0]]
+
+        monkeypatch.setattr("src.managers.ai_player_input.random.choices", fake_choices)
+        ai.update(dt=0.01, enemies=[close_enemy], teammate=None)
+        assert max(captured["weights"]) >= 1.0 + ai._defender_base_bias
+
+    def test_hunter_when_base_position_is_none(
+        self, mock_player_tank, mock_enemy_factory, monkeypatch
+    ):
+        ai = AIPlayerInput(tank=mock_player_tank)
+        ai._direction_timer = ai._direction_change_interval
+        monkeypatch.setattr(EnemyTank, "base_position", None)
+        # Face UP so RIGHT (toward enemy) is not the excluded opposite.
+        mock_player_tank.direction = Direction.UP
+        enemy = mock_enemy_factory(100.0, 0.0)
+
+        captured = {}
+
+        def fake_choices(candidates, weights):
+            captured["weights"] = weights
+            return [candidates[0]]
+
+        monkeypatch.setattr("src.managers.ai_player_input.random.choices", fake_choices)
+        ai.update(dt=0.01, enemies=[enemy], teammate=None)
+        assert max(captured["weights"]) == pytest.approx(1.0 + ai._hunter_target_bias)
+
+
+class TestDirectionCandidates:
+    def test_blocked_directions_excluded(self, mock_player_tank, monkeypatch):
+        ai = AIPlayerInput(tank=mock_player_tank)
+        ai._blocked_directions = {Direction.UP}
+        ai._direction_timer = ai._direction_change_interval
+        mock_player_tank.direction = Direction.RIGHT
+        monkeypatch.setattr(EnemyTank, "base_position", None)
+
+        captured = {}
+
+        def fake_choices(candidates, weights):
+            captured["candidates"] = list(candidates)
+            return [candidates[0]]
+
+        monkeypatch.setattr("src.managers.ai_player_input.random.choices", fake_choices)
+        ai.update(dt=0.01, enemies=[], teammate=None)
+        assert Direction.UP not in captured["candidates"]
+
+    def test_opposite_direction_excluded_when_others_available(
+        self, mock_player_tank, monkeypatch
+    ):
+        ai = AIPlayerInput(tank=mock_player_tank)
+        ai._direction_timer = ai._direction_change_interval
+        mock_player_tank.direction = Direction.RIGHT
+        monkeypatch.setattr(EnemyTank, "base_position", None)
+
+        captured = {}
+
+        def fake_choices(candidates, weights):
+            captured["candidates"] = list(candidates)
+            return [candidates[0]]
+
+        monkeypatch.setattr("src.managers.ai_player_input.random.choices", fake_choices)
+        ai.update(dt=0.01, enemies=[], teammate=None)
+        assert Direction.LEFT not in captured["candidates"]
+
+    def test_opposite_allowed_when_only_option(self, mock_player_tank, monkeypatch):
+        ai = AIPlayerInput(tank=mock_player_tank)
+        ai._blocked_directions = {Direction.UP, Direction.DOWN, Direction.RIGHT}
+        ai._direction_timer = ai._direction_change_interval
+        mock_player_tank.direction = Direction.RIGHT
+        monkeypatch.setattr(EnemyTank, "base_position", None)
+
+        captured = {}
+
+        def fake_choices(candidates, weights):
+            captured["candidates"] = list(candidates)
+            return [candidates[0]]
+
+        monkeypatch.setattr("src.managers.ai_player_input.random.choices", fake_choices)
+        ai.update(dt=0.01, enemies=[], teammate=None)
+        assert Direction.LEFT in captured["candidates"]
+
+
+class TestDirectionPicking:
+    def test_timer_resets_with_jitter(self, mock_player_tank, monkeypatch):
+        ai = AIPlayerInput(tank=mock_player_tank)
+        ai._direction_timer = ai._direction_change_interval
+        mock_player_tank.direction = Direction.RIGHT
+        monkeypatch.setattr(EnemyTank, "base_position", None)
+        monkeypatch.setattr(
+            "src.managers.ai_player_input.random.choices",
+            lambda c, w: [c[0]],
+        )
+        monkeypatch.setattr(
+            "src.managers.ai_player_input.random.uniform", lambda a, b: 0.03
+        )
+        ai.update(dt=0.01, enemies=[], teammate=None)
+        assert ai._direction_timer == pytest.approx(0.03)
+
+    def test_dx_dy_set_from_picked_direction(self, mock_player_tank, monkeypatch):
+        ai = AIPlayerInput(tank=mock_player_tank)
+        ai._direction_timer = ai._direction_change_interval
+        mock_player_tank.direction = Direction.RIGHT
+        monkeypatch.setattr(EnemyTank, "base_position", None)
+
+        monkeypatch.setattr(
+            "src.managers.ai_player_input.random.choices",
+            lambda c, w: [Direction.DOWN],
+        )
+        monkeypatch.setattr(
+            "src.managers.ai_player_input.random.uniform", lambda a, b: 0.0
+        )
+        ai.update(dt=0.01, enemies=[], teammate=None)
+        assert (ai._dx, ai._dy) == Direction.DOWN.delta

--- a/tests/unit/managers/test_ai_player_input.py
+++ b/tests/unit/managers/test_ai_player_input.py
@@ -110,7 +110,6 @@ class TestBlockMemory:
         mock_player_tank.y = 0.0
         ai.update(dt=1 / 60, enemies=[], teammate=None)
         assert Direction.UP in ai._blocked_directions
-        assert ai._direction_timer == 0.0
 
     def test_not_added_when_frozen(self, mock_player_tank):
         ai = AIPlayerInput(tank=mock_player_tank)
@@ -132,6 +131,35 @@ class TestBlockMemory:
         mock_player_tank.prev_y = mock_player_tank.y = 0.0
         ai.update(dt=1 / 60, enemies=[], teammate=None)
         assert ai._blocked_directions == set()
+
+
+class TestBlockageReplan:
+    def test_blocked_ai_replans_same_frame(
+        self, mock_player_tank, mock_enemy_factory, monkeypatch
+    ):
+        """When the tank can't move and the AI is requesting movement, the
+        AI must replan that frame instead of resetting its timer and looping
+        forever on the same blocked direction.
+        """
+        ai = AIPlayerInput(tank=mock_player_tank)
+        ai._dx, ai._dy = 1, 0
+        mock_player_tank.direction = Direction.RIGHT
+        # Tank did not move (prev == current).
+        mock_player_tank.prev_x = mock_player_tank.x = 100.0
+        mock_player_tank.prev_y = mock_player_tank.y = 100.0
+        monkeypatch.setattr(EnemyTank, "base_position", None)
+        monkeypatch.setattr(
+            "src.managers.ai_player_input.random.choices",
+            lambda c, w: [Direction.UP],
+        )
+        monkeypatch.setattr(
+            "src.managers.ai_player_input.random.uniform", lambda a, b: 0.0
+        )
+
+        ai.update(dt=1 / 60, enemies=[mock_enemy_factory(0.0, 0.0)], teammate=None)
+
+        assert Direction.RIGHT in ai._blocked_directions
+        assert (ai._dx, ai._dy) == Direction.UP.delta
 
 
 class TestTimerAdvancement:

--- a/tests/unit/managers/test_ai_player_input.py
+++ b/tests/unit/managers/test_ai_player_input.py
@@ -70,3 +70,60 @@ class TestConfigLoader:
         from src.managers import ai_player_input as mod
 
         assert mod._ai_teammate_config is not None
+
+
+class TestBlockMemory:
+    def test_cleared_when_tank_moved(self, mock_player_tank):
+        ai = AIPlayerInput(tank=mock_player_tank)
+        ai._blocked_directions.add(Direction.UP)
+        mock_player_tank.prev_x = 0.0
+        mock_player_tank.prev_y = 0.0
+        mock_player_tank.x = 10.0
+        mock_player_tank.y = 0.0
+        ai.update(dt=1 / 60, enemies=[], teammate=None)
+        assert Direction.UP not in ai._blocked_directions
+
+    def test_added_when_tank_did_not_move_with_nonzero_intent(self, mock_player_tank):
+        ai = AIPlayerInput(tank=mock_player_tank)
+        ai._dx, ai._dy = 0, -1
+        mock_player_tank.direction = Direction.UP
+        mock_player_tank.prev_x = 0.0
+        mock_player_tank.prev_y = 0.0
+        mock_player_tank.x = 0.0
+        mock_player_tank.y = 0.0
+        ai.update(dt=1 / 60, enemies=[], teammate=None)
+        assert Direction.UP in ai._blocked_directions
+        assert ai._direction_timer == 0.0
+
+    def test_not_added_when_frozen(self, mock_player_tank):
+        ai = AIPlayerInput(tank=mock_player_tank)
+        ai._dx, ai._dy = 0, -1
+        mock_player_tank.direction = Direction.UP
+        mock_player_tank.prev_x = 0.0
+        mock_player_tank.prev_y = 0.0
+        mock_player_tank.x = 0.0
+        mock_player_tank.y = 0.0
+        mock_player_tank.is_frozen = True
+        ai.update(dt=1 / 60, enemies=[], teammate=None)
+        assert ai._blocked_directions == set()
+
+    def test_not_added_when_intent_is_zero(self, mock_player_tank):
+        ai = AIPlayerInput(tank=mock_player_tank)
+        ai._dx, ai._dy = 0, 0
+        mock_player_tank.direction = Direction.UP
+        mock_player_tank.prev_x = mock_player_tank.x = 0.0
+        mock_player_tank.prev_y = mock_player_tank.y = 0.0
+        ai.update(dt=1 / 60, enemies=[], teammate=None)
+        assert ai._blocked_directions == set()
+
+
+class TestTimerAdvancement:
+    def test_direction_timer_advances(self, mock_player_tank):
+        ai = AIPlayerInput(tank=mock_player_tank)
+        ai.update(dt=0.1, enemies=[], teammate=None)
+        assert ai._direction_timer == pytest.approx(0.1)
+
+    def test_shoot_timer_advances(self, mock_player_tank):
+        ai = AIPlayerInput(tank=mock_player_tank)
+        ai.update(dt=0.1, enemies=[], teammate=None)
+        assert ai._shoot_timer == pytest.approx(0.1)

--- a/tests/unit/managers/test_game_manager.py
+++ b/tests/unit/managers/test_game_manager.py
@@ -1,6 +1,7 @@
 import pytest
 import pygame
 from unittest.mock import patch, MagicMock
+from src.states.game_mode import GameMode
 from src.states.game_state import GameState
 from src.core.enemy_tank import EnemyTank
 from src.utils.constants import (
@@ -57,7 +58,7 @@ class TestGameManager:
         pygame.event.post(key_down_event(pygame.K_RETURN))
         gm.handle_events()
         assert gm.state == GameState.STAGE_CURTAIN_CLOSE
-        assert gm._two_player_mode is True
+        assert gm._game_mode == GameMode.TWO_PLAYER
 
     def test_victory_r_does_nothing(self, game_manager, key_down_event):
         """Test pressing R during VICTORY does nothing (auto-advances instead)."""
@@ -392,7 +393,7 @@ class TestPauseAndOptionsStateMachine:
     ):
         """Enter on OPTIONS (index 2) on title screen goes to OPTIONS_MENU."""
         gm = game_manager_at_title
-        gm._title_menu.selection = 2
+        gm._title_menu.selection = 3
         pygame.event.post(key_down_event(pygame.K_RETURN))
         gm.handle_events()
         assert gm.state == GameState.OPTIONS_MENU
@@ -400,9 +401,9 @@ class TestPauseAndOptionsStateMachine:
         assert gm._options_menu.selection == 0
 
     def test_title_quit_exits(self, game_manager_at_title, key_down_event):
-        """Enter on QUIT (index 3) on title screen exits the game."""
+        """Enter on QUIT (index 4) on title screen exits the game."""
         gm = game_manager_at_title
-        gm._title_menu.selection = 3
+        gm._title_menu.selection = 4
         gm.sound_manager = MagicMock()
         pygame.event.post(key_down_event(pygame.K_RETURN))
         gm.handle_events()
@@ -676,3 +677,30 @@ class TestPauseAndOptionsStateMachine:
         gm.renderer.render_title_screen.assert_called_once_with(
             gm._title_menu.labels, 2
         )
+
+
+class TestAICoopMenu:
+    def test_title_menu_contains_ai_coop_item(self, game_manager):
+        labels = game_manager._title_menu.labels
+        assert "1 Player + AI" in labels
+
+    def test_selecting_ai_coop_starts_game_in_ai_mode(self, game_manager, monkeypatch):
+        captured = {}
+        monkeypatch.setattr(
+            game_manager,
+            "_start_game",
+            lambda mode: captured.update(mode=mode),
+        )
+        game_manager._title_menu, _, _ = game_manager._build_menus()
+        for item in game_manager._title_menu._items:
+            if item.label == "1 Player + AI":
+                item.on_confirm()
+                break
+        assert captured["mode"] == GameMode.ONE_PLAYER_AI
+
+    def test_game_mode_defaults_to_one_player(self, game_manager):
+        assert game_manager._game_mode == GameMode.ONE_PLAYER
+
+    def test_start_game_sets_game_mode(self, game_manager):
+        game_manager._start_game(GameMode.ONE_PLAYER_AI)
+        assert game_manager._game_mode == GameMode.ONE_PLAYER_AI

--- a/tests/unit/managers/test_player_manager.py
+++ b/tests/unit/managers/test_player_manager.py
@@ -874,3 +874,26 @@ class TestPlayerManagerUpdateAI:
         )
         player_manager.update(1 / 60, mock_game_map, [])
         assert recorded["teammate"] is None
+
+
+class TestAICoopRespawnReset:
+    def test_ai_state_resets_when_tank_respawns(self, player_manager, mock_game_map):
+        mock_game_map.player_spawn_2 = (16, 24)
+        player_manager.create_players(
+            mock_game_map,
+            controller_instance_ids=[],
+            mode=GameMode.ONE_PLAYER_AI,
+        )
+        ai_tank = player_manager._players[1]
+        ai_input = player_manager._player_inputs[1]
+        # Simulate stale state accumulated in the previous life.
+        ai_input._wants_shoot = True
+        ai_input._direction_timer = 0.9
+        ai_input._shoot_timer = 0.9
+
+        ai_tank.lives = 2  # ensure respawn path, not game-over
+        player_manager.handle_player_death(ai_tank)
+
+        assert ai_input.consume_shoot() is False
+        assert ai_input._direction_timer == 0.0
+        assert ai_input._shoot_timer == 0.0

--- a/tests/unit/managers/test_player_manager.py
+++ b/tests/unit/managers/test_player_manager.py
@@ -16,8 +16,10 @@ from src.managers.player_input import (
     KeyboardInput,
     PlayerInput,
 )
+from src.managers.ai_player_input import AIPlayerInput
 from src.managers.player_manager import PlayerManager
 from src.managers.sound_manager import SoundManager
+from src.states.game_mode import GameMode
 from src.utils.constants import TILE_SIZE
 
 
@@ -171,7 +173,7 @@ class TestPlayerManagerUpdate:
         # Pair with a keyboard input that has no keys pressed
         self.pm._player_inputs = [KeyboardInput()]
 
-        self.pm.update(0.016, self.game_map)
+        self.pm.update(0.016, self.game_map, [])
 
         player.update.assert_called_once_with(0.016)
 
@@ -182,7 +184,7 @@ class TestPlayerManagerUpdate:
         self.pm._players = [player]
         self.pm._player_inputs = [KeyboardInput()]
 
-        self.pm.update(0.016, self.game_map)
+        self.pm.update(0.016, self.game_map, [])
 
         player.update.assert_not_called()
 
@@ -204,7 +206,7 @@ class TestPlayerManagerUpdate:
         pi.handle_event(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_UP))
         self.pm._player_inputs = [pi]
 
-        self.pm.update(0.016, self.game_map)
+        self.pm.update(0.016, self.game_map, [])
 
         player.move.assert_called_once_with(0, -1, 0.016)
 
@@ -228,7 +230,7 @@ class TestPlayerManagerUpdate:
         pi.handle_event(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_RIGHT))
         self.pm._player_inputs = [pi]
 
-        self.pm.update(0.016, self.game_map)
+        self.pm.update(0.016, self.game_map, [])
 
         player.move.assert_not_called()
 
@@ -250,7 +252,7 @@ class TestPlayerManagerUpdate:
         pi.handle_event(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_UP))
         self.pm._player_inputs = [pi]
 
-        self.pm.update(0.016, self.game_map)
+        self.pm.update(0.016, self.game_map, [])
 
         player.move.assert_not_called()
 
@@ -278,7 +280,7 @@ class TestPlayerManagerUpdate:
         self.pm._players = [player]
         self.pm._player_inputs = [KeyboardInput()]  # no keys pressed
 
-        self.pm.update(0.016, self.game_map)
+        self.pm.update(0.016, self.game_map, [])
 
         player.start_slide.assert_called_once()
         self.pm._sound_manager.play.assert_called_once_with("ice_slide")
@@ -289,7 +291,7 @@ class TestPlayerManagerUpdate:
         bullet.active = True
         self.pm._bullets = [bullet]
 
-        self.pm.update(0.016, self.game_map)
+        self.pm.update(0.016, self.game_map, [])
 
         bullet.update.assert_called_once_with(0.016)
 
@@ -299,7 +301,7 @@ class TestPlayerManagerUpdate:
         bullet.active = False
         self.pm._bullets = [bullet]
 
-        self.pm.update(0.016, self.game_map)
+        self.pm.update(0.016, self.game_map, [])
 
         assert self.pm._bullets == []
 
@@ -619,10 +621,10 @@ class TestPlayerManagerReset:
 
 class TestPlayerManagerTwoPlayerCreation:
     def test_create_two_players(self, player_manager, mock_game_map):
-        """create_players(two_player_mode=True) produces two active players."""
+        """create_players(mode=GameMode.TWO_PLAYER) produces two active players."""
         mock_game_map.player_spawn_2 = (16, 24)
         player_manager.create_players(
-            mock_game_map, controller_instance_ids=[0], two_player_mode=True
+            mock_game_map, controller_instance_ids=[0], mode=GameMode.TWO_PLAYER
         )
         players = player_manager.get_active_players()
         assert len(players) == 2
@@ -631,7 +633,7 @@ class TestPlayerManagerTwoPlayerCreation:
         """Second player has player_id=2."""
         mock_game_map.player_spawn_2 = (16, 24)
         player_manager.create_players(
-            mock_game_map, controller_instance_ids=[0], two_player_mode=True
+            mock_game_map, controller_instance_ids=[0], mode=GameMode.TWO_PLAYER
         )
         assert player_manager._players[0].player_id == 1
         assert player_manager._players[1].player_id == 2
@@ -640,7 +642,7 @@ class TestPlayerManagerTwoPlayerCreation:
         """Player 2 spawns at player_spawn_2 coordinates."""
         mock_game_map.player_spawn_2 = (16, 24)
         player_manager.create_players(
-            mock_game_map, controller_instance_ids=[0], two_player_mode=True
+            mock_game_map, controller_instance_ids=[0], mode=GameMode.TWO_PLAYER
         )
         p2 = player_manager._players[1]
         assert p2.x == 16 * TILE_SIZE
@@ -650,7 +652,7 @@ class TestPlayerManagerTwoPlayerCreation:
         """2P + 1 controller: P1=keyboard, P2=controller bound by instance_id."""
         mock_game_map.player_spawn_2 = (16, 24)
         player_manager.create_players(
-            mock_game_map, controller_instance_ids=[4], two_player_mode=True
+            mock_game_map, controller_instance_ids=[4], mode=GameMode.TWO_PLAYER
         )
         assert isinstance(player_manager._player_inputs[0], KeyboardInput)
         assert isinstance(player_manager._player_inputs[1], ControllerInput)
@@ -660,7 +662,7 @@ class TestPlayerManagerTwoPlayerCreation:
         """2P + 2 controllers: each player bound to its own instance_id."""
         mock_game_map.player_spawn_2 = (16, 24)
         player_manager.create_players(
-            mock_game_map, controller_instance_ids=[8, 12], two_player_mode=True
+            mock_game_map, controller_instance_ids=[8, 12], mode=GameMode.TWO_PLAYER
         )
         assert isinstance(player_manager._player_inputs[0], ControllerInput)
         assert player_manager._player_inputs[0].instance_id == 8
@@ -678,7 +680,7 @@ class TestPlayerManagerTwoPlayerCreation:
         """
         mock_game_map.player_spawn_2 = (16, 24)
         player_manager.create_players(
-            mock_game_map, controller_instance_ids=[0, 5], two_player_mode=True
+            mock_game_map, controller_instance_ids=[0, 5], mode=GameMode.TWO_PLAYER
         )
         assert player_manager._player_inputs[0].instance_id == 0
         assert player_manager._player_inputs[1].instance_id == 5
@@ -688,7 +690,7 @@ class TestPlayerManagerTwoPlayerCreation:
         mock_game_map.player_spawn_2 = None
         mock_game_map.player_spawn = (8, 24)
         player_manager.create_players(
-            mock_game_map, controller_instance_ids=[0], two_player_mode=True
+            mock_game_map, controller_instance_ids=[0], mode=GameMode.TWO_PLAYER
         )
         p2 = player_manager._players[1]
         assert p2.x == (8 + 8) * TILE_SIZE
@@ -698,7 +700,7 @@ class TestPlayerManagerTwoPlayerCreation:
         """Per-player scores start at 0 and accumulate independently."""
         mock_game_map.player_spawn_2 = (16, 24)
         player_manager.create_players(
-            mock_game_map, controller_instance_ids=[0], two_player_mode=True
+            mock_game_map, controller_instance_ids=[0], mode=GameMode.TWO_PLAYER
         )
         player_manager.add_score(100, player_id=1)
         player_manager.add_score(200, player_id=2)
@@ -720,7 +722,7 @@ class TestPlayerManagerTwoPlayerCreation:
         """
         mock_game_map.player_spawn_2 = (16, 24)
         player_manager.create_players(
-            mock_game_map, controller_instance_ids=[], two_player_mode=True
+            mock_game_map, controller_instance_ids=[], mode=GameMode.TWO_PLAYER
         )
 
         assert isinstance(player_manager._player_inputs[0], KeyboardInput)
@@ -738,7 +740,7 @@ class TestPlayerManagerTwoPlayerDeath:
         """Create a 2P PlayerManager."""
         mock_game_map.player_spawn_2 = (16, 24)
         player_manager.create_players(
-            mock_game_map, controller_instance_ids=[0], two_player_mode=True
+            mock_game_map, controller_instance_ids=[0], mode=GameMode.TWO_PLAYER
         )
         return player_manager
 
@@ -781,3 +783,94 @@ class TestPlayerManagerTwoPlayerDeath:
         p2.lives = 0
         p2.health = 0
         assert two_player_pm.is_game_over() is True
+
+
+# ---------------------------------------------------------------------------
+# TestAICoopSlotConstruction / TestPlayerManagerUpdateAI
+# ---------------------------------------------------------------------------
+
+
+class TestAICoopSlotConstruction:
+    def test_one_player_ai_mode_builds_ai_input_in_slot_2(
+        self, player_manager, mock_game_map
+    ):
+        mock_game_map.player_spawn_2 = (16, 24)
+        player_manager.create_players(
+            mock_game_map,
+            controller_instance_ids=[],
+            mode=GameMode.ONE_PLAYER_AI,
+        )
+        assert len(player_manager._players) == 2
+        assert not isinstance(player_manager._player_inputs[0], AIPlayerInput)
+        assert isinstance(player_manager._player_inputs[1], AIPlayerInput)
+        assert player_manager._player_inputs[1]._tank is player_manager._players[1]
+
+    def test_one_player_mode_does_not_build_ai(self, player_manager, mock_game_map):
+        player_manager.create_players(
+            mock_game_map,
+            controller_instance_ids=[],
+            mode=GameMode.ONE_PLAYER,
+        )
+        assert len(player_manager._players) == 1
+        assert not any(
+            isinstance(pi, AIPlayerInput) for pi in player_manager._player_inputs
+        )
+
+    def test_two_player_mode_does_not_build_ai(self, player_manager, mock_game_map):
+        mock_game_map.player_spawn_2 = (16, 24)
+        player_manager.create_players(
+            mock_game_map,
+            controller_instance_ids=[],
+            mode=GameMode.TWO_PLAYER,
+        )
+        assert len(player_manager._players) == 2
+        assert not any(
+            isinstance(pi, AIPlayerInput) for pi in player_manager._player_inputs
+        )
+
+
+class TestPlayerManagerUpdateAI:
+    def test_update_calls_ai_input_with_enemies_and_teammate(
+        self, player_manager, mock_game_map, monkeypatch
+    ):
+        mock_game_map.player_spawn_2 = (16, 24)
+        mock_game_map.is_tile_slidable.return_value = False
+        player_manager.create_players(
+            mock_game_map,
+            controller_instance_ids=[],
+            mode=GameMode.ONE_PLAYER_AI,
+        )
+        ai = player_manager._player_inputs[1]
+        calls = []
+        monkeypatch.setattr(
+            ai,
+            "update",
+            lambda dt, enemies, teammate: calls.append((dt, enemies, teammate)),
+        )
+        enemies = []
+        player_manager.update(1 / 60, mock_game_map, enemies)
+        assert len(calls) == 1
+        dt, passed_enemies, passed_teammate = calls[0]
+        assert passed_enemies is enemies
+        assert passed_teammate is player_manager._players[0]
+
+    def test_update_passes_none_teammate_when_other_player_dead(
+        self, player_manager, mock_game_map, monkeypatch
+    ):
+        mock_game_map.player_spawn_2 = (16, 24)
+        mock_game_map.is_tile_slidable.return_value = False
+        player_manager.create_players(
+            mock_game_map,
+            controller_instance_ids=[],
+            mode=GameMode.ONE_PLAYER_AI,
+        )
+        player_manager._players[0].health = 0
+        ai = player_manager._player_inputs[1]
+        recorded = {}
+        monkeypatch.setattr(
+            ai,
+            "update",
+            lambda dt, enemies, teammate: recorded.update(teammate=teammate),
+        )
+        player_manager.update(1 / 60, mock_game_map, [])
+        assert recorded["teammate"] is None


### PR DESCRIPTION
## Summary
- New **1 Player + AI** title-screen mode: a second player slot steered by an AI teammate.
- `AIPlayerInput` implements the `PlayerInput` protocol via a role-aware AI (`HUNTER` / `DEFENDER`) with periodic replan, aligned-shoot, and friendly-fire suppression.
- Shared geometry extracted into `src/core/ai_geometry.py` (`direction_moves_toward`, `is_aligned_with`, `manhattan`, `filter_candidate_directions`) — consumed by both `EnemyTank` and `AIPlayerInput` to remove duplicated math.
- New `GameMode` enum replaces the previous `_two_player_mode: bool`; `PlayerManager` wires the right input stack based on the selected mode.
- Tuning lives in `assets/config/ai_teammate.json` (direction/shoot intervals, target biases, defender radius, friendly-fire window).

## Notes
- AI state (timers, pending shot, blocked-direction memory) is reset on teammate respawn so prior-life state can't leak in.
- `EnemyTank.base_position` is the defender anchor; when an enemy is within the configured radius, the AI switches role.

## Test plan
- [ ] `pytest` — all suites pass (unit + integration, including the new `tests/integration/test_ai_coop_mode.py` and `tests/unit/managers/test_ai_player_input.py`).
- [ ] `ruff check src/ tests/` and `ruff format --check src/ tests/` clean.
- [ ] Launch the game, pick **1 Player + AI** at the title screen, verify the teammate spawns, moves, shoots, survives a death/respawn cycle, and doesn't shoot the human player.
- [ ] Verify **1 Player** and **2 Player** modes still behave as before.