### PR TITLE
ci: add workflow to run tests and lint on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      UV_LINK_MODE: copy
+      SDL_VIDEODRIVER: dummy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version-file: '.python-version'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+
+      - name: Install dependencies
+        run: uv pip install -e ".[dev]" --system
+
+      - name: Run tests
+        run: pytest
+
+  lint:
+    runs-on: ubuntu-latest
+    env:
+      UV_LINK_MODE: copy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version-file: '.python-version'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+
+      - name: Install dependencies
+        run: uv pip install -e ".[dev]" --system
+
+      - name: Ruff check
+        run: ruff check src/ tests/
+
+      - name: Ruff format check
+        run: ruff format --check src/ tests/


### PR DESCRIPTION
Closes #252.

## Summary
- New `.github/workflows/ci.yml` triggered on `pull_request` and `push: main`.
- `test` job: installs `[dev]` extras, runs `pytest` with `SDL_VIDEODRIVER=dummy`.
- `lint` job: runs `ruff check` and `ruff format --check` on `src/` and `tests/`.
- `permissions: contents: read` at workflow level (default-deny).
- `concurrency` group with `cancel-in-progress: true` so superseded PR pushes don't tie up runners.
- All actions pinned to the same SHAs already used in `release.yml`.

Two distinct jobs so the status checks (`test`, `lint`) report separately and can be wired into branch protection independently in #261.

## Test plan
- [x] `ruff check src/ tests/` passes locally
- [x] `ruff format --check src/ tests/` passes locally
- [x] Full `pytest` suite passes locally (884 passed)
- [ ] CI runs green on this PR